### PR TITLE
Automatically get FL installation path for Launcher (Windows)

### DIFF
--- a/src/Launcher/Launcher.csproj
+++ b/src/Launcher/Launcher.csproj
@@ -26,4 +26,8 @@
 
   <Import Project="..\PublishAssets\PublishAssets.projitems" Label="Shared" />
 
+  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+    <DefineConstants>_WINDOWS</DefineConstants>
+  </PropertyGroup>
+
 </Project>

--- a/src/Launcher/Launcher.csproj
+++ b/src/Launcher/Launcher.csproj
@@ -26,8 +26,4 @@
 
   <Import Project="..\PublishAssets\PublishAssets.projitems" Label="Shared" />
 
-  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <DefineConstants>_WINDOWS</DefineConstants>
-  </PropertyGroup>
-
 </Project>

--- a/src/Launcher/MainWindow.cs
+++ b/src/Launcher/MainWindow.cs
@@ -10,9 +10,7 @@ using LibreLancer;
 using LibreLancer.Exceptions;
 using LibreLancer.ImUI;
 using ImGuiNET;
-#if _WINDOWS
 using Microsoft.Win32;
-#endif
 
 namespace Launcher
 {
@@ -34,13 +32,14 @@ namespace Launcher
             config = GameConfig.Create();
             if (config.FreelancerPath == "")
             {
-                #if _WINDOWS
+                if (Platform.RunningOS == OS.Windows)
+                {
                     var combinedPath = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),"\\Microsoft Games\\Freelancer");
                     const string flPathRegistry = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Microsoft Games\\Freelancer\\1.0";
 
                     var actualPath = (string) Registry.GetValue(flPathRegistry, "AppPath", combinedPath);
                     freelancerFolder.SetText(actualPath);
-                #endif
+                }
             }
             else
                 freelancerFolder.SetText(config.FreelancerPath);

--- a/src/Launcher/MainWindow.cs
+++ b/src/Launcher/MainWindow.cs
@@ -10,6 +10,9 @@ using LibreLancer;
 using LibreLancer.Exceptions;
 using LibreLancer.ImUI;
 using ImGuiNET;
+#if _WINDOWS
+using Microsoft.Win32;
+#endif
 
 namespace Launcher
 {
@@ -31,10 +34,13 @@ namespace Launcher
             config = GameConfig.Create();
             if (config.FreelancerPath == "")
             {
-                if (Platform.RunningOS == OS.Windows) {
-                    string CombinedPath = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),"\\Microsoft Games\\Freelancer");
-                    freelancerFolder.SetText(CombinedPath);
-                }
+                #if _WINDOWS
+                    var combinedPath = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),"\\Microsoft Games\\Freelancer");
+                    const string flPathRegistry = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Microsoft Games\\Freelancer\\1.0";
+
+                    var actualPath = (string) Registry.GetValue(flPathRegistry, "AppPath", combinedPath);
+                    freelancerFolder.SetText(actualPath);
+                #endif
             }
             else
                 freelancerFolder.SetText(config.FreelancerPath);


### PR DESCRIPTION
Automatically retrieves the registry key containing the Freelancer installation path on Windows. The path will then be auto-filled in the Librelancer Launcher. If the registry key doesn't exist, the default PF x86 path will be used.

I wasn't really sure what to do with the Windows environment preprocessor check since getting the registry key requires the `Microsoft.Win32` namespace. Please let me know if there's a better way to go about this.

Also, the code hasn't yet been tested on Linux.