### PR TITLE
Jmitchvii/colliders should only use single dispose

### DIFF
--- a/src/LibreLancer.Physics/Collider.cs
+++ b/src/LibreLancer.Physics/Collider.cs
@@ -15,12 +15,18 @@ namespace LibreLancer.Physics
     {
         protected Simulation sim;
         protected BufferPool pool;
+        private bool isDisposed = false;
         public TypedIndex Handle { get; protected set; }
 
         public void Dispose()
         {
+            if (isDisposed)
+            {
+                throw new ObjectDisposedException("Collider has already been disposed!");
+            }
             sim.Shapes.RemoveAndDispose(Handle, pool);
             Handle = new TypedIndex();
+            isDisposed = true;
         }
         public abstract float Radius { get; }
 

--- a/src/LibreLancer.Physics/Collider.cs
+++ b/src/LibreLancer.Physics/Collider.cs
@@ -19,7 +19,7 @@ namespace LibreLancer.Physics
 
         public void Dispose()
         {
-            sim.Shapes.RecursivelyRemoveAndDispose(Handle, pool);
+            sim.Shapes.RemoveAndDispose(Handle, pool);
             Handle = new TypedIndex();
         }
         public abstract float Radius { get; }


### PR DESCRIPTION
- Changes Collider.Dispose to use a single dispose instead of a recursive one
- Adds IsDisposed property so we can check whether objects are being free'd up more than once.