### PR TITLE
Fix for loading systems that do not have some background layers

### DIFF
--- a/src/LibreLancer/GameDataManager.cs
+++ b/src/LibreLancer/GameDataManager.cs
@@ -1114,9 +1114,9 @@ namespace LibreLancer
                     resource.LoadResourceFile(ResolveDataPath(txmfile));
             }
             yield return null;
-            sys.StarsBasic.LoadFile(resource);
-            sys.StarsComplex.LoadFile(resource);
-            sys.StarsNebula.LoadFile(resource);
+            sys.StarsBasic?.LoadFile(resource);
+            sys.StarsComplex?.LoadFile(resource);
+            sys.StarsNebula?.LoadFile(resource);
             yield return null;
             long a = 0;
             if (glResource != null)


### PR DESCRIPTION
Got a NullPointerException whilst trying to load system ST01 in LancerEdit, but occurs on other systems too.
After loading the system ini and after the calls to ResolveDrawable(): StarsBasic, StarsComplex and StarsNebula could be null. This change adds null checks and skips loading if needed.
