### PR TITLE
LancerEdit: Fix for AccessViolationException when loading game data

### DIFF
--- a/src/Editor/LancerEdit/GameDataContext.cs
+++ b/src/Editor/LancerEdit/GameDataContext.cs
@@ -16,10 +16,10 @@ public class GameDataContext : IDisposable
 
     public void Load(MainWindow win, string folder, Action onComplete)
     {
+        Folder = folder;
+        Resources = new GameResourceManager(win);
         Task.Run(() =>
         {
-            Folder = folder;
-            Resources = new GameResourceManager(win);
             GameData = new GameDataManager(folder, Resources);
             GameData.LoadData(win);
             FLLog.Info("Game", "Finished loading game data");


### PR DESCRIPTION
Kept receiving System.AccessViolationException when loading game data from the Data menu. Possibly due to the call to _glGenTextures on a non-UI thread in the creation of GameResourceManager in GameDataContext.Load(). This change ensures that the GameResourceManager is created on the UI thread before loading the main bulk of data.