### PR TITLE
Refactoring ini parsing code into strategy pattern and adding unit tests 

### DIFF
--- a/src/LibreLancer.Data/Cameras/CameraIni.cs
+++ b/src/LibreLancer.Data/Cameras/CameraIni.cs
@@ -1,6 +1,7 @@
 // MIT License - Copyright (c) Callum McGing
 // This file is subject to the terms and conditions defined in
 // LICENSE, which is part of this source code package
+using LibreLancer.Data.IO;
 using LibreLancer.Ini;
 
 namespace LibreLancer.Data.Cameras
@@ -13,6 +14,11 @@ namespace LibreLancer.Data.Cameras
         [Section("DeathCamera")] public CameraProps DeathCamera = new CameraProps();
         [Section("TurretCamera")] public CameraProps TurretCamera = new CameraProps();
         [Section("RearViewCamera")] public CameraProps RearViewCamera = new CameraProps();
+
+        public CameraIni(string camerasPath, FileSystem vFS)
+        {
+            ParseAndFill(camerasPath, vFS);
+        }
     }
 
     public class CameraProps

--- a/src/LibreLancer.Data/FreelancerData.cs
+++ b/src/LibreLancer.Data/FreelancerData.cs
@@ -345,8 +345,7 @@ namespace LibreLancer.Data
             });
             Run(() =>
             {
-                Cameras = new CameraIni();
-                Cameras.ParseAndFill(Freelancer.CamerasPath, VFS);
+                Cameras = new CameraIni(Freelancer.CamerasPath, VFS);
             });
             Run(() =>
             {

--- a/src/LibreLancer.Data/Ini/BinaryIniParser.cs
+++ b/src/LibreLancer.Data/Ini/BinaryIniParser.cs
@@ -47,6 +47,8 @@ namespace LibreLancer.Ini
                     var entryNameOffset = reader.ReadInt16();
                     var entryName = stringBlock.Get(entryNameOffset);
 
+                    var entry = new Entry(section, entryName);
+
                     var valueCount = reader.ReadByte();
                     var values = new List<IValue>(valueCount);
 
@@ -56,22 +58,21 @@ namespace LibreLancer.Ini
                         switch (valueType)
                         {
                             case IniValueType.Boolean:
-                                values.Add(new BooleanValue(reader));
+                                entry.Add(new BooleanValue(reader) { Entry = entry });
                                 break;
                             case IniValueType.Int32:
-                                values.Add(new Int32Value(reader));
+                                entry.Add(new Int32Value(reader) { Entry = entry });
                                 break;
                             case IniValueType.Single:
-                                values.Add(new SingleValue(reader));
+                                entry.Add(new SingleValue(reader) { Entry = entry });
                                 break;
                             case IniValueType.String:
-                                values.Add(new StringValue(reader, stringBlock, sectionName, path, -1));
+                                entry.Add(new StringValue(reader, stringBlock) { Entry = entry });
                                 break;
                             default:
                                 throw new FileContentException(FileType, "Unknown BINI value type: " + valueType);
                         }
                     }
-                    var entry = new Entry(entryName, values) { File = path };
                     section.Add(entry);
                 }
 

--- a/src/LibreLancer.Data/Ini/BinaryIniParser.cs
+++ b/src/LibreLancer.Data/Ini/BinaryIniParser.cs
@@ -1,0 +1,82 @@
+﻿// MIT License - Copyright (c) Callum McGing
+// This file is subject to the terms and conditions defined in
+// LICENSE, which is part of this source code package
+
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace LibreLancer.Ini
+{
+    public class BinaryIniParser : IIniParser
+    {
+        private const string FileType = "BINI";
+        private const int FileVersion = 1;
+
+        public IEnumerable<Section> ParseIniFile(string path, Stream stream, bool preparse = true, bool allowmaps = false)
+        {
+            var reader = new BinaryReader(stream);
+
+            // Read Magic
+            reader.ReadInt32();
+
+            int formatVersion = reader.ReadInt32();
+            if (formatVersion != FileVersion) throw new FileVersionException(path, FileType, formatVersion, FileVersion);
+
+            int stringBlockOffset = reader.ReadInt32();
+            if (stringBlockOffset > reader.BaseStream.Length) throw new FileContentException(path, FileType, "The string block offset was out of range: " + stringBlockOffset);
+
+            long sectionBlockOffset = reader.BaseStream.Position;
+
+            reader.BaseStream.Seek(stringBlockOffset, SeekOrigin.Begin);
+            byte[] stringBuffer = new byte[reader.BaseStream.Length - stringBlockOffset];
+            reader.Read(stringBuffer, 0, stringBuffer.Length);
+            var stringBlock = new BiniStringBlock(Encoding.ASCII.GetString(stringBuffer));
+
+            reader.BaseStream.Seek(sectionBlockOffset, SeekOrigin.Begin);
+            while (reader.BaseStream.Position < stringBlockOffset)
+            {
+                short sectionNameOffset = reader.ReadInt16();
+                var sectionName = stringBlock.Get(sectionNameOffset);
+
+                var section = new Section(sectionName) { File = path };
+
+                short entryCount = reader.ReadInt16();
+                for (int i = 0; i < entryCount; i++)
+                {
+                    var entryNameOffset = reader.ReadInt16();
+                    var entryName = stringBlock.Get(entryNameOffset);
+
+                    var valueCount = reader.ReadByte();
+                    var values = new List<IValue>(valueCount);
+
+                    for (int j = 0; j < valueCount; j++)
+                    {
+                        var valueType = (IniValueType)reader.ReadByte();
+                        switch (valueType)
+                        {
+                            case IniValueType.Boolean:
+                                values.Add(new BooleanValue(reader));
+                                break;
+                            case IniValueType.Int32:
+                                values.Add(new Int32Value(reader));
+                                break;
+                            case IniValueType.Single:
+                                values.Add(new SingleValue(reader));
+                                break;
+                            case IniValueType.String:
+                                values.Add(new StringValue(reader, stringBlock, sectionName, path, -1));
+                                break;
+                            default:
+                                throw new FileContentException(FileType, "Unknown BINI value type: " + valueType);
+                        }
+                    }
+                    var entry = new Entry(entryName, values) { File = path };
+                    section.Add(entry);
+                }
+
+                yield return section;
+            }
+        }
+    }
+}

--- a/src/LibreLancer.Data/Ini/BooleanValue.cs
+++ b/src/LibreLancer.Data/Ini/BooleanValue.cs
@@ -8,18 +8,17 @@ using System.IO;
 
 namespace LibreLancer.Ini
 {
-	public class BooleanValue : IValue
+	public class BooleanValue : ValueBase
 	{
-		private bool value;
+		private readonly bool value;
 
 		public BooleanValue(BinaryReader reader)
 		{
-			if (reader == null) throw new ArgumentNullException("reader");
-
+			if (reader == null) throw new ArgumentNullException(nameof(reader));
 			value = reader.ReadBoolean();
 		}
 
-		public BooleanValue(bool value)
+		public BooleanValue(bool value) 
 		{
 			this.value = value;
 		}
@@ -30,41 +29,33 @@ namespace LibreLancer.Ini
 			else return operand.value;
 		}
 
-		public bool ToBoolean()
+		public override bool TryToBoolean(out bool result)
 		{
-			return value;
+            result = value;
+            return true;
 		}
 
-        public bool TryToInt32(out int result)
+        public override bool TryToInt32(out int result)
         {
             result = value ? 1 : 0;
             return true;
         }
 
-		public int ToInt32()
-		{
-			return value ? 1 : 0;
-		}
-
-        public long ToInt64()
+        public override bool TryToInt64(out long result)
         {
-            return value ? 1 : 0;
-        }
-        
+            result = value ? 1 : 0;
+            return true;
+        }        
 
-        public float ToSingle(string propertyName = null)
+        public override bool TryToSingle(out float result)
 		{
-			return value ? 1 : 0;
+			result = value ? 1 : 0;
+            return true;
 		}
 
 		public override string ToString()
 		{
 			return value.ToString(CultureInfo.InvariantCulture);
-		}
-
-		public StringKeyValue ToKeyValue()
-		{
-			throw new InvalidCastException ();
 		}
 	}
 }

--- a/src/LibreLancer.Data/Ini/Entry.cs
+++ b/src/LibreLancer.Data/Ini/Entry.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using System.Text;
 
 namespace LibreLancer.Ini
@@ -13,9 +12,6 @@ namespace LibreLancer.Ini
 	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix")]
 	public class Entry : ICollection<IValue>
 	{
-		private const string BINI = "BINI";
-		private const int N_LEN = 2, C_LEN = 1, T_LEN = 1;
-
 		public string Name { get; private set; }
 
 		private List<IValue> values;
@@ -23,46 +19,10 @@ namespace LibreLancer.Ini
         public string File = "[Null]";
         public int Line = -1;
 
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "string")]
-		public Entry(string file, BinaryReader reader, BiniStringBlock stringBlock, string section)
-		{
-			if (reader == null) throw new ArgumentNullException("reader");
-			if (stringBlock == null) throw new ArgumentNullException("stringBlock");
-            
-            File = file;
-			short nameOffset = reader.ReadInt16();
-            Name = stringBlock.Get(nameOffset);
-
-			byte count = reader.ReadByte();
-			values = new List<IValue>(count);
-
-			for (int i = 0; i < count; i++)
-			{
-				IniValueType valueType = (IniValueType)reader.ReadByte();
-				switch (valueType)
-				{
-				case IniValueType.Boolean:
-					values.Add(new BooleanValue(reader));
-					break;
-				case IniValueType.Int32:
-					values.Add(new Int32Value(reader));
-					break;
-				case IniValueType.Single:
-					values.Add(new SingleValue(reader));
-					break;
-				case IniValueType.String:
-					values.Add(new StringValue(reader, stringBlock, section, file, -1));
-					break;
-				default:
-					throw new FileContentException(BINI, "Unknown BINI value type: " + valueType);
-				}
-			}
-		}
-
 		public Entry(string name, ICollection<IValue> values)
 		{
-			if (name == null) throw new ArgumentNullException("name");
-			if (values == null) throw new ArgumentNullException("values");
+			if (name == null) throw new ArgumentNullException(nameof(name));
+			if (values == null) throw new ArgumentNullException(nameof(values));
 
 			this.Name = name;
 			this.values = new List<IValue>(values);

--- a/src/LibreLancer.Data/Ini/Entry.cs
+++ b/src/LibreLancer.Data/Ini/Entry.cs
@@ -12,20 +12,22 @@ namespace LibreLancer.Ini
 	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix")]
 	public class Entry : ICollection<IValue>
 	{
-		public string Name { get; private set; }
+        private readonly IList<IValue> values;
 
-		private List<IValue> values;
+        public string Name { get; init; }
 
-        public string File = "[Null]";
-        public int Line = -1;
+        public Section Section { get; init; }
 
-		public Entry(string name, ICollection<IValue> values)
+		public int Line { get; init; } = -1;
+
+		public Entry(Section section, string name)
 		{
+            if (section == null) throw new ArgumentNullException(nameof(section));
 			if (name == null) throw new ArgumentNullException(nameof(name));
-			if (values == null) throw new ArgumentNullException(nameof(values));
 
-			this.Name = name;
-			this.values = new List<IValue>(values);
+            Section = section;
+			Name = name;
+			values = new List<IValue>();
 		}
 
 		public IValue this[int index]

--- a/src/LibreLancer.Data/Ini/IIniParser.cs
+++ b/src/LibreLancer.Data/Ini/IIniParser.cs
@@ -1,0 +1,14 @@
+﻿// MIT License - Copyright (c) Callum McGing
+// This file is subject to the terms and conditions defined in
+// LICENSE, which is part of this source code package
+
+using System.Collections.Generic;
+using System.IO;
+
+namespace LibreLancer.Ini
+{
+    public interface IIniParser
+    {
+        IEnumerable<Section> ParseIniFile(string path, Stream stream, bool preparse = true, bool allowmaps = false);
+    }
+}

--- a/src/LibreLancer.Data/Ini/IValue.cs
+++ b/src/LibreLancer.Data/Ini/IValue.cs
@@ -6,11 +6,16 @@ namespace LibreLancer.Ini
 {
 	public interface IValue
 	{
-		bool ToBoolean();
-		int ToInt32();
+        bool TryToBoolean(out bool result);
         bool TryToInt32(out int result);
+        bool TryToInt64(out long result);
+        bool TryToSingle(out float result);
+
+        bool ToBoolean();
+		int ToInt32(); 
         long ToInt64();
-        float ToSingle(string propertyName = null);
+        float ToSingle();
+
 		StringKeyValue ToKeyValue();
 	}
 }

--- a/src/LibreLancer.Data/Ini/IniFile.Reflection.cs
+++ b/src/LibreLancer.Data/Ini/IniFile.Reflection.cs
@@ -243,10 +243,10 @@ namespace LibreLancer.Ini
         {
             if (min == -1) min = c;
             if (e.Count > c)
-                FLLog.Warning("Ini", "Too many components for " + e.Name + FormatLine(e.File, e.Line, s.Name));
+                FLLog.Warning("Ini", "Too many components for " + e.Name + FormatLine(s.File, e.Line, s.Name));
             if (e.Count >= min)
                 return true;
-            FLLog.Error("Ini", "Not enough components for " + e.Name + FormatLine(e.File, e.Line, s.Name));
+            FLLog.Error("Ini", "Not enough components for " + e.Name + FormatLine(s.File, e.Line, s.Name));
             return false;
         }
         private static object GetFromSection(Section s, ReflectionInfo type, object obj = null, string datapath = null, FileSystem vfs = null, bool checkRequired = true)
@@ -331,7 +331,7 @@ namespace LibreLancer.Ini
                 }
                 else if (ftype == typeof(float))
                 {
-                    if (ComponentCheck(1, s, e)) field.Field.SetValue(obj, e[0].ToSingle(e.Name));
+                    if (ComponentCheck(1, s, e)) field.Field.SetValue(obj, e[0].ToSingle());
                 }
                 else if (ftype == typeof(int))
                 {
@@ -343,7 +343,7 @@ namespace LibreLancer.Ini
                 }
                 else if (ftype == typeof(ValueRange<float>))
                 {
-                    if (ComponentCheck(2, s, e)) field.Field.SetValue(obj, new ValueRange<float>(e[0].ToSingle(e.Name), e[1].ToSingle(e.Name)));
+                    if (ComponentCheck(2, s, e)) field.Field.SetValue(obj, new ValueRange<float>(e[0].ToSingle(), e[1].ToSingle()));
 
                 }
                 else if (ftype == typeof(long))
@@ -357,28 +357,28 @@ namespace LibreLancer.Ini
                 }
                 else if (ftype == typeof(Vector3))
                 {
-                    if(e.Count == 1 && e[0].ToSingle(e.Name) == 0)
+                    if(e.Count == 1 && e[0].ToSingle() == 0)
                         field.Field.SetValue(obj, Vector3.Zero);
                     else if (field.Attr.Mode == Vec3Mode.None) {
-                        if (ComponentCheck(3, s, e)) field.Field.SetValue(obj, new Vector3(e[0].ToSingle(e.Name), e[1].ToSingle(e.Name), e[2].ToSingle(e.Name)));
+                        if (ComponentCheck(3, s, e)) field.Field.SetValue(obj, new Vector3(e[0].ToSingle(), e[1].ToSingle(), e[2].ToSingle()));
                     } else if (ComponentCheck(3, s, e, 1))
                     {
                         if (field.Attr.Mode == Vec3Mode.Size)
                         {
                             if(e.Count == 1)
-                                field.Field.SetValue(obj, new Vector3(e[0].ToSingle(e.Name)));
+                                field.Field.SetValue(obj, new Vector3(e[0].ToSingle()));
                             else if(e.Count == 2)
-                                field.Field.SetValue(obj, new Vector3(e[0].ToSingle(e.Name), e[1].ToSingle(e.Name), 0));
+                                field.Field.SetValue(obj, new Vector3(e[0].ToSingle(), e[1].ToSingle(), 0));
                             else
-                                field.Field.SetValue(obj, new Vector3(e[0].ToSingle(e.Name), e[1].ToSingle(e.Name), e[2].ToSingle(e.Name)));
+                                field.Field.SetValue(obj, new Vector3(e[0].ToSingle(), e[1].ToSingle(), e[2].ToSingle()));
                         }
                         else
                         {
                             //optional components
                             var v3 = Vector3.Zero;
-                            v3.X = e[0].ToSingle(e.Name);
-                            if (e.Count > 1) v3.Y = e[1].ToSingle(e.Name);
-                            if (e.Count > 2) v3.Z = e[2].ToSingle(e.Name);
+                            v3.X = e[0].ToSingle();
+                            if (e.Count > 1) v3.Y = e[1].ToSingle();
+                            if (e.Count > 2) v3.Z = e[2].ToSingle();
                             field.Field.SetValue(obj, v3);
                         }
                     }
@@ -389,22 +389,22 @@ namespace LibreLancer.Ini
                     if (ComponentCheck(3, s, e))
                     {
                         var v = (List<Vector3>)field.Field.GetValue(obj);
-                        v.Add(new Vector3(e[0].ToSingle(e.Name), e[1].ToSingle(e.Name), e[2].ToSingle(e.Name)));
+                        v.Add(new Vector3(e[0].ToSingle(), e[1].ToSingle(), e[2].ToSingle()));
                     }
                 }
                 else if(ftype == typeof(Quaternion))
                 {
-                    if (ComponentCheck(4, s, e)) field.Field.SetValue(obj, new Quaternion(e[1].ToSingle(e.Name), e[2].ToSingle(e.Name), e[3].ToSingle(e.Name), e[0].ToSingle(e.Name)));
+                    if (ComponentCheck(4, s, e)) field.Field.SetValue(obj, new Quaternion(e[1].ToSingle(), e[2].ToSingle(), e[3].ToSingle(), e[0].ToSingle()));
                 }
                 else if(ftype == typeof(Vector4))
                 {
-                    if (ComponentCheck(4, s, e)) field.Field.SetValue(obj, new Vector4(e[0].ToSingle(e.Name), e[1].ToSingle(e.Name), e[2].ToSingle(e.Name), e[3].ToSingle(e.Name)));
+                    if (ComponentCheck(4, s, e)) field.Field.SetValue(obj, new Vector4(e[0].ToSingle(), e[1].ToSingle(), e[2].ToSingle(), e[3].ToSingle()));
                 }
                 else if (ftype == typeof(Vector2))
                 {
                     if (e.Count == 1 && field.Attr.MinMax)
-                        field.Field.SetValue(obj, new Vector2(-1, e[0].ToSingle(e.Name)));
-                    else if (ComponentCheck(2, s, e)) field.Field.SetValue(obj, new Vector2(e[0].ToSingle(e.Name), e[1].ToSingle(e.Name)));
+                        field.Field.SetValue(obj, new Vector2(-1, e[0].ToSingle()));
+                    else if (ComponentCheck(2, s, e)) field.Field.SetValue(obj, new Vector2(e[0].ToSingle(), e[1].ToSingle()));
                 }
                 else if (ftype == typeof(Color4))
                 {
@@ -424,11 +424,11 @@ namespace LibreLancer.Ini
                     {
                         if (field.Attr.FloatColor)
                         {
-                            field.Field.SetValue(obj, new Color3f(e[0].ToSingle(e.Name), e[1].ToSingle(e.Name), e[2].ToSingle(e.Name)));
+                            field.Field.SetValue(obj, new Color3f(e[0].ToSingle(), e[1].ToSingle(), e[2].ToSingle()));
                         }
                         else
                         {
-                            field.Field.SetValue(obj, new Color3f(e[0].ToSingle(e.Name) / 255f, e[1].ToSingle(e.Name) / 255f, e[2].ToSingle(e.Name) / 255f));
+                            field.Field.SetValue(obj, new Color3f(e[0].ToSingle() / 255f, e[1].ToSingle() / 255f, e[2].ToSingle() / 255f));
                         }
                     }
                 }
@@ -463,7 +463,7 @@ namespace LibreLancer.Ini
                 {
                     if(ComponentCheck(int.MaxValue,s,e,1)) {
                         var floats = new float[e.Count];
-                        for (int i = 0; i < e.Count; i++) floats[i] = e[i].ToSingle(e.Name);
+                        for (int i = 0; i < e.Count; i++) floats[i] = e[i].ToSingle();
                         field.Field.SetValue(obj, floats);
                     }
                 }
@@ -499,7 +499,7 @@ namespace LibreLancer.Ini
                         if (Guid.TryParse(e[0].ToString(), out var g))
                             field.Field.SetValue(obj, g);
                         else
-                            FLLog.Warning("Ini", "Unable to parse GUID" + FormatLine(e.File, e.Line, s.Name));
+                            FLLog.Warning("Ini", "Unable to parse GUID" + FormatLine(s.File, e.Line, s.Name));
                     }
                 }
                 else if (ftype.IsEnum)
@@ -513,7 +513,7 @@ namespace LibreLancer.Ini
                         }
                         catch (Exception)
                         {
-                            FLLog.Error("Ini", "Invalid value for enum " + e[0].ToString() + FormatLine(e.File, e.Line, s.Name));
+                            FLLog.Error("Ini", "Invalid value for enum " + e[0].ToString() + FormatLine(s.File, e.Line, s.Name));
                         }
                     }
                 }
@@ -775,7 +775,7 @@ namespace LibreLancer.Ini
                 if (currentSection != null)
                     currentSection.Add(e);
                 else
-                    FLLog.Warning("Ini", $"Entry without object '{e.Name}' {FormatLine(e.File, e.Line, parent.Name)}");
+                    FLLog.Warning("Ini", $"Entry without object '{e.Name}' {FormatLine(parent.File, e.Line, parent.Name)}");
             }
             if (currentSection != null) yield return currentSection;
         }

--- a/src/LibreLancer.Data/Ini/IniFile.Reflection.cs
+++ b/src/LibreLancer.Data/Ini/IniFile.Reflection.cs
@@ -18,7 +18,7 @@ namespace LibreLancer.Ini
     //Class for constructing ini through Reflection
     public abstract partial class IniFile
     {
-        public static uint Hash(string s)
+        private static uint Hash(string s)
         {
             uint num = 0x811c9dc5;
             for (int i = 0; i < s.Length; i++)
@@ -30,7 +30,8 @@ namespace LibreLancer.Ini
             }
             return num;
         }
-        class ReflectionInfo
+
+        private class ReflectionInfo
         {
             public Type Type;
             public bool IsChildSection;
@@ -42,13 +43,13 @@ namespace LibreLancer.Ini
             public ulong RequiredFields = 0;
         }
 
-        class ReflectionMethod
+        private class ReflectionMethod
         {
             public EntryHandlerAttribute Attr;
             public MethodInfo Method;
         }
 
-        class ReflectionSection
+        private class ReflectionSection
         {
             public string Name;
             public string[] Delimiters;
@@ -59,7 +60,7 @@ namespace LibreLancer.Ini
             public bool IsInheritSection;
         }
 
-        class ContainerClass
+        private class ContainerClass
         {
             public ReflectionSection[] Sections;
             public uint[] IgnoreHashes;
@@ -77,17 +78,17 @@ namespace LibreLancer.Ini
             }
         }
 
-        class ReflectionField
+        private class ReflectionField
         {
             public EntryAttribute Attr;
             public FieldInfo Field;
             public Type NullableType;
         }
 
-        static Dictionary<Type, ContainerClass> containerclasses = new Dictionary<Type, ContainerClass>();
-        static Dictionary<Type, ReflectionInfo> sectionclasses = new Dictionary<Type, ReflectionInfo>();
+        private static Dictionary<Type, ContainerClass> containerclasses = new Dictionary<Type, ContainerClass>();
+        private static Dictionary<Type, ReflectionInfo> sectionclasses = new Dictionary<Type, ReflectionInfo>();
 
-        static string FormatLine(string file, int line)
+        private static string FormatLine(string file, int line)
         {
             if (line >= 0)
                 return $" at {file}, line {line}";
@@ -95,7 +96,7 @@ namespace LibreLancer.Ini
                 return $" in {file} (line not available)";
         }
 
-        static string FormatLine(string file, int line, string section)
+        private static string FormatLine(string file, int line, string section)
         {
             if (line >= 0)
                 return $" at section {section}: {file}, line {line}";
@@ -103,12 +104,12 @@ namespace LibreLancer.Ini
                 return $" in section {section}: {file} (line not available)";
         }
 
-        const BindingFlags F_CLASSMEMBERS = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+        private const BindingFlags F_CLASSMEMBERS = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
 
-        static object _sLock = new object();
-        static object _cLock = new object();
+        private static object _sLock = new object();
+        private static object _cLock = new object();
 
-        static ReflectionInfo GetSectionInfo(Type t)
+        private static ReflectionInfo GetSectionInfo(Type t)
         {
             lock (_sLock)
             {
@@ -169,7 +170,7 @@ namespace LibreLancer.Ini
             }
         }
 
-        static ContainerClass GetContainerInfo(Type t)
+        private static ContainerClass GetContainerInfo(Type t)
         {
             lock (_cLock)
             {
@@ -226,7 +227,7 @@ namespace LibreLancer.Ini
             }
         }
 
-        public static T FromSection<T>(Section s)
+        protected static T FromSection<T>(Section s)
         {
             return (T)GetFromSection(s, GetSectionInfo(typeof(T)));
         }
@@ -235,9 +236,10 @@ namespace LibreLancer.Ini
         {
             GetFromSection(s, GetSectionInfo(GetType()), this);
         }
+
         protected virtual void OnSelfFilled(string datapath, FileSystem vfs) {}
 
-        static bool ComponentCheck(int c, Section s, Entry e, int min = -1)
+        private static bool ComponentCheck(int c, Section s, Entry e, int min = -1)
         {
             if (min == -1) min = c;
             if (e.Count > c)
@@ -247,7 +249,7 @@ namespace LibreLancer.Ini
             FLLog.Error("Ini", "Not enough components for " + e.Name + FormatLine(e.File, e.Line, s.Name));
             return false;
         }
-        static object GetFromSection(Section s, ReflectionInfo type, object obj = null, string datapath = null, FileSystem vfs = null, bool checkRequired = true)
+        private static object GetFromSection(Section s, ReflectionInfo type, object obj = null, string datapath = null, FileSystem vfs = null, bool checkRequired = true)
         {
             if(obj == null) obj = Activator.CreateInstance(type.Type);
             ulong bitmask = 0;
@@ -536,7 +538,7 @@ namespace LibreLancer.Ini
             }
         }
 
-        public void ParseAndFill(string filename, MemoryStream stream, bool preparse = true)
+        protected void ParseAndFill(string filename, MemoryStream stream, bool preparse = true)
         {
             var sections = GetContainerInfo(GetType());
             var deferred = new Dictionary<ReflectionSection, List<DeferredSection>>();
@@ -549,7 +551,7 @@ namespace LibreLancer.Ini
                 ProcessDeferred(kv.Key, kv.Value);
         }
 
-        public void ParseAndFill(string filename, string datapath, FileSystem vfs)
+        protected void ParseAndFill(string filename, string datapath, FileSystem vfs)
         {
             var sections = GetContainerInfo(GetType());
             var deferred = new Dictionary<ReflectionSection, List<DeferredSection>>();
@@ -562,7 +564,7 @@ namespace LibreLancer.Ini
                 ProcessDeferred(kv.Key, kv.Value, datapath, vfs);
         }
 
-        public void ParseAndFill(IEnumerable<string> filenames, FileSystem vfs)
+        protected void ParseAndFill(IEnumerable<string> filenames, FileSystem vfs)
         {
             var sections = GetContainerInfo(GetType());
             var deferred = new Dictionary<ReflectionSection, List<DeferredSection>>();
@@ -578,7 +580,7 @@ namespace LibreLancer.Ini
                 ProcessDeferred(kv.Key, kv.Value);
         }
 
-        public void ParseAndFill(string filename, FileSystem vfs)
+        protected void ParseAndFill(string filename, FileSystem vfs)
         {
             var sections = GetContainerInfo(GetType());
             var deferred = new Dictionary<ReflectionSection, List<DeferredSection>>();
@@ -593,14 +595,15 @@ namespace LibreLancer.Ini
 
         private static readonly uint nicknameHash = Hash("nickname");
         private static readonly uint inheritHash = Hash("inherit");
-        string GetProperty(Section section, uint hash)
+
+        private string GetProperty(Section section, uint hash)
         {
             var n = section.LastOrDefault(x => Hash(x.Name) == hash);
             if (n == null || n.Count < 1) return null;
             return n[0].ToString();
         }
 
-        void ProcessDeferred(ReflectionSection tgt, List<DeferredSection> data, string datapath = null, FileSystem vfs = null)
+        private void ProcessDeferred(ReflectionSection tgt, List<DeferredSection> data, string datapath = null, FileSystem vfs = null)
         {
             //Collect names
             Dictionary<string, Section> byNickname = new Dictionary<string, Section>();
@@ -645,9 +648,9 @@ namespace LibreLancer.Ini
 
         }
 
-        record DeferredSection(Section Section, List<(Section, ReflectionSection)> Children);
+        private record DeferredSection(Section Section, List<(Section, ReflectionSection)> Children);
 
-        void AddSectionToParent(object parsed, object parent, Section section)
+        private void AddSectionToParent(object parsed, object parent, Section section)
         {
             bool success = false;
             var parentInfo = GetSectionInfo(parent.GetType());
@@ -668,7 +671,13 @@ namespace LibreLancer.Ini
         }
 
 
-        DeferredSection ProcessSection(Section section, ContainerClass sections, DeferredSection lastDeferred, Dictionary<ReflectionSection, List<DeferredSection>> deferredSections, string datapath = null, FileSystem vfs = null)
+        private DeferredSection ProcessSection(Section section,
+            ContainerClass sections,
+            DeferredSection lastDeferred,
+            Dictionary<ReflectionSection,
+            List<DeferredSection>> deferredSections,
+            string datapath = null,
+            FileSystem vfs = null)
         {
             if (sections.IgnoreHashes.Contains(Hash(section.Name))) return null;
             var tgt = sections.GetSection(section.Name);
@@ -742,14 +751,14 @@ namespace LibreLancer.Ini
             return null;
         }
 
-        static bool HasIgnoreCase(string[] array, string value)
+        private static bool HasIgnoreCase(string[] array, string value)
         {
             for(int i = 0; i < array.Length; i++)
                 if (array[i].Equals(value, StringComparison.OrdinalIgnoreCase))
                     return true;
             return false;
         }
-        static IEnumerable<Section> Chunk(string[] delimiters, Section parent)
+        private static IEnumerable<Section> Chunk(string[] delimiters, Section parent)
         {
             Section currentSection = null;
             foreach (var e in parent) {

--- a/src/LibreLancer.Data/Ini/IniFile.cs
+++ b/src/LibreLancer.Data/Ini/IniFile.cs
@@ -3,7 +3,6 @@
 // LICENSE, which is part of this source code package
 
 using System;
-using System.Globalization;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -14,180 +13,41 @@ namespace LibreLancer.Ini
 {
 	public abstract partial class IniFile
 	{
-		private const string FileType = "BINI", IniFileType = "INI";
-		private const int FileVersion = 1;
+        private const string Bini = "BINI";
 
-        private static int ParseEquals(string line, string[] part, bool allowmaps)
+        private static string DetermineFileType(Stream stream)
         {
-            var idx0 = line.IndexOf('=');
-            if (idx0 == -1)
-            {
-                part[0] = line;
-                return 1;
-            }
-
-            part[0] = line.Substring(0, idx0);
-            if ((idx0 + 1) >= line.Length) return 1;
-            var idx1 = line.IndexOf('=', idx0 + 1);
-            if (idx1 != -1 && !allowmaps)
-            {
-                //Skip duplicate equals
-                for (int i = idx0; i < line.Length; i++)
-                {
-                    if (line[i] != '=' && line[i] != ' ' && line[i] != '\t')
-                    {
-                        idx0 = i - 1;
-                        break;
-                    }
-                }
-            }
-            else if (idx1 != -1)
-            {
-                part[1] = line.Substring(idx0 + 1, idx1 - (idx0 + 1));
-                part[2] = line.Substring(idx1 + 1);
-                return 3;
-            }
-            part[1] = line.Substring(idx0 + 1);
-            return 2;
+            stream.Seek(0, SeekOrigin.Begin);
+            byte[] buffer = new byte[4];
+            stream.Read(buffer, 0, 4);
+            var fileType = Encoding.ASCII.GetString(buffer);
+            stream.Seek(0, SeekOrigin.Begin);
+            return fileType;
         }
 
         protected IEnumerable<Section> ParseFile(string path, Stream stream, bool preparse = true, bool allowmaps = false)
         {
             if (string.IsNullOrEmpty(path)) path = "[Memory]";
-            stream.Position = 0;
-            byte[] buffer = new byte[4];
-            stream.Read(buffer, 0, 4);
-            string fileType = Encoding.ASCII.GetString(buffer);
-            Section currentSection = null;
-            if (fileType == FileType) // Binary Ini
+            
+            var fileType = DetermineFileType(stream);
+
+            IIniParser parser = null;
+            if (fileType == Bini) 
             {
-                var reader = new BinaryReader(stream);
-
-                int formatVersion = reader.ReadInt32();
-                if (formatVersion != FileVersion) throw new FileVersionException(path, fileType, formatVersion, FileVersion);
-
-                int stringBlockOffset = reader.ReadInt32();
-                if (stringBlockOffset > reader.BaseStream.Length) throw new FileContentException(path, fileType, "The string block offset was out of range: " + stringBlockOffset);
-
-                long sectionBlockOffset = reader.BaseStream.Position;
-
-                reader.BaseStream.Seek(stringBlockOffset, SeekOrigin.Begin);
-                Array.Resize<byte>(ref buffer, (int)(reader.BaseStream.Length - stringBlockOffset));
-                reader.Read(buffer, 0, buffer.Length);
-                var stringBlock = new BiniStringBlock(Encoding.ASCII.GetString(buffer));
-
-                reader.BaseStream.Seek(sectionBlockOffset, SeekOrigin.Begin);
-                while (reader.BaseStream.Position < stringBlockOffset) yield return new Section(path, reader, stringBlock);
+                // Binary Ini
+                parser = new BinaryIniParser();
             }
-            else // Text Ini
+            else 
             {
-                stream.Seek(0, SeekOrigin.Begin);
-                var reader = new StreamReader(stream);
-
-                int currentLine = 0;
-                bool inSection = false;
-                string[] parts = new string[3];
-                while (!reader.EndOfStream)
-                {
-                    currentLine++;
-                    string line = reader.ReadLine().Trim();
-
-                    if (string.IsNullOrWhiteSpace(line)
-                        || line[0] == ';'
-                        || line[0] == '@')
-                        continue;
-
-                    if (line[0] == '[')
-                    {
-                        if (currentSection != null) yield return currentSection;
-                        int indexComment = line.IndexOf(';');
-                        int indexClose = line.IndexOf(']');
-                        if (indexComment != -1 && indexComment < indexClose)
-                        {
-                            inSection = false;
-                            currentSection = null;
-                            continue;
-                        }
-                        if (indexClose == -1) throw new FileContentException(path, IniFileType, "Invalid section header: " + line);
-                        string name = line.Substring(1, indexClose - 1).Trim();
-                        currentSection = new Section(name) { File = path, Line = currentLine };
-
-                        inSection = true;
-                        continue;
-                    }
-                    else
-                    {
-                        if (!inSection) continue;
-                        int indexComment = line.IndexOf(';');
-                        if (indexComment != -1) line = line.Remove(indexComment);
-                        int partCount;
-                        if (!char.IsLetterOrDigit(line[0]) && line[0] != '_')
-                        {
-                            FLLog.Warning("Ini", "Invalid line in file: " + path + " at line " + currentLine + '"' + line + '"');
-                        }
-                        else
-                        {
-                            partCount = ParseEquals(line, parts, allowmaps);
-                            if (partCount == 2)
-                            {
-                                string val = parts[1];
-                                string[] valParts = val.Split(',');
-
-                                var values = new List<IValue>(valParts.Length);
-                                foreach (string part in valParts)
-                                {
-                                    string s = part.Trim();
-                                    if (s.Length == 0)
-                                    {
-                                        values.Add(new StringValue("", currentSection.Name, path, currentLine));
-                                        continue;
-                                    }
-                                    if (preparse && (s[0] == '-' || s[0] >= '0' && s[0] <= '9'))
-                                    {
-                                        if (long.TryParse(s, out long tempLong))
-                                        {
-                                            if (tempLong >= int.MinValue && tempLong <= int.MaxValue)
-                                                values.Add(new Int32Value((int)tempLong));
-                                            else
-                                                values.Add(new SingleValue(tempLong, tempLong));
-                                        }
-                                        else if (float.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out float tempFloat))
-                                        {
-                                            values.Add(new SingleValue(tempFloat, null));
-                                        }
-                                        else
-                                            values.Add(new StringValue(s, currentSection.Name, path, currentLine));
-                                    }
-                                    else if (preparse && bool.TryParse(s, out bool tempBool))
-                                        values.Add(new BooleanValue(tempBool));
-                                    else
-                                        values.Add(new StringValue(s, currentSection.Name, path, currentLine));
-                                }
-
-                                currentSection.Add(new Entry(parts[0].Trim(), values) { File = path, Line = currentLine });
-                            }
-                            else if (partCount == 3 && allowmaps)
-                            {
-                                string k = parts[1].Trim();
-                                string v = parts[2].Trim();
-                                currentSection.Add(new Entry(parts[0].Trim(), new IValue[] { new StringKeyValue(k, v) }) { File = path, Line = currentLine });
-                            }
-                            else if (partCount == 1)
-                            {
-                                currentSection.Add(new Entry(parts[0].Trim(), new List<IValue>()) { File = path, Line = currentLine });
-                            }
-                        }
-                    
-
-                    }
-                }
+                // Text Ini
+                parser = new TextIniParser();
             }
-            if (currentSection != null) yield return currentSection;
+            return parser.ParseIniFile(path, stream, preparse, allowmaps);
         }
 
 		protected IEnumerable<Section> ParseFile(string path, FileSystem vfs, bool allowmaps = false)
 		{
-			if (path == null) throw new ArgumentNullException("path");
+			if (path == null) throw new ArgumentNullException(nameof(path));
 			if (!path.EndsWith(".ini", StringComparison.OrdinalIgnoreCase))
 				path = path + ".ini";
             using (var stream = new MemoryStream())

--- a/src/LibreLancer.Data/Ini/IniFile.cs
+++ b/src/LibreLancer.Data/Ini/IniFile.cs
@@ -14,9 +14,10 @@ namespace LibreLancer.Ini
 {
 	public abstract partial class IniFile
 	{
-		public const string FileType = "BINI", IniFileType = "INI";
-		public const int FileVersion = 1;
-        static int ParseEquals(string line, string[] part, bool allowmaps)
+		private const string FileType = "BINI", IniFileType = "INI";
+		private const int FileVersion = 1;
+
+        private static int ParseEquals(string line, string[] part, bool allowmaps)
         {
             var idx0 = line.IndexOf('=');
             if (idx0 == -1)
@@ -60,7 +61,7 @@ namespace LibreLancer.Ini
             Section currentSection = null;
             if (fileType == FileType) // Binary Ini
             {
-                BinaryReader reader = new BinaryReader(stream);
+                var reader = new BinaryReader(stream);
 
                 int formatVersion = reader.ReadInt32();
                 if (formatVersion != FileVersion) throw new FileVersionException(path, fileType, formatVersion, FileVersion);
@@ -81,7 +82,7 @@ namespace LibreLancer.Ini
             else // Text Ini
             {
                 stream.Seek(0, SeekOrigin.Begin);
-                StreamReader reader = new StreamReader(stream);
+                var reader = new StreamReader(stream);
 
                 int currentLine = 0;
                 bool inSection = false;
@@ -132,13 +133,10 @@ namespace LibreLancer.Ini
                                 string val = parts[1];
                                 string[] valParts = val.Split(',');
 
-                                List<IValue> values = new List<IValue>(valParts.Length);
+                                var values = new List<IValue>(valParts.Length);
                                 foreach (string part in valParts)
                                 {
                                     string s = part.Trim();
-                                    bool tempBool;
-                                    float tempFloat;
-                                    long tempLong;
                                     if (s.Length == 0)
                                     {
                                         values.Add(new StringValue("", currentSection.Name, path, currentLine));
@@ -146,21 +144,21 @@ namespace LibreLancer.Ini
                                     }
                                     if (preparse && (s[0] == '-' || s[0] >= '0' && s[0] <= '9'))
                                     {
-                                        if (long.TryParse(s, out tempLong))
+                                        if (long.TryParse(s, out long tempLong))
                                         {
                                             if (tempLong >= int.MinValue && tempLong <= int.MaxValue)
                                                 values.Add(new Int32Value((int)tempLong));
                                             else
                                                 values.Add(new SingleValue(tempLong, tempLong));
                                         }
-                                        else if (float.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out tempFloat))
+                                        else if (float.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out float tempFloat))
                                         {
                                             values.Add(new SingleValue(tempFloat, null));
                                         }
                                         else
                                             values.Add(new StringValue(s, currentSection.Name, path, currentLine));
                                     }
-                                    else if (preparse && bool.TryParse(s, out tempBool))
+                                    else if (preparse && bool.TryParse(s, out bool tempBool))
                                         values.Add(new BooleanValue(tempBool));
                                     else
                                         values.Add(new StringValue(s, currentSection.Name, path, currentLine));
@@ -186,6 +184,7 @@ namespace LibreLancer.Ini
             }
             if (currentSection != null) yield return currentSection;
         }
+
 		protected IEnumerable<Section> ParseFile(string path, FileSystem vfs, bool allowmaps = false)
 		{
 			if (path == null) throw new ArgumentNullException("path");

--- a/src/LibreLancer.Data/Ini/IniWarning.cs
+++ b/src/LibreLancer.Data/Ini/IniWarning.cs
@@ -4,7 +4,7 @@ public static class IniWarning
 {
     public static void UnknownEntry(Entry e, Section s)
     {
-        FLLog.Warning("Ini", "Unknown entry " + e.Name + FormatLine(e.File, e.Line, s));
+        FLLog.Warning("Ini", "Unknown entry " + e.Name + FormatLine(s.File, e.Line, s));
     }
 
     public static void UnknownSection(Section section)
@@ -14,12 +14,12 @@ public static class IniWarning
 
     public static void DuplicateEntry(Entry e, Section s)
     {
-        FLLog.Warning("Ini", "Duplicate of " + e.Name + FormatLine(e.File, e.Line, s));
+        FLLog.Warning("Ini", "Duplicate of " + e.Name + FormatLine(s.File, e.Line, s));
     }
 
-    public static void Warn(string warning, Entry e, Section? s = null)
+    public static void Warn(string warning, Entry e)
     {
-        FLLog.Warning("Ini", warning + " " + FormatLine(e.File, e.Line, s));
+        FLLog.Warning("Ini", warning + " " + FormatLine(e.Section.File, e.Line, e.Section));
     }
     
     static string FormatLine(string file, int line)

--- a/src/LibreLancer.Data/Ini/Int32Value.cs
+++ b/src/LibreLancer.Data/Ini/Int32Value.cs
@@ -8,18 +8,18 @@ using System.IO;
 
 namespace LibreLancer.Ini
 {
-	public class Int32Value : IValue
+	public class Int32Value : ValueBase
 	{
-		private int value;
+		private readonly int value;
 
 		public Int32Value(BinaryReader reader)
 		{
-			if (reader == null) throw new ArgumentNullException("reader");
+			if (reader == null) throw new ArgumentNullException(nameof(reader));
 
 			value = reader.ReadInt32();
 		}
 
-		public Int32Value(int value)
+		public Int32Value(int value) 
 		{
 			this.value = value;
 		}
@@ -30,41 +30,33 @@ namespace LibreLancer.Ini
 			else return operand.value;
 		}
 
-		public bool ToBoolean()
+		public override bool TryToBoolean(out bool result)
 		{
-			return value != 0;
+			result = value != 0;
+            return true;
 		}
 
-        public bool TryToInt32(out int result)
+        public override bool TryToInt32(out int result)
         {
             result = value;
             return true;
         }
 
-		public int ToInt32()
+		public override bool TryToInt64(out long result)
 		{
-			return value;
-		}
+            result = value;
+			return true;
+		}        
 
-        public long ToInt64()
-        {
-            return value;
-        }
-        
-
-        public float ToSingle(string propertyName = null)
+        public override bool TryToSingle(out float result)
 		{
-			return value;
+			result = value;
+            return true;
 		}
 
 		public override string ToString()
 		{
 			return value.ToString(CultureInfo.InvariantCulture);
-		}
-
-		public StringKeyValue ToKeyValue()
-		{
-			throw new InvalidCastException ();
 		}
 	}
 }

--- a/src/LibreLancer.Data/Ini/MapValue.cs
+++ b/src/LibreLancer.Data/Ini/MapValue.cs
@@ -5,43 +5,38 @@ using System;
 
 namespace LibreLancer.Ini
 {
-	public class MapValue : IValue
+	public class MapValue : ValueBase
 	{
-		public StringKeyValue Value;
+		public readonly StringKeyValue value;
 
-		public MapValue (string k, string v)
+		public MapValue(string k, string v)
 		{
-			Value = new StringKeyValue (k, v);
+			value = new StringKeyValue(k, v);
 		}
 
-		public bool ToBoolean ()
+		public override bool TryToBoolean(out bool result)
 		{
-			throw new InvalidCastException ();
+			throw new InvalidCastException();
 		}
 
-        public bool TryToInt32(out int result)
-        {
-            result = 0;
-            return false;
-        }
-
-		public int ToInt32 ()
-		{
-			throw new InvalidCastException ();
-		}
-        public long ToInt64()
+        public override bool TryToInt32(out int result)
         {
             throw new InvalidCastException();
         }
 
-        public float ToSingle (string propertyName = null)
+        public override bool TryToInt64(out long result)
+        {
+            throw new InvalidCastException();
+        }
+
+        public override bool TryToSingle(out float result)
 		{
 			throw new InvalidCastException ();
 		}
 
-		public StringKeyValue ToKeyValue()
+		public override StringKeyValue ToKeyValue()
 		{
-			return Value;
+			return value;
 		}
 	}
 }

--- a/src/LibreLancer.Data/Ini/Section.cs
+++ b/src/LibreLancer.Data/Ini/Section.cs
@@ -20,27 +20,9 @@ namespace LibreLancer.Ini
 
 		private List<Entry> entries;
 
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "string")]
-		public Section(string file, BinaryReader reader, BiniStringBlock stringBlock)
-		{
-			if (reader == null) throw new ArgumentNullException("reader");
-			if (stringBlock == null) throw new ArgumentNullException("stringBlock");
-
-            File = file;
-            
-			short nameOffset = reader.ReadInt16();
-            Name = stringBlock.Get(nameOffset);
-
-			short count = reader.ReadInt16();
-			entries = new List<Entry>(count);
-
-			for (int i = 0; i < count; i++)
-				entries.Add(new Entry(file, reader, stringBlock, Name));
-		}
-
 		public Section(string name)
 		{
-			if (name == null) throw new ArgumentNullException("name");
+			if (name == null) throw new ArgumentNullException(nameof(name));
 
 			entries = new List<Entry>();
 			this.Name = name;

--- a/src/LibreLancer.Data/Ini/Section.cs
+++ b/src/LibreLancer.Data/Ini/Section.cs
@@ -13,19 +13,20 @@ namespace LibreLancer.Ini
 	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix")]
 	public class Section : ICollection<Entry>
 	{
-		public string Name { get; private set; }
+        private List<Entry> entries;
 
-        public string File = "[Null]";
-        public int Line = -1;
+        public string Name { get; init; }
 
-		private List<Entry> entries;
+        public string File { get; init; } = "[Null]";
+
+        public int Line { get; init; } = -1;
 
 		public Section(string name)
 		{
 			if (name == null) throw new ArgumentNullException(nameof(name));
 
 			entries = new List<Entry>();
-			this.Name = name;
+			Name = name;
 		}
 
 		public Entry this[int index]

--- a/src/LibreLancer.Data/Ini/SingleValue.cs
+++ b/src/LibreLancer.Data/Ini/SingleValue.cs
@@ -8,19 +8,19 @@ using System.IO;
 
 namespace LibreLancer.Ini
 {
-	public class SingleValue : IValue
+	public class SingleValue : ValueBase
 	{
 		private float value;
 		private long? longvalue;
+
 		public SingleValue(BinaryReader reader)
 		{
-			if (reader == null) throw new ArgumentNullException("reader");
-
+			if (reader == null) throw new ArgumentNullException(nameof(reader));
 			value = reader.ReadSingle();
 		}
 
 		public SingleValue(float value, long? templong)
-		{
+        {
 			longvalue = templong;
 			this.value = value;
 		}
@@ -30,47 +30,39 @@ namespace LibreLancer.Ini
             return operand.value;
 		}
 
-		public bool ToBoolean()
+		public override bool TryToBoolean(out bool result)
 		{
-			return value != 0;
+			result = value != 0;
+            return true;
 		}
 
-        public bool TryToInt32(out int result)
+        public override bool TryToInt32(out int result)
         {
-            result = ToInt32();
+            if (longvalue != null)
+            {
+                result = unchecked((int)longvalue.Value);
+                return true;
+            }
+            result = (int)value;
             return true;
         }
 
-		public int ToInt32()
-		{
-			if (longvalue != null)
-			{
-				return unchecked((int)longvalue.Value);
-			}
-			return (int)value;
-		}
-
-        public long ToInt64()
+        public override bool TryToInt64(out long result)
         {
-            if (longvalue != null) return longvalue.Value;
-            return (int)value;
-        }
-
-        public bool TryGetSingle(out float f)
-        {
-            f = value;
+            if (longvalue != null)
+            {
+                result = longvalue.Value;
+                return true;
+            }
+            result = (int)value;
             return true;
         }
 
-        public float ToSingle(string propertyName = null)
-		{
-			return value;
-		}
-
-		public StringKeyValue ToKeyValue()
-		{
-			throw new InvalidCastException ();
-		}
+        public override bool TryToSingle(out float result)
+        {
+            result = value;
+            return true;
+        }
 
 		public override string ToString()
 		{

--- a/src/LibreLancer.Data/Ini/StringKeyValue.cs
+++ b/src/LibreLancer.Data/Ini/StringKeyValue.cs
@@ -5,45 +5,44 @@ using System;
 
 namespace LibreLancer.Ini
 {
-	public class StringKeyValue : IValue
+	public class StringKeyValue : ValueBase
 	{
-		public string Key;
-		public string Value;
-		public StringKeyValue (string k, string v)
+        public string Key { get; init; }
+		public string Value { get; init; }
+
+		public StringKeyValue (string key, string value)
 		{
-			Key = k;
-			Value = v;
+            if (key == null) throw new ArgumentNullException(nameof(key));
+            if (value == null) throw new ArgumentNullException(nameof(value));
+
+			Key = key;
+			Value = value;
 		}
 
-		public bool ToBoolean()
-		{
-			throw new NotImplementedException();
-		}
-
-		public int ToInt32()
-		{
-			throw new NotImplementedException();
-		}
-
-        public bool TryToInt32(out int value)
+        public override bool TryToBoolean(out bool result)
         {
-            value = 0;
+            throw new InvalidCastException();
+        }
+
+        public override bool TryToInt32(out int result)
+        {
+            result = 0;
             return false;
         }
 
-        public long ToInt64()
+        public override bool TryToInt64(out long result)
         {
-            throw new NotImplementedException();
+            throw new InvalidCastException();
         }
 
-        public StringKeyValue ToKeyValue()
+        public override bool TryToSingle(out float result)
+        {
+            throw new InvalidCastException();
+        }
+
+        public override StringKeyValue ToKeyValue()
 		{
 			return this;
-		}
-
-		public float ToSingle(string propertyName = null)
-		{
-			throw new NotImplementedException();
 		}
 	}
 }

--- a/src/LibreLancer.Data/Ini/TextIniParser.cs
+++ b/src/LibreLancer.Data/Ini/TextIniParser.cs
@@ -95,18 +95,18 @@ namespace LibreLancer.Ini
                     else
                     {
                         partCount = ParseEquals(line, parts, allowmaps);
+                        var entry = new Entry(currentSection, parts[0].Trim()) { Line = currentLine,  };
                         if (partCount == 2)
                         {
                             string val = parts[1];
                             string[] valParts = val.Split(',');
 
-                            var values = new List<IValue>(valParts.Length);
                             foreach (string part in valParts)
                             {
                                 string s = part.Trim();
                                 if (s.Length == 0)
                                 {
-                                    values.Add(new StringValue("", currentSection.Name, path, currentLine));
+                                    entry.Add(new StringValue("") { Entry = entry, Line = currentLine});
                                     continue;
                                 }
                                 if (preparse && (s[0] == '-' || s[0] >= '0' && s[0] <= '9'))
@@ -114,34 +114,34 @@ namespace LibreLancer.Ini
                                     if (long.TryParse(s, out long tempLong))
                                     {
                                         if (tempLong >= int.MinValue && tempLong <= int.MaxValue)
-                                            values.Add(new Int32Value((int)tempLong));
+                                            entry.Add(new Int32Value((int)tempLong) { Entry = entry, Line = currentLine });
                                         else
-                                            values.Add(new SingleValue(tempLong, tempLong));
+                                            entry.Add(new SingleValue(tempLong, tempLong) { Entry = entry, Line = currentLine });
                                     }
                                     else if (float.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out float tempFloat))
                                     {
-                                        values.Add(new SingleValue(tempFloat, null));
+                                        entry.Add(new SingleValue(tempFloat, null) { Entry = entry , Line = currentLine });
                                     }
                                     else
-                                        values.Add(new StringValue(s, currentSection.Name, path, currentLine));
+                                        entry.Add(new StringValue(s) { Entry = entry, Line = currentLine });
                                 }
                                 else if (preparse && bool.TryParse(s, out bool tempBool))
-                                    values.Add(new BooleanValue(tempBool));
+                                    entry.Add(new BooleanValue(tempBool) { Entry = entry, Line = currentLine });
                                 else
-                                    values.Add(new StringValue(s, currentSection.Name, path, currentLine));
+                                    entry.Add(new StringValue(s) { Entry = entry, Line = currentLine });
                             }
-
-                            currentSection.Add(new Entry(parts[0].Trim(), values) { File = path, Line = currentLine });
+                            currentSection.Add(entry);
                         }
                         else if (partCount == 3 && allowmaps)
                         {
                             string k = parts[1].Trim();
                             string v = parts[2].Trim();
-                            currentSection.Add(new Entry(parts[0].Trim(), new IValue[] { new StringKeyValue(k, v) }) { File = path, Line = currentLine });
+                            entry.Add(new StringKeyValue(k, v) { Entry = entry, Line = currentLine });
+                            currentSection.Add(entry);
                         }
                         else if (partCount == 1)
                         {
-                            currentSection.Add(new Entry(parts[0].Trim(), new List<IValue>()) { File = path, Line = currentLine });
+                            currentSection.Add(entry);
                         }
                     }
                 }

--- a/src/LibreLancer.Data/Ini/ValueBase.cs
+++ b/src/LibreLancer.Data/Ini/ValueBase.cs
@@ -1,0 +1,52 @@
+﻿// MIT License - Copyright (c) Callum McGing
+// This file is subject to the terms and conditions defined in
+// LICENSE, which is part of this source code package
+
+using System;
+
+namespace LibreLancer.Ini
+{
+    public abstract class ValueBase : IValue
+    {
+        public Entry Entry { get; init; }
+
+        public int Line { get; init; } = -1;
+
+        public abstract bool TryToBoolean(out bool result);
+
+        public abstract bool TryToInt32(out int result);
+
+        public abstract bool TryToInt64(out long result);
+
+        public abstract bool TryToSingle(out float result);
+
+        public bool ToBoolean()
+        {
+            TryToBoolean(out var result);
+            return result;
+        }
+
+        public int ToInt32()
+        {
+            TryToInt32(out var result);
+            return result;
+        }
+
+        public long ToInt64()
+        {
+            TryToInt64(out var result);
+            return result;
+        }
+
+        public float ToSingle()
+        {
+            TryToSingle(out var result);
+            return result;
+        }
+
+        public virtual StringKeyValue ToKeyValue()
+        {
+            throw new InvalidCastException();
+        }
+    }
+}

--- a/src/LibreLancer.Data/Missions/EmpathyEvent.cs
+++ b/src/LibreLancer.Data/Missions/EmpathyEvent.cs
@@ -25,7 +25,7 @@ namespace LibreLancer.Data.Missions
                     Type = EmpathyEventType.RandomMissionAbort;
                     break;
                 default:
-                    FLLog.Error("Ini", $"Bad empathy event {e[0]} at {e.File}:{e.Line}");
+                    FLLog.Error("Ini", $"Bad empathy event {e[0]} at {e.Section.File}:{e.Line}");
                     Type = EmpathyEventType.None;
                     break;
             }

--- a/src/LibreLancer.Data/Universe/Base.cs
+++ b/src/LibreLancer.Data/Universe/Base.cs
@@ -97,7 +97,7 @@ namespace LibreLancer.Data.Universe
 						AutosaveForbidden = e[0].ToBoolean();
 						break;
 					default:
-                        FLLog.Warning("Ini", $"Invalid Entry `{e.Name}` in {section.Name}: {e.File}:{e.Line}");
+                        FLLog.Warning("Ini", $"Invalid Entry `{e.Name}` in {section.Name}: {e.Section.File}:{e.Line}");
                         break;
 				}
 			}
@@ -130,7 +130,7 @@ namespace LibreLancer.Data.Universe
                                         FLLog.Error("Base", "Unimplemented: price_variance");
                                         break;
                                     default:
-                                        FLLog.Warning("Ini", $"Invalid Entry `{e.Name}` in {section.Name}: {e.File}:{e.Line}");
+                                        FLLog.Warning("Ini", $"Invalid Entry `{e.Name}` in {section.Name}: {section.File}:{e.Line}");
                                         break;
                                 }
                             }

--- a/src/LibreLancer.Data/Universe/Encounter.cs
+++ b/src/LibreLancer.Data/Universe/Encounter.cs
@@ -25,7 +25,7 @@ namespace LibreLancer.Data.Universe
             if(e.Count > 1)
                 Difficulty = e[1].ToInt32();
             if (e.Count > 2)
-                Chance = e[2].ToSingle("chance");
+                Chance = e[2].ToSingle();
         }
 
         object ICloneable.Clone()

--- a/src/LibreLancer.Data/Universe/TexturePanels.cs
+++ b/src/LibreLancer.Data/Universe/TexturePanels.cs
@@ -27,7 +27,7 @@ namespace LibreLancer.Data.Universe
         string shapeTexName = "";
         public TexturePanels(string filename, FileSystem vfs)
 		{
-			var parsed = ParseFile (filename, vfs);
+			var parsed = ParseFile(filename, vfs);
 
             Shapes = new Dictionary<string, TextureShape>(StringComparer.InvariantCultureIgnoreCase);
 			Files = new List<string>();
@@ -127,7 +127,7 @@ namespace LibreLancer.Data.Universe
                         shapeTexName = e[0].ToString();
                         break;
                     default:
-                        FLLog.Warning("Ini", "Invalid entry " + e.Name + " in " + e.File);
+                        FLLog.Warning("Ini", "Invalid entry " + e.Name + " in " + section.File);
                     break;
 				}
 			}

--- a/src/LibreLancer.Data/Universe/Zone.cs
+++ b/src/LibreLancer.Data/Universe/Zone.cs
@@ -112,10 +112,10 @@ namespace LibreLancer.Data.Universe
         void HandleFaction(Entry e)
         {
             if (Encounters.Count == 0) {
-                //FLLog.Warning("Ini", $"faction entry without matching encounter at {e.File}:{e.Line}");
+                //FLLog.Warning("Ini", $"faction entry without matching encounter at {e.Section.File}:{e.Line}");
             }
             else {
-                Encounters[^1].FactionSpawns.Add(new (e[0].ToString(), e[1].ToSingle("chance")));
+                Encounters[^1].FactionSpawns.Add(new (e[0].ToString(), e[1].ToSingle()));
             }
         }
 

--- a/src/LibreLancer.Tests/Ini/BinaryIniParserTests.cs
+++ b/src/LibreLancer.Tests/Ini/BinaryIniParserTests.cs
@@ -1,0 +1,108 @@
+﻿// MIT License - Copyright (c) Callum McGing
+// This file is subject to the terms and conditions defined in
+// LICENSE, which is part of this source code package
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using FluentAssertions;
+using LibreLancer.Ini;
+using Xunit;
+
+namespace LibreLancer.Tests.Ini
+{
+    public class BinaryIniParserTests
+    {
+        private static IList<Section> Parse(byte[] bini)
+        {
+            var stream = new MemoryStream(bini);
+            var parser = new BinaryIniParser();
+            return parser.ParseIniFile(null, stream).ToList();
+        }
+
+        [Fact]
+        public void ParseEmptyBiniSucceeds()
+        {
+            var bini = new byte[] { 0x42, 0x49, 0x4e, 0x49, // magic("BINI")
+                                    0x1, 0x0, 0x0, 0x0,     // version(1)
+                                    0xc, 0x0, 0x0, 0x0 };   // textoff(0xc)
+
+            var ini = Parse(bini);
+            ini.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ParseBiniBadVersionThrows()
+        {
+            var bini = new byte[] { 0x42, 0x49, 0x4e, 0x49, // magic("BINI")
+                                    0x0, 0x0, 0x0, 0x0,     // version(0) - invalid version
+                                    0xc, 0x0, 0x0, 0x0 };   // textoff(0xc)
+
+            Action act = () => { Parse(bini); };
+            act.Should().Throw<FileVersionException>().WithMessage("*version 1 was expected but a vesion 0*");
+        }
+
+        [Fact]
+        public void ParseBiniTextOffsetGreaterThanLengthThrows()
+        {
+            var bini = new byte[] { 0x42, 0x49, 0x4e, 0x49, // magic("BINI")
+                                    0x1, 0x0, 0x0, 0x0,     // version(1)
+                                    0xd, 0x0, 0x0, 0x0 };   // textoff(0xd) - invalid offset
+
+            Action act = () => { Parse(bini); };
+            act.Should().Throw<FileContentException>().WithMessage("*out of range*");
+        }
+
+        [Fact]
+        public void ParseBiniBadValueTypeThrows()
+        {
+            var bini = new byte[] { 0x42, 0x49, 0x4e, 0x49, // magic("BINI")
+                                    0x1, 0x0, 0x0, 0x0,     // version(1)
+                                    0x18, 0x0, 0x0, 0x0,    // textoff(0x18)
+                                                            // Data Section
+                                    0x0, 0x0,               // sectionName(A)
+                                    0x1, 0x0,               // numEntries(1)
+                                    0x0, 0x0,               // entryName(A)
+                                    0x1,                    // numValues(1)
+                                    0x4,                    // type - bad type
+                                    0x0, 0x0, 0x0, 0x0,     // value(0)
+                                                            // Text Section
+                                    0x48, 0x0 };            // "A"
+
+            Action act = () => { Parse(bini); };
+            act.Should().Throw<FileContentException>().WithMessage("*value type*");
+        }
+
+        [Fact]
+        public void ParseBasicBiniSucceeds()
+        {
+            var bini = new byte[] { 0x42, 0x49, 0x4e, 0x49, // magic("BINI")
+                                    0x1, 0x0, 0x0, 0x0,     // version(1)
+                                    0x18, 0x0, 0x0, 0x0,    // textoff(0x18)
+                                                            // Data Section
+                                    0x0, 0x0,               // sectionName("MySection")
+                                    0x1, 0x0,               // numEntries(1)
+                                    0xa, 0x0,               // entryName("MyKey")
+                                    0x1,                    // numValues(1)
+                                    0x3,                    // type(string)
+                                    0x10, 0x0, 0x0, 0x0,    // value("MyValue")
+                                                            // Text Section
+                                    0x4d, 0x79, 0x53, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x0,  // "MySection"
+                                    0x4d, 0x79, 0x4b, 0x65, 0x79, 0x0,                          // "MyKey"
+                                    0x4d, 0x79, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x0 };            // "MyValue"
+
+            var ini = Parse(bini);
+            ini.Should().HaveCount(1);
+            var section = ini[0];
+            section.Should().HaveCount(1);
+            section.Name.Should().Be("MySection");
+            var entry = section[0];
+            entry.Should().HaveCount(1);
+            entry.Name.Should().Be("MyKey");
+            var value = entry[0];
+            value.ToString().Should().Be("MyValue");
+        }
+    }
+}

--- a/src/LibreLancer.Tests/Ini/TextIniParserTests.cs
+++ b/src/LibreLancer.Tests/Ini/TextIniParserTests.cs
@@ -1,0 +1,159 @@
+﻿// MIT License - Copyright (c) Callum McGing
+// This file is subject to the terms and conditions defined in
+// LICENSE, which is part of this source code package
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+using FluentAssertions;
+using LibreLancer.Ini;
+using Xunit;
+
+namespace LibreLancer.Tests.Ini
+{
+    public class TextIniParserTests
+    {
+        private static IList<Section> Parse(string ini)
+        {
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(ini));
+            var parser = new TextIniParser();
+            return parser.ParseIniFile(null, stream).ToList();
+        }
+
+        [Fact]
+        public void ParseEmptyIniSucceeds()
+        {
+            var ini = Parse("");
+            ini.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData("[MySection]", "MySection")]
+        [InlineData("[=*MySection*=]", "=*MySection*=")]
+        [InlineData("[!£$%^&*()#':/?\\|]", "!£$%^&*()#':/?\\|")]
+        public void ParseSectionSucceeds(string iniString, string result)
+        {
+            var ini = Parse(iniString).ToList();
+            ini.Should().HaveCount(1);
+            var section = ini[0];
+            section.Should().HaveCount(0);
+            section.Name.Should().Be(result);
+        }
+
+        [Fact]
+        public void ParseEmptyEntryValueSucceeds()
+        {
+            var ini = Parse("[MySection]\nMyKey =").ToList();
+            ini.Should().HaveCount(1);
+            var section = ini[0];
+            section.Should().HaveCount(1);
+            section.Name.Should().Be("MySection");
+            var entry = section[0];
+            entry.Should().HaveCount(0);
+            entry.Name.Should().Be("MyKey");
+        }
+
+        [Theory]
+        [InlineData("[MySection")]
+        //[InlineData("MySection]")]
+        //[InlineData("[\"MySection]")]
+        //[InlineData("[MySection\"]")]
+        public void ParseIncompleteSectionThrows(string ini)
+        {
+            Action act = () => { Parse(ini); };
+            act.Should().Throw<FileContentException>().WithMessage("*Invalid section header*");
+        }
+
+        [Theory]
+        [InlineData("[A]\nK=0.0", 0)]
+        [InlineData("[A]\nK=1.1", 1.1)]
+        [InlineData("[A]\nK=1.11E4", 11100.0)]
+        [InlineData("[A]\nK=1.11E-4", 0.000111)]
+        [InlineData("[A]\nK=-2147483649", -2147483649)]
+        [InlineData("[A]\nK=2147483648", 2147483648)]
+        public void ParseSingleValueSucceeds(string iniString, float result)
+        {
+            var ini = Parse(iniString);
+            var value = ini[0][0][0];
+            value.Should().BeOfType<SingleValue>();
+            value.ToSingle().Should().Be(result);
+        }
+
+        [Theory]
+        [InlineData("[A]\nK=0", 0)]
+        [InlineData("[A]\nK=1", 1)]
+        [InlineData("[A]\nK=-2147483648", -2147483648)]
+        [InlineData("[A]\nK=2147483647", 2147483647)]
+        public void ParseIntegerValueSucceeds(string iniString, int result)
+        {
+            var ini = Parse(iniString);
+            var value = ini[0][0][0];
+            value.Should().BeOfType<Int32Value>();
+            value.ToInt32().Should().Be(result);
+        }
+
+        [Theory]
+        [InlineData("[A]\nK=true", true)]
+        [InlineData("[A]\nK=True", true)]
+        [InlineData("[A]\nK=TRUE", true)]
+        [InlineData("[A]\nK=false", false)]
+        [InlineData("[A]\nK=False", false)]
+        [InlineData("[A]\nK=FALSE", false)]
+        public void ParseBooleanValueSucceeds(string iniString, bool result)
+        {
+            var ini = Parse(iniString);
+            var value = ini[0][0][0];
+            value.Should().BeOfType<BooleanValue>();
+            value.ToBoolean().Should().Be(result);
+        }
+
+        [Theory]
+        [InlineData("[A]\nK=ImaString", "ImaString")]
+        [InlineData("[A]\nK=I'maString", "I'maString")]
+        [InlineData("[A]\nK=\"ImaString\"", "\"ImaString\"")]
+        [InlineData("[A]\nK=\"I'maString\"", "\"I'maString\"")]
+        [InlineData("[A]\nK=1.1.1", "1.1.1")]
+        [InlineData("[A]\nK=T", "T")]
+        [InlineData("[A]\nK=f", "f")]
+        public void ParseStringValueSucceeds(string iniString, string result)
+        {
+            var ini = Parse(iniString);
+            var value = ini[0][0][0];
+            value.Should().BeOfType<StringValue>();
+            value.ToString().Should().Be(result);
+        }
+
+        [Fact]
+        public void ParseIncompleteEntryValueIsIgnored()
+        {
+            var ini = Parse("[MySection]\nMyKey");
+            ini.Should().HaveCount(1);
+            ini[0].Should().HaveCount(1);
+            ini[0][0].Should().HaveCount(0);
+        }
+
+        [Fact]
+        public void ParseMultipleValueTypesSucceeds()
+        {
+            var ini = Parse("[Commodities]\niron = 1.42, 300, icons\\iron.bmp, \"+1\"");
+            ini.Should().HaveCount(1);
+            var section = ini[0];
+            section.Name.Should().Be("Commodities");
+            section.Should().HaveCount(1);
+            var entry = section[0];
+            entry.Name.Should().Be("iron");
+            entry.Should().HaveCount(4);
+            entry[0].Should().BeOfType<SingleValue>();
+            entry[0].ToSingle().Should().Be((float)1.42);
+            entry[1].Should().BeOfType<Int32Value>();
+            entry[1].ToInt32().Should().Be(300);
+            entry[2].Should().BeOfType<StringValue>();
+            entry[2].ToString().Should().Be("icons\\iron.bmp");
+            entry[3].Should().BeOfType<StringValue>();
+            entry[3].ToString().Should().Be("\"+1\"");
+        }
+    }
+}

--- a/src/LibreLancer.Tests/Ini/ValueTests.cs
+++ b/src/LibreLancer.Tests/Ini/ValueTests.cs
@@ -1,0 +1,90 @@
+﻿// MIT License - Copyright (c) Callum McGing
+// This file is subject to the terms and conditions defined in
+// LICENSE, which is part of this source code package
+
+using FluentAssertions;
+using LibreLancer.Ini;
+using Xunit;
+
+namespace LibreLancer.Tests.Ini
+{
+    public class ValueTests
+    {
+        [Theory]
+        [InlineData(true,  true,  1, 1, 1, "True")]
+        [InlineData(false, false, 0, 0, 0, "False")]
+        public void BooleanValueConversions(bool testValue,
+            bool toBoolean, int toInt32, long toInt64, float toSingle, string toString)
+        {
+            var value = new BooleanValue(testValue);
+
+            value.ToBoolean().Should().Be(toBoolean);
+            value.TryToInt32(out int i).Should().BeTrue();
+            i.Should().Be(toInt32);
+            value.ToInt32().Should().Be(toInt32);
+            value.ToInt64().Should().Be(toInt64);
+            value.ToSingle().Should().Be(toSingle);
+            value.ToString().Should().Be(toString);
+        }
+
+        [Theory]
+        [InlineData(0,            false, 0,            0,            0,            "0")]
+        [InlineData(int.MinValue, true,  int.MinValue, int.MinValue, int.MinValue, "-2147483648")]
+        [InlineData(int.MaxValue, true,  int.MaxValue, int.MaxValue, int.MaxValue, "2147483647")]
+        public void Int32ValueConversions(int testValue,
+            bool toBoolean, int toInt32, long toInt64, float toSingle, string toString)
+        {
+            var value = new Int32Value(testValue);
+
+            value.ToBoolean().Should().Be(toBoolean);
+            value.TryToInt32(out int i).Should().BeTrue();
+            i.Should().Be(toInt32);
+            value.ToInt32().Should().Be(toInt32);
+            value.ToInt64().Should().Be(toInt64);
+            value.ToSingle().Should().Be(toSingle);
+            value.ToString().Should().Be(toString);
+        }
+
+        [Theory]
+        [InlineData(0,              null, false, 0,            0,            0,              "0")]
+        [InlineData(1,              null, true,  1,            1,            1,              "1")]
+        [InlineData(float.MinValue, null, true,  int.MinValue, int.MinValue, float.MinValue, "-3.4028235E+38")]
+        [InlineData(float.MinValue, -3,   true,  -3,           -3,           float.MinValue, "-3.4028235E+38")]
+        [InlineData(float.MaxValue, null, true,  int.MinValue, int.MinValue, float.MaxValue, "3.4028235E+38")]
+        [InlineData(float.MaxValue, 3,    true,  3,            3,            float.MaxValue, "3.4028235E+38")]
+        public void SingleValueConversions(float testValue, long? testLongValue,
+            bool toBoolean, int toInt32, long toInt64, float toSingle, string toString)
+        {
+            var value = new SingleValue(testValue, testLongValue);
+
+            value.ToBoolean().Should().Be(toBoolean);
+            value.TryToInt32(out int i).Should().BeTrue();
+            i.Should().Be(toInt32);
+            value.ToInt32().Should().Be(toInt32);
+            value.ToInt64().Should().Be(toInt64);
+            value.ToSingle().Should().Be(toSingle);
+            value.ToString().Should().Be(toString);
+        }
+
+        [Theory]
+        [InlineData("0",           true, true,  0,            0,            0,            0,            "0")]
+        [InlineData("-2147483648", true, true,  int.MinValue, int.MinValue, int.MinValue, int.MinValue, "-2147483648")]
+        [InlineData("2147483647",  true, true,  int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, "2147483647")]
+        [InlineData("6566123.22",  true, false, 0,            -1,           -1,           6566123.22,   "6566123.22")]
+        [InlineData("NaN",         true, false, 0,            -1,           -1,           float.NaN,    "NaN")]
+        [InlineData("Nothing",     true, false, 0,            -1,           -1,           0,            "Nothing")]
+        public void StringValueConversions(string testValue,
+            bool toBoolean, bool tryInt32Return, int tryToInt32, int toInt32, long toInt64, float toSingle, string toString)
+        {
+            var value = new StringValue(testValue, null, null, -1);
+
+            value.ToBoolean().Should().Be(toBoolean);
+            value.TryToInt32(out int i).Should().Be(tryInt32Return);
+            i.Should().Be(tryToInt32);
+            value.ToInt32().Should().Be(toInt32);
+            value.ToInt64().Should().Be(toInt64);
+            value.ToSingle().Should().Be(toSingle);
+            value.ToString().Should().Be(toString);
+        }
+    }
+}

--- a/src/LibreLancer.Tests/Ini/ValueTests.cs
+++ b/src/LibreLancer.Tests/Ini/ValueTests.cs
@@ -70,13 +70,13 @@ namespace LibreLancer.Tests.Ini
         [InlineData("0",           true, true,  0,            0,            0,            0,            "0")]
         [InlineData("-2147483648", true, true,  int.MinValue, int.MinValue, int.MinValue, int.MinValue, "-2147483648")]
         [InlineData("2147483647",  true, true,  int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, "2147483647")]
-        [InlineData("6566123.22",  true, false, 0,            -1,           -1,           6566123.22,   "6566123.22")]
-        [InlineData("NaN",         true, false, 0,            -1,           -1,           float.NaN,    "NaN")]
-        [InlineData("Nothing",     true, false, 0,            -1,           -1,           0,            "Nothing")]
+        [InlineData("6566123.22",  true, false, -1,           -1,           -1,           6566123.22,   "6566123.22")]
+        [InlineData("NaN",         true, false, -1,           -1,           -1,           float.NaN,    "NaN")]
+        [InlineData("Nothing",     true, false, -1,           -1,           -1,           0,            "Nothing")]
         public void StringValueConversions(string testValue,
             bool toBoolean, bool tryInt32Return, int tryToInt32, int toInt32, long toInt64, float toSingle, string toString)
         {
-            var value = new StringValue(testValue, null, null, -1);
+            var value = new StringValue(testValue);
 
             value.ToBoolean().Should().Be(toBoolean);
             value.TryToInt32(out int i).Should().Be(tryInt32Return);

--- a/src/LibreLancer.Tests/LibreLancer.Tests.csproj
+++ b/src/LibreLancer.Tests/LibreLancer.Tests.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
Whilst attempting to create an ini file editor in LancerEdit I hit on a number of issues with the current interface to ini file parsing. This change prepares the foundations for such an editor, but also allows for unit tests of the ini parsers. 
A number of issues with the binary parser have been addressed and a set of potential issues with the text parser have been identified.
