### PR TITLE
Launcher waits for lancer to exit

### DIFF
--- a/src/Launcher/MainWindow.cs
+++ b/src/Launcher/MainWindow.cs
@@ -35,7 +35,7 @@ namespace Launcher
                 if (Platform.RunningOS == OS.Windows)
                 {
                     var combinedPath = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),"\\Microsoft Games\\Freelancer");
-                    string flPathRegistry = IntPtr.Size == 8 
+                    string flPathRegistry = IntPtr.Size == 8
                         ? "HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Microsoft Games\\Freelancer\\1.0"
                         : "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft Games\\Freelancer\\1.0";
                     var actualPath = (string) Registry.GetValue(flPathRegistry, "AppPath", combinedPath);
@@ -158,7 +158,7 @@ namespace Launcher
                 return;
             }
             config.Save();
-            Process.Start(Path.Combine(GetBasePath(), "lancer"));
+            Program.startPath = Path.Combine(GetBasePath(), "lancer");
             Exit();
         }
         static void SoundSlider(string text, ref float flt)

--- a/src/Launcher/Program.cs
+++ b/src/Launcher/Program.cs
@@ -3,6 +3,7 @@
 // LICENSE, which is part of this source code package
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using LibreLancer;
@@ -13,6 +14,8 @@ namespace Launcher
     static class Program
     {
         public static bool introForceDisable = false;
+        public static string startPath = null;
+
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
@@ -23,10 +26,16 @@ namespace Launcher
             {
                 WindowsChecks();
                 new MainWindow().Run();
+                if (startPath == null)
+                    return;
+                using Process process = new Process();
+                process.StartInfo.FileName = startPath;
+                process.Start();
+                process.WaitForExit();
             });
         }
 
- 
+
         static void WindowsChecks()
         {
             if (Platform.RunningOS != OS.Windows) return;
@@ -40,4 +49,3 @@ namespace Launcher
         }
     }
 }
-    


### PR DESCRIPTION
This is a minor change which makes running the Launcher behave a bit better when started from the terminal.

When the launcher quits before the game, the terminal is desynchronised, the command prompt is printed, and control is given back to the user with output from the game still streaming on top of it. Pressing control C doesn't kill the game either.

When the launcher waits, control isn't given back to the user until the the game quits, which can be forced by pressing control C. The command prompt only appears after the game quits. 