### PR TITLE
feat: add support for building using the nix package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ You need to either uninstall the 32-bit dotnet SDK (recommended), or modify your
 1. Clone this repository with `git clone --recursive https://github.com/Librelancer/Librelancer`
 2. Run `build.sh`
 
+### Nix
+
+If you are using the Nix package manager, you can use the provided shell script to easily acquire all the packages. You can do so by running the `nix-shell --pure` command then running `./build.sh`.
 
 ## Screenshots
 See: https://librelancer.net/screenshots.html

--- a/scripts/depcheck_unix
+++ b/scripts/depcheck_unix
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Script to check if dependencies for build are installed
 
 check_command() {

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,28 @@
+with import <nixpkgs> { };
+pkgs.stdenv.mkDerivation rec {
+  name = "dev-env";
+  # Build time dependencies
+  nativeBuildInputs = with pkgs; [
+    pkg-config
+    git
+    cmake
+    dotnetCorePackages.sdk_8_0_4xx
+    freetype.dev
+    libGL.dev
+    SDL2.dev
+    pango.dev
+    cairo.dev
+    gtk3.dev
+    glib.dev
+    pcre2.dev
+    libgcc
+    util-linux.dev
+    util-linux.lib
+    harfbuzz.dev
+    icu.dev
+    fontconfig.dev
+    openal
+  ];
+
+  LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.fontconfig pkgs.SDL2 pkgs.gtk3 pkgs.openal ];
+}


### PR DESCRIPTION
Currently trying to build on NixOS is a bit of a chore. I've made a nix shell that has all the needed dependencies for building and running Librelancer.

Also adjusts the shbang in depcheck_unix to search for bash on the env rather than a hardcoded location.