### PR TITLE
LancerEdit Improvements

### DIFF
--- a/src/Editor/LancerEdit/EditorTab.cs
+++ b/src/Editor/LancerEdit/EditorTab.cs
@@ -23,7 +23,6 @@ public abstract class EditorTab : DockTab
 
     public virtual void SetActiveTab(MainWindow win)
     {
-        win.ActiveTab = null;
     }
 
     public virtual void OnHotkey(Hotkeys hk)

--- a/src/Editor/LancerEdit/GameDataContext.cs
+++ b/src/Editor/LancerEdit/GameDataContext.cs
@@ -16,10 +16,10 @@ public class GameDataContext : IDisposable
 
     public void Load(MainWindow win, string folder, Action onComplete)
     {
+        Folder = folder;
+        Resources = new GameResourceManager(win);
         Task.Run(() =>
         {
-            Folder = folder;
-            Resources = new GameResourceManager(win);
             GameData = new GameDataManager(folder, Resources);
             GameData.LoadData(win);
             FLLog.Info("Game", "Finished loading game data");

--- a/src/Editor/LancerEdit/Model/ModelViewer.cs
+++ b/src/Editor/LancerEdit/Model/ModelViewer.cs
@@ -195,10 +195,6 @@ namespace LancerEdit
             parent.DirtyCountPart++;
         }
 
-        public override void SetActiveTab(MainWindow win)
-        {
-            win.ActiveTab = parent;
-        }
         public override void Update(double elapsed)
         {
             if (animator != null)

--- a/src/Editor/LancerEdit/Utf/UtfTab.cs
+++ b/src/Editor/LancerEdit/Utf/UtfTab.cs
@@ -50,10 +50,6 @@ namespace LancerEdit
         {
             Title = DocumentName;
         }
-        public override void SetActiveTab(MainWindow win)
-        {
-            win.ActiveTab = this;
-        }
       
         ImGuiTreeNodeFlags tflags = ImGuiTreeNodeFlags.OpenOnArrow | ImGuiTreeNodeFlags.OpenOnDoubleClick;
         TextBuffer text;


### PR DESCRIPTION
Kept receiving System.AccessViolationException when loading game data from the Data menu. Possibly due to the call to _glGenTextures on a non-UI thread in the creation of GameResourceManager in GameDataContext.Load(). This change ensures that the GameResourceManager is created on the UI thread before loading the main bulk of data.

Use of ActiveTab was redundant since we already know which is the current tab and can use casting to check which type of tab we are currently on.