### PR TITLE
Fix attachment of head and hands to character meshes

### DIFF
--- a/src/Editor/LancerEdit/Model/DfmBoneInfo.cs
+++ b/src/Editor/LancerEdit/Model/DfmBoneInfo.cs
@@ -25,7 +25,7 @@ public class DfmBoneInfo : PopupWindow
         ImGui.Text(instance.InvBindPose.ToString().Replace("} {", "}\n{"));
         ImGui.Text("");
         ImGui.Text("LocalTransform (pos + euler)");
-        var tr = instance.LocalTransform();
+        var tr = instance.LocalTransform;
         ImGui.Text(Vector3.Transform(Vector3.Zero, tr).ToString());
         ImGui.Text(tr.GetEulerDegrees().ToString());
     }

--- a/src/Editor/LancerEdit/Model/ModelViewer.Viewport.cs
+++ b/src/Editor/LancerEdit/Model/ModelViewer.Viewport.cs
@@ -370,6 +370,7 @@ namespace LancerEdit
         void DrawSkeleton(ICamera cam)
         {
             var matrix = GetModelMatrix();
+            _window.LineRenderer.SkeletonHighlight = skeletonHighlight;
             _window.LineRenderer.StartFrame(_window.RenderContext);
             skel.DebugDraw(_window.LineRenderer, matrix, DfmDrawMode.DebugBonesHardpoints);
             _window.LineRenderer.Render();

--- a/src/Editor/LancerEdit/Model/ModelViewer.cs
+++ b/src/Editor/LancerEdit/Model/ModelViewer.cs
@@ -911,6 +911,7 @@ namespace LancerEdit
 
         bool drawSkeleton = false;
         Anm.AnmFile anmFile;
+        private string skeletonHighlight;
         void SkeletonPanel()
         {
             ImGui.Checkbox("Draw Skeleton", ref drawSkeleton);
@@ -921,12 +922,15 @@ namespace LancerEdit
             ImGui.Separator();
 
             var dfm = (DF.DfmFile)drawable;
+            skeletonHighlight = null;
             if (ImGui.CollapsingHeader("Bones", ImGuiTreeNodeFlags.CollapsingHeader))
             {
                 foreach(var inst in skel.BodySkinning.Bones)
                 {
                     if(ImGui.Selectable(inst.Key))
                         popups.OpenPopup(new DfmBoneInfo(inst.Value));
+                    if(ImGui.IsItemHovered())
+                        skeletonHighlight = inst.Key;
                 }
             }
             if (ImGui.CollapsingHeader("Hardpoints", ImGuiTreeNodeFlags.DefaultOpen))
@@ -935,6 +939,8 @@ namespace LancerEdit
                 {
                     if (ImGui.Selectable(hp.Hp.Name))
                         popups.OpenPopup(new DfmHpInfo(hp));
+                    if(ImGui.IsItemHovered())
+                        skeletonHighlight = hp.Hp.Name;
                 }
             }
 

--- a/src/LibreLancer/Render/BoneInstance.cs
+++ b/src/LibreLancer/Render/BoneInstance.cs
@@ -12,28 +12,28 @@ namespace LibreLancer.Render
         public string Name;
         public BoneInstance Parent;
         public Matrix4x4 InvBindPose;
+        public Matrix4x4 BoneMatrix = Matrix4x4.Identity;
         public Matrix4x4 OriginalRotation = Matrix4x4.Identity;
         public Vector3 Origin = Vector3.Zero;
-        public bool HasChildren = false;
         public Quaternion Rotation = Quaternion.Identity;
         public Vector3 Translation = Vector3.Zero;
-        public List<BoneInstance> Children = new List<BoneInstance>();
-        public void Update(Matrix4x4 parentMatrix)
+        public List<BoneInstance> Children = new();
+        public Matrix4x4 LocalTransform;
+
+        public BoneInstance(string name, Matrix4x4 boneToRoot)
         {
-            var local = Matrix4x4.CreateFromQuaternion(Rotation) *
-                        (OriginalRotation * Matrix4x4.CreateTranslation(Translation + Origin)) * parentMatrix;
-            BoneMatrix = InvBindPose * local;
-            for(int i = 0; i < Children.Count; i++)
-                Children[i].Update(local);
-        }
-        public Matrix4x4 LocalTransform()
-        {
-            var mine = Matrix4x4.CreateFromQuaternion(Rotation) * (OriginalRotation * Matrix4x4.CreateTranslation(Translation + Origin));
-            if (Parent != null)
-                mine *= Parent.LocalTransform();
-            return mine;
+            Name = name;
+            LocalTransform = boneToRoot;
+            Matrix4x4.Invert(boneToRoot, out InvBindPose);
         }
 
-        public Matrix4x4 BoneMatrix;
+        public void Update(Matrix4x4 parentMatrix)
+        {
+            LocalTransform = Matrix4x4.CreateFromQuaternion(Rotation) *
+                        (OriginalRotation * Matrix4x4.CreateTranslation(Translation + Origin)) * parentMatrix;
+            BoneMatrix = InvBindPose * LocalTransform;
+            foreach (var b in Children)
+                b.Update(LocalTransform);
+        }
     }
 }

--- a/src/LibreLancer/Render/DfmSkeletonManager.cs
+++ b/src/LibreLancer/Render/DfmSkeletonManager.cs
@@ -31,6 +31,8 @@ namespace LibreLancer.Render
         private BoneInstance HeadBodyBone;
         private HardpointDefinition BodyHeadHp;
         private BoneInstance BodyHeadBone;
+        private HardpointDefinition BodyNeckHp;
+        private BoneInstance BodyNeckBone;
         //Connect Left Hand
         private HardpointDefinition LeftBodyHp;
         private BoneInstance LeftBodyBone;
@@ -171,6 +173,7 @@ namespace LibreLancer.Render
             {
                 HeadSkinning.GetHardpoint("hp_head", out HeadBodyHp, out HeadBodyBone);
                 BodySkinning.GetHardpoint("hp_head", out BodyHeadHp, out BodyHeadBone);
+                BodySkinning.GetHardpoint("hp_neck", out BodyNeckHp, out BodyNeckBone);
             }
             if (LeftHand != null)
             {
@@ -209,7 +212,10 @@ namespace LibreLancer.Render
             BodySkinning.SetBoneData(bonesBuffer, ref off);
             if (Head != null)
             {
-                HeadSkinning.SetBoneData(bonesBuffer, ref off);
+                var headTransform = GetAttachmentTransform(HeadBodyHp, HeadBodyBone, BodyHeadHp, BodyHeadBone);
+                Matrix4x4.Invert(headTransform, out Matrix4x4 inv);
+                Matrix4x4 missingBone = (BodyNeckHp.Transform * BodyNeckBone.LocalTransform() * inv);
+                HeadSkinning.SetBoneData(bonesBuffer, ref off, missingBone);
             }
             if (LeftHand != null)
             {

--- a/src/LibreLancer/Render/DfmSkinning.cs
+++ b/src/LibreLancer/Render/DfmSkinning.cs
@@ -28,10 +28,7 @@ namespace LibreLancer.Render
 
             foreach (var kv in dfm.Parts)
             {
-                var inst = new BoneInstance();
-                inst.Name = kv.Value.objectName;
-                Matrix4x4.Invert(kv.Value.Bone.BoneToRoot, out inst.InvBindPose);
-                inst.BoneMatrix = inst.InvBindPose;
+                var inst = new BoneInstance(kv.Value.objectName, kv.Value.Bone.BoneToRoot);
                 instanceArray[kv.Key] = inst;
                 Bones.Add(inst.Name, inst);
             }
@@ -71,10 +68,14 @@ namespace LibreLancer.Render
             return false;
         }
 
+        public void UpdateBones()
+        {
+            foreach (var s in starts)
+                s.Update(Matrix4x4.Identity);
+        }
+
         public void SetBoneData(UniformBuffer bonesBuffer, ref int offset, Matrix4x4? missingBone = null)
         {
-            for(int i = 0; i < starts.Count; i++)
-                starts[i].Update(Matrix4x4.Identity);
             for (int i = 0; i < boneMatrices.Length; i++)
             {
                 if (instanceArray[i] != null) boneMatrices[i] = instanceArray[i].BoneMatrix;
@@ -143,7 +144,7 @@ namespace LibreLancer.Render
                 {
                     if (instanceArray[i] == null)
                         continue;
-                    var tr = instanceArray[i].LocalTransform();
+                    var tr = instanceArray[i].LocalTransform;
                     var color = instanceArray[i].Name == lines.SkeletonHighlight ? Color4.White : Color4.Red;
                     DrawCube(lines, tr * world, scale, color);
                 }
@@ -159,7 +160,7 @@ namespace LibreLancer.Render
                 {
                     if (Bones.TryGetValue(hp.Part.objectName, out BoneInstance bi))
                     {
-                        var tr = (hp.Hp.Transform * bi.LocalTransform()) * world;
+                        var tr = (hp.Hp.Transform * bi.LocalTransform) * world;
                         var color = hp.Hp.Name == lines.SkeletonHighlight ? Color4.White : Color4.Green;
                         DrawCube(lines, tr, scale, color);
                     }

--- a/src/LibreLancer/Render/DfmSkinning.cs
+++ b/src/LibreLancer/Render/DfmSkinning.cs
@@ -71,13 +71,14 @@ namespace LibreLancer.Render
             return false;
         }
 
-        public void SetBoneData(UniformBuffer bonesBuffer, ref int offset)
+        public void SetBoneData(UniformBuffer bonesBuffer, ref int offset, Matrix4x4? missingBone = null)
         {
             for(int i = 0; i < starts.Count; i++)
                 starts[i].Update(Matrix4x4.Identity);
             for (int i = 0; i < boneMatrices.Length; i++)
             {
                 if (instanceArray[i] != null) boneMatrices[i] = instanceArray[i].BoneMatrix;
+                else if (missingBone.HasValue) boneMatrices[i] = missingBone.Value;
             }
             BufferOffset = offset;
             bonesBuffer.SetData(boneMatrices, offset);

--- a/src/LibreLancer/Render/DfmSkinning.cs
+++ b/src/LibreLancer/Render/DfmSkinning.cs
@@ -74,12 +74,12 @@ namespace LibreLancer.Render
                 s.Update(Matrix4x4.Identity);
         }
 
-        public void SetBoneData(UniformBuffer bonesBuffer, ref int offset, Matrix4x4? missingBone = null)
+        public void SetBoneData(UniformBuffer bonesBuffer, ref int offset, Matrix4x4? connectionBone = null)
         {
             for (int i = 0; i < boneMatrices.Length; i++)
             {
                 if (instanceArray[i] != null) boneMatrices[i] = instanceArray[i].BoneMatrix;
-                else if (missingBone.HasValue) boneMatrices[i] = missingBone.Value;
+                else if (connectionBone.HasValue) boneMatrices[i] = connectionBone.Value;
             }
             BufferOffset = offset;
             bonesBuffer.SetData(boneMatrices, offset);

--- a/src/LibreLancer/Render/DfmSkinning.cs
+++ b/src/LibreLancer/Render/DfmSkinning.cs
@@ -100,6 +100,9 @@ namespace LibreLancer.Render
             new Vector3(1, -1, -1),
             //Top
             new Vector3(0,0, 1.8f),
+            //Arrow
+            new Vector3(0,0, 0),
+            new Vector3(0,1.8f, 0),
         };
 
         private static readonly int[] cubeIndices = new[]
@@ -111,7 +114,9 @@ namespace LibreLancer.Render
             //Join
             0,4, 1,5, 2,6, 3,7,
             //Point
-            0,8, 1,8, 2,8, 3,8
+            0,8, 1,8, 2,8, 3,8,
+            //Arrow
+            9,10
         };
 
         void DrawCube(LineRenderer lines, Matrix4x4 world, float scale, Color4 color)
@@ -139,7 +144,8 @@ namespace LibreLancer.Render
                     if (instanceArray[i] == null)
                         continue;
                     var tr = instanceArray[i].LocalTransform();
-                    DrawCube(lines, tr * world, scale, Color4.Red);
+                    var color = instanceArray[i].Name == lines.SkeletonHighlight ? Color4.White : Color4.Red;
+                    DrawCube(lines, tr * world, scale, color);
                 }
             }
 
@@ -154,7 +160,8 @@ namespace LibreLancer.Render
                     if (Bones.TryGetValue(hp.Part.objectName, out BoneInstance bi))
                     {
                         var tr = (hp.Hp.Transform * bi.LocalTransform()) * world;
-                        DrawCube(lines, tr, scale, Color4.Green);
+                        var color = hp.Hp.Name == lines.SkeletonHighlight ? Color4.White : Color4.Green;
+                        DrawCube(lines, tr, scale, color);
                     }
                 }
             }

--- a/src/LibreLancer/Render/LineRenderer.cs
+++ b/src/LibreLancer/Render/LineRenderer.cs
@@ -15,6 +15,7 @@ namespace LibreLancer.Render
 		VertexPositionColor[] lines = new VertexPositionColor[MAX_LINES * 2];
 		VertexBuffer linebuffer;
 		int lineVertices = 0;
+        public string SkeletonHighlight;
 
 		Shaders.ShaderVariables shader;
 		public LineRenderer()


### PR DESCRIPTION
This PR:

- Connects head and hands to bodies
- Fixes the models being scrunched up on the floor in the LancerEdit model viewer.
- Changes the bone calculation code to avoid duplicate calculations.
- Adds a feature where mousing over a bone or hardpoint in the list when viewing a skeleton will highlight that bone/hardpoint.
- Other small refactors. 