### PR TITLE
Server Connect Button Crash Fix

### DIFF
--- a/src/LibreLancer/GameStates/LuaMenu.cs
+++ b/src/LibreLancer/GameStates/LuaMenu.cs
@@ -223,7 +223,10 @@ namespace LibreLancer
 
             public void ConnectSelection()
             {
-                netClient.Connect(serverList.Servers[serverList.Selected].EndPoint);
+                if(serverList.Selected != -1)
+                {
+                    netClient.Connect(serverList.Servers[serverList.Selected].EndPoint);
+                }
             }
 
             public void NewCharacter(string name, int index)


### PR DESCRIPTION
Fixes a crash in the server browser, when pressing the "Connect" button when there is no selected server 