### PR TITLE
Fix launcher crash when config xml file doesn't exist.

### DIFF
--- a/src/LibreLancer/GameConfig.cs
+++ b/src/LibreLancer/GameConfig.cs
@@ -11,7 +11,7 @@ namespace LibreLancer
 {
 	public class GameConfig
 	{
-		public string FreelancerPath;
+		public string FreelancerPath = "";
         public float MasterVolume = 1.0f;
         public float SfxVolume = 1.0f;
         public float MusicVolume = 1.0f;


### PR DESCRIPTION
Null type was passed as string and caused exceptions when no xml config file was present in the directory on launch. Setting the variable to empty string fixes that.