### PR TITLE
Removed reference to old NFD library

### DIFF
--- a/src/lancerdialogs/CMakeLists.txt
+++ b/src/lancerdialogs/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required (VERSION 3.1)
 project(win32dialogs)
 set(CMAKE_BUILD_TYPE release)
 set(CMAKE_CXX_STANDARD 11)
-include_directories("../../extern/nativefiledialog/src/include")
 
 # Sources:
 # NFD for Linux/Windows, windows has different manifest requirements based on compiler


### PR DESCRIPTION
This actually caused a build error on my machine as the old submodule was still in the directory structure.