### PR TITLE
LancerEdit: Refactor saving into a strategy pattern to allow extension

### DIFF
--- a/src/Editor/LancerEdit/EditorTab.cs
+++ b/src/Editor/LancerEdit/EditorTab.cs
@@ -16,14 +16,11 @@ public enum Hotkeys
 }
 
 public abstract class EditorTab : DockTab
-{
+{ 
+    public ISaveStrategy SaveStrategy { get; set; } = new NoSaveStrategy();
+
     public virtual void DetectResources(List<MissingReference> missing, List<uint> matrefs, List<string> texrefs)
     {
-    }
-
-    public virtual void SetActiveTab(MainWindow win)
-    {
-        win.ActiveTab = null;
     }
 
     public virtual void OnHotkey(Hotkeys hk)

--- a/src/Editor/LancerEdit/ISaveStrategy.cs
+++ b/src/Editor/LancerEdit/ISaveStrategy.cs
@@ -1,0 +1,22 @@
+// MIT License - Copyright (c) Callum McGing
+// This file is subject to the terms and conditions defined in
+// LICENSE, which is part of this source code package
+
+namespace LancerEdit
+{
+    /// <summary>
+    /// Specifies the saving method for a particular EditorTab
+    /// </summary>
+    public interface ISaveStrategy
+    {
+        /// <summary>
+        /// Saves the currently loaded file
+        /// </summary>
+        void Save();
+
+        /// <summary>
+        /// Draws the menu options in the File menu
+        /// </summary>
+        void DrawMenuOptions();
+    }
+}

--- a/src/Editor/LancerEdit/Model/ModelViewer.cs
+++ b/src/Editor/LancerEdit/Model/ModelViewer.cs
@@ -106,6 +106,7 @@ namespace LancerEdit
             res = win.Resources;
             buffer = win.Commands;
             _window = win;
+            SaveStrategy = parent.SaveStrategy;
             if (drawable is CmpFile)
             {
                 //Setup Editor UI for constructs + hardpoints
@@ -195,10 +196,6 @@ namespace LancerEdit
             parent.DirtyCountPart++;
         }
 
-        public override void SetActiveTab(MainWindow win)
-        {
-            win.ActiveTab = parent;
-        }
         public override void Update(double elapsed)
         {
             if (animator != null)

--- a/src/Editor/LancerEdit/NoSaveStrategy.cs
+++ b/src/Editor/LancerEdit/NoSaveStrategy.cs
@@ -1,0 +1,27 @@
+// MIT License - Copyright (c) Callum McGing
+// This file is subject to the terms and conditions defined in
+// LICENSE, which is part of this source code package
+
+using LibreLancer.ImUI;
+
+namespace LancerEdit
+{
+    /// <summary>
+    /// This save strategy is used when the EditorTab has no ability to save
+    /// </summary>
+    internal class NoSaveStrategy : ISaveStrategy
+    {
+        public void DrawMenuOptions()
+        {
+            Theme.IconMenuItem(Icons.Save, "Save", false);
+            Theme.IconMenuItem(Icons.Save, "Save As", false);
+        }
+
+        public void Save()
+        {
+            // Does nothing
+        }
+
+        public static NoSaveStrategy Instance = new NoSaveStrategy();
+    }
+}

--- a/src/Editor/LancerEdit/Utf/UtfSaveStrategy.cs
+++ b/src/Editor/LancerEdit/Utf/UtfSaveStrategy.cs
@@ -1,0 +1,75 @@
+// MIT License - Copyright (c) Callum McGing
+// This file is subject to the terms and conditions defined in
+// LICENSE, which is part of this source code package
+
+using LibreLancer.ImUI;
+using System;
+
+namespace LancerEdit
+{
+    /// <summary>
+    /// Implements the save features for the UTF files
+    /// </summary>
+    internal class UtfSaveStrategy : ISaveStrategy
+    {
+        private readonly MainWindow window;
+        private readonly UtfTab utfTab;
+
+        public UtfSaveStrategy(MainWindow window, UtfTab utfTab)
+        {
+            this.window = window;
+            this.utfTab = utfTab;
+        }
+
+        public void DrawMenuOptions()
+        {
+            if (Theme.IconMenuItem(Icons.Save, string.Format("Save '{0}'", utfTab.DocumentName), true))
+            {
+                Save(false);
+            }
+            if (Theme.IconMenuItem(Icons.Save, "Save As", true))
+            {
+                Save(true);
+            }
+        }
+
+        public void Save()
+        {
+            Save(false);
+        }
+
+        internal void Save(bool forceSaveAs)
+        {
+            Action save = () =>
+            {
+                if (!forceSaveAs && !string.IsNullOrEmpty(utfTab.FilePath))
+                {
+                    window.ResultMessages(utfTab.Utf.Save(utfTab.FilePath, 0));
+                }
+                else
+                    RunSaveDialog();
+            };
+            if (utfTab.DirtyCountHp > 0 || utfTab.DirtyCountPart > 0)
+            {
+                window.Confirm("This model has unapplied changes. Continue?", save);
+            }
+            else
+                save();
+        }
+
+        internal void RunSaveDialog()
+        {
+            FileDialog.Save(f =>
+            {
+                var result = utfTab.Utf.Save(f, 0);
+                window.ResultMessages(result);
+                if (result.IsSuccess)
+                {
+                    utfTab.DocumentName = System.IO.Path.GetFileName(f);
+                    utfTab.UpdateTitle();
+                    utfTab.FilePath = f;
+                }
+            }, FileDialogFilters.UtfFilters);
+        }
+    }
+}

--- a/src/Editor/LancerEdit/Utf/UtfTab.cs
+++ b/src/Editor/LancerEdit/Utf/UtfTab.cs
@@ -16,7 +16,6 @@ using LibreLancer.ContentEdit;
 using LibreLancer.ContentEdit.Model;
 using LibreLancer.Utf.Cmp;
 
-
 namespace LancerEdit
 {
     public partial class UtfTab : EditorTab
@@ -44,17 +43,14 @@ namespace LancerEdit
                 main.Resources.AddResources(utf.Source, Unique.ToString());
                 utf.Source = null;
             }
+            SaveStrategy = new UtfSaveStrategy(main, this);
             RegisterPopups();
         }
         public void UpdateTitle()
         {
             Title = DocumentName;
         }
-        public override void SetActiveTab(MainWindow win)
-        {
-            win.ActiveTab = this;
-        }
-      
+     
         ImGuiTreeNodeFlags tflags = ImGuiTreeNodeFlags.OpenOnArrow | ImGuiTreeNodeFlags.OpenOnDoubleClick;
         TextBuffer text;
 


### PR DESCRIPTION
This change refactors tab saving into a strategy pattern. By decoupling from MainWindow, tabs are now able to implement their own idea of saving, and pass that idea down to child tabs as needed. 