### PR TITLE
Allow LancerEdit to compile FRC files

### DIFF
--- a/src/Editor/LancerEdit/editorscripts/compile-frc.cs-script
+++ b/src/Editor/LancerEdit/editorscripts/compile-frc.cs-script
@@ -1,0 +1,95 @@
+/*
+    ; FRC Compiler Script by Laz
+    [Script]
+    name = Compile FRC file
+    [Argument]
+    name = Directory
+    type = flag
+    flag = d
+    [Argument]
+    name = Input File
+    type = file
+    isactive = Directory, false
+    [Argument]
+    name = Output File
+    type = file
+    isactive = Directory, false
+    [Argument]
+    name = Dll Index
+    type = integer
+    flag = index
+    default = -1
+    isactive = Directory, false
+    [Argument]
+    name = Input Folder
+    type = folder
+    isactive = Directory, true
+    [Argument]
+    name = Output Folder
+    type = folder
+    isactive = Directory, true
+*/
+
+using System.IO;
+using System.Linq;
+using LibreLancer.ContentEdit.Frc;
+using LibreLancer.ContentEdit.RandomMissions;
+
+ScriptUsage(@"input output [-d] [index=int]
+If -d is specified, input and output must be directories, otherwise they will be an frc file and dll file respectively
+If index is specified extra checks will be added to ensure that absolute numbers match the specifed index");
+
+bool directory = false;
+FlagOption("d|directory", "INPUT and OUTPUT are directories", v => directory = v);
+
+int index = -1;
+IntegerOption("index=", "Index of the output file in freelancer.ini (resources.dll == 0)", v => index = v);
+
+var args = ParseArguments(2);
+string input = args[0];
+string output = args[1];
+
+if (!directory)
+{
+    if (!File.Exists(input))
+    {
+        Console.WriteLine("Input file not found");
+        Environment.Exit(2);
+    }
+
+    if (!Directory.Exists(Path.GetDirectoryName(output)))
+    {
+        Console.WriteLine("Output directory not found");
+        Environment.Exit(2);
+    }
+
+    CompileFrcToDll(input, output);
+    return;
+}
+
+if (!Directory.Exists(input))
+{
+    Console.WriteLine("Input directory not found");
+    Environment.Exit(2);
+}
+
+if (!Directory.Exists(output))
+{
+    Directory.CreateDirectory(output);
+}
+
+foreach(var file in Directory.GetFiles(input, "*.frc", SearchOption.TopDirectoryOnly))
+{
+    CompileFrcToDll(file, Path.Combine(output, Path.ChangeExtension(file, ".dll")));
+}
+
+void CompileFrcToDll(string file, string output)
+{
+    string text = File.ReadAllText(file);
+    var compiler = new FrcCompiler();
+    var resourceDll = compiler.Compile(text, file, index);
+
+    using FileStream fs = File.Create(output);
+    DllWriter.Write(resourceDll, fs);
+}
+

--- a/src/Editor/LancerEdit/editorscripts/compile-frc.cs-script
+++ b/src/Editor/LancerEdit/editorscripts/compile-frc.cs-script
@@ -51,6 +51,7 @@ string output = args[1];
 
 if (!directory)
 {
+    Console.WriteLine($"Compiling {input} to {output}");
     if (!File.Exists(input))
     {
         Console.WriteLine("Input file not found");
@@ -67,6 +68,8 @@ if (!directory)
     return;
 }
 
+Console.WriteLine("Compiling all FRC files in " + input);
+
 if (!Directory.Exists(input))
 {
     Console.WriteLine("Input directory not found");
@@ -80,7 +83,8 @@ if (!Directory.Exists(output))
 
 foreach(var file in Directory.GetFiles(input, "*.frc", SearchOption.TopDirectoryOnly))
 {
-    CompileFrcToDll(file, Path.Combine(output, Path.ChangeExtension(file, ".dll")));
+    Console.WriteLine("Compiling " + file);
+    CompileFrcToDll(file, Path.Combine(output, Path.GetFileName(Path.ChangeExtension(file, ".dll"))));
 }
 
 void CompileFrcToDll(string file, string output)

--- a/src/Editor/LibreLancer.ContentEdit/Frc/FrcCompiler.cs
+++ b/src/Editor/LibreLancer.ContentEdit/Frc/FrcCompiler.cs
@@ -394,6 +394,24 @@ public class FrcCompiler
                         specialCharacterState = SpecialCharacterState.Raw;
                         currentSpecialString.Append('<');
                         return false;
+                    case '1':
+                        AppendText('\u2081');
+                        break;
+                    case '2':
+                        AppendText('\u2082');
+                        break;
+                    case '3':
+                        AppendText('\u2083');
+                        break;
+                    case '0':
+                    case '4':
+                    case '5':
+                    case '6':
+                    case '7':
+                    case '8':
+                    case '9':
+                        AppendText((char)(ch - '0' + '\u2070'));
+                        break;
                     default:
                     {
                         throw new CompileErrorException(source, reader.Column, reader.Line,

--- a/src/Editor/LibreLancer.ContentEdit/Frc/FrcCompiler.cs
+++ b/src/Editor/LibreLancer.ContentEdit/Frc/FrcCompiler.cs
@@ -1,0 +1,445 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using LibreLancer.ContentEdit.RandomMissions;
+using LibreLancer.Dll;
+
+namespace LibreLancer.ContentEdit.Frc;
+
+public class FrcCompiler
+{
+    private enum State
+    {
+        Start,
+        String,
+        StringIds,
+        Info,
+        InfoIds,
+    }
+
+    private enum SpecialCharacterState
+    {
+        None,
+        Color,
+        FontNumber,
+        Pos,
+        Unicode
+    }
+
+    [SuppressMessage("ReSharper", "UnusedMember.Local")]
+    private enum AvailableColour
+    {
+        Gray,
+        Blue,
+        Green,
+        Aqua,
+        Red,
+        Fuchsia,
+        Yellow,
+        White
+    }
+
+    private int currentIdsNumber = -1;
+    private string currentString = string.Empty;
+
+    private bool skipWhitespace;
+    private char lastSymbol = '\0';
+    private string currentSpecialString = string.Empty;
+    private bool lastCharWasNewLine;
+    private State state = State.Start;
+    private SpecialCharacterState specialCharacterState = SpecialCharacterState.None;
+
+    private static bool IsSpace(char c) => c is ' ' or '\t';
+
+    public const string InfocardStart = "<?xml version=\"1.0\" encoding=\"UTF-16\"?><RDL><PUSH/>";
+    public const string InfocardEnd = "<POP/></RDL>";
+    public ResourceDll Compile(string text, string source, int resourceIndex = -1)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            throw new ArgumentNullException(nameof(text));
+        }
+
+        ResourceDll res = new();
+
+        var reader = new FrcReader(text, source);
+
+        var ch = (char)reader.Current();
+        state = ch switch
+        {
+            'S' => State.StringIds,
+            'H' or 'I' => State.InfoIds,
+            _ => throw new CompileErrorException(source, reader.Column, reader.Line,
+                $"Unexpected character '{ch}'. Expected S, H/I")
+        };
+
+        while (reader.Current() != -1)
+        {
+            if (!Advance(state is not State.String and not State.Info || lastCharWasNewLine || skipWhitespace))
+            {
+                break;
+            }
+
+            if (skipWhitespace)
+            {
+                skipWhitespace = false;
+                lastSymbol = ' ';
+            }
+
+            ch = (char)reader.Current();
+            if (ch == '\r')
+            {
+                continue;
+            }
+
+            if (reader.Column is 1 && char.IsAsciiLetterUpper(ch))
+            {
+                // Line ended without finishing a special character
+                if (specialCharacterState != SpecialCharacterState.None)
+                {
+                    var oldCh = ch;
+                    ch = '\0';
+                    HandleSpecialCharacter();
+                    ch = oldCh;
+                }
+
+                switch (state)
+                {
+                    // We are changing the state, lets finish what we were doing with the previous state
+                    case State.String:
+                        res.Strings[currentIdsNumber] = currentString;
+                        break;
+                    case State.Info:
+                        res.Infocards[currentIdsNumber] = InfocardStart + currentString + InfocardEnd;
+                        break;
+                    case State.StringIds:
+                    case State.InfoIds:
+                    {
+                        throw new CompileErrorException(source, reader.Column, reader.Line,
+                            $"Unexpected character '{ch}'. Was expecting a {(state is State.StringIds ? "string" : "infocard")}.");
+                    }
+                    case State.Start:
+                    default:
+                        break;
+                }
+
+                state = ch switch
+                {
+                    'S' => State.StringIds,
+                    'H' or 'I' => State.InfoIds,
+                    _ => throw new CompileErrorException(source, reader.Column, reader.Line,
+                        $"Unexpected character '{ch}'. Expected S, H/I")
+                };
+
+                currentString = string.Empty;
+                currentIdsNumber = -1;
+                lastSymbol = ch;
+                lastCharWasNewLine = false;
+                continue;
+            }
+
+            if (state is State.StringIds or State.InfoIds)
+            {
+                if (!HandleIds())
+                {
+                    continue;
+                }
+
+                state = state is State.StringIds ? State.String : State.Info;
+            }
+
+            if (ch is '\n')
+            {
+                // If we end our string with a backslash, don't add a new line to the string
+                if (lastSymbol is not '\\')
+                {
+                    lastCharWasNewLine = true;
+                }
+                else
+                {
+                    skipWhitespace = true;
+                }
+
+                continue;
+            }
+
+            if (lastCharWasNewLine)
+            {
+                if (currentString.Length is not 0)
+                {
+                    currentString += state is State.String ? "\n" : "<PARA/>";
+                }
+
+                lastCharWasNewLine = false;
+            }
+
+            switch (lastSymbol)
+            {
+                case '\\' when ch is ' ':
+                    if (currentString.Length is 0)
+                    {
+                        currentString += ch;
+                    }
+
+                    lastSymbol = '\0';
+                    break;
+                case '\\':
+                    if (HandleSpecialCharacter())
+                    {
+                        if (ch is not '\\' and not '\n')
+                        {
+                            currentString += ch;
+                        }
+
+                        lastSymbol = ch;
+                    }
+                    break;
+                default:
+                    if (ch is not '\\' and not '\n')
+                    {
+                        currentString += ch;
+                    }
+
+                    lastSymbol = ch;
+                    break;
+            }
+        }
+
+        // File ended without finishing a special character
+        if (specialCharacterState != SpecialCharacterState.None)
+        {
+            ch = ' ';
+            HandleSpecialCharacter();
+        }
+
+        switch (state)
+        {
+            case State.String:
+                res.Strings[currentIdsNumber] = currentString;
+                break;
+            case State.Info:
+                res.Infocards[currentIdsNumber] = InfocardStart + currentString + InfocardEnd;
+                break;
+            default:
+                throw new CompileErrorException(source, reader.Column, reader.Line,
+                    $"State was invalid at file end");
+        }
+
+        return res;
+
+        bool HandleSpecialCharacter()
+        {
+            if (specialCharacterState is SpecialCharacterState.None)
+            {
+                switch (ch)
+                {
+                    case '\\':
+                        currentString += '\\';
+                        break;
+                    case 'b':
+                        currentString += """<TRA bold="true"/>""";
+                        break;
+                    case 'B':
+                        currentString += """<TRA bold="false"/>""";
+                        break;
+                    case 'c':
+                        specialCharacterState = SpecialCharacterState.Color;
+                        return false;
+                    case 'C':
+                        currentString += """<TRA color="default"/>""";
+                        break;
+                    case 'f':
+                        specialCharacterState = SpecialCharacterState.FontNumber;
+                        return false;
+                    case 'F':
+                        currentString += """<TRA font="default"/>""";
+                        break;
+                    case 'h':
+                        specialCharacterState = SpecialCharacterState.Pos;
+                        return false;
+                    case 'i':
+                        currentString += """<TRA italic="true"/>""";
+                        break;
+                    case 'I':
+                        currentString += """<TRA italic="false"/>""";
+                        break;
+                    case 'l':
+                        currentString += """<JUST loc="l"/>""";
+                        break;
+                    case 'm':
+                        currentString += """<JUST loc="c"/>""";
+                        break;
+                    case 'n':
+                        currentString += state is State.Info ? "<PARA/>" : "\n";
+                        break;
+                    case 'r':
+                        currentString += """<JUST loc="r"/>""";
+                        break;
+                    case 'u':
+                        currentString += """<TRA underline="true"/>""";
+                        break;
+                    case 'U':
+                        currentString += """<TRA underline="false"/>""";
+                        break;
+                    case 'x':
+                        specialCharacterState = SpecialCharacterState.Unicode;
+                        return false;
+                    case '.':
+                        break;
+                    default:
+                    {
+                        throw new CompileErrorException(source, reader.Column, reader.Line,
+                            $"Unexpected character '{ch}'. Expected special character.");
+                    }
+                }
+
+                lastSymbol = ch;
+                return false;
+            }
+
+            switch (specialCharacterState)
+            {
+                case SpecialCharacterState.Color:
+                {
+                    if (ch is not ' ')
+                    {
+                        currentSpecialString += ch;
+                        return false;
+                    }
+
+                    if (Enum.TryParse<AvailableColour>(currentSpecialString, out var color))
+                    {
+                        currentString += $"""<TRA color="{color.ToString().ToLowerInvariant()}"/>""";
+                    }
+                    else if (currentSpecialString.Length == 6)
+                    {
+                        if (!currentSpecialString.All(char.IsAsciiHexDigit))
+                        {
+                            throw new CompileErrorException(source, reader.Column, reader.Line,
+                                $"Provided colour was not a valid RRGGBB hex string.");
+                        }
+
+                        currentString += $"""<TRA color="#{currentSpecialString.ToUpper()}"/>""";
+                    }
+                    else
+                    {
+                        throw new CompileErrorException(source, reader.Column, reader.Line,
+                            $"Provided colour was not a valid colour string.");
+                    }
+
+                    break;
+                }
+                case SpecialCharacterState.FontNumber:
+                    if (ch is not ' ')
+                    {
+                        currentSpecialString += ch;
+                        return false;
+                    }
+
+                    if (int.TryParse(currentSpecialString, out var fontNumber) && fontNumber is > 0 and < 100)
+                    {
+                        currentString += $"""<TRA font="{fontNumber}"/>""";
+                    }
+                    else
+                    {
+                        throw new CompileErrorException(source, reader.Column, reader.Line,
+                            $"Provided font was not a valid number. Should be between 1-99 (inclusive).");
+                    }
+
+                    break;
+                case SpecialCharacterState.Pos:
+                    if (ch is not ' ')
+                    {
+                        currentSpecialString += ch;
+                        return false;
+                    }
+
+                    if (int.TryParse(currentSpecialString, out var pos) && pos is > 0 and < 1000)
+                    {
+                        currentString += $"""<POS h="{pos}" relH="true"/>""";
+                    }
+                    else
+                    {
+                        throw new CompileErrorException(source, reader.Column, reader.Line,
+                            $"Provided pos was not a valid number. Should be between 1-999 (inclusive).");
+                    }
+
+                    break;
+                case SpecialCharacterState.Unicode:
+                    if (currentSpecialString.Length is not 4 && ch is not ' ')
+                    {
+                        currentSpecialString += ch;
+                        return false;
+                    }
+
+                    if (currentSpecialString.Length is not 4)
+                    {
+                        throw new CompileErrorException(source, reader.Column, reader.Line,
+                            $"Provided unicode string was not four characters.");
+                    }
+
+                    if (!currentSpecialString.All(char.IsAsciiHexDigit))
+                    {
+                        throw new CompileErrorException(source, reader.Column, reader.Line,
+                            $"Provided unicode was not a valid hex string.");
+                    }
+
+                    var hex = Convert.ToInt32(currentSpecialString, 16);
+                    currentString += char.ConvertFromUtf32(hex);
+                    break;
+            }
+
+            currentSpecialString = string.Empty;
+            specialCharacterState = SpecialCharacterState.None;
+            lastSymbol = ch;
+            return true;
+        }
+
+        bool HandleIds()
+        {
+            if (currentString.Length is 0 && IsSpace(ch))
+            {
+                return false;
+            }
+
+            // Set the IDS number and start reading text
+            if (char.IsNumber(ch))
+            {
+                currentString += ch.ToString();
+                lastSymbol = ch;
+                return false;
+            }
+
+            if (currentString.Length is 0)
+            {
+                throw new CompileErrorException(source, reader.Column, reader.Line,
+                    $"Unexpected character '{ch}'. Expected number or whitespace.");
+            }
+
+            currentIdsNumber = int.Parse(currentString);
+            currentString = "";
+
+            return true;
+        }
+
+        bool Advance(bool skip)
+        {
+            reader.Advance();
+
+            if (!skip)
+            {
+                return reader.Current() != -1;
+            }
+
+            int character;
+            while ((character = reader.Current()) != -1 && IsSpace((char)character))
+            {
+                reader.Advance();
+            }
+
+            return (character != -1);
+
+        }
+    }
+}

--- a/src/Editor/LibreLancer.ContentEdit/Frc/FrcReader.cs
+++ b/src/Editor/LibreLancer.ContentEdit/Frc/FrcReader.cs
@@ -1,0 +1,32 @@
+using System.IO;
+
+namespace LibreLancer.ContentEdit.Frc;
+
+public class FrcReader(string text, string source)
+{
+    public int Column { get; private set; } = 1;
+    public int Line { get; private set; } = 1;
+
+    private readonly StringReader reader = new(text);
+    public string Source = source;
+
+    //Returns -1 on EOF
+    public int Current()
+    {
+        return reader.Peek();
+    }
+
+    public void Advance()
+    {
+        var n = reader.Read();
+        if (n == '\n')
+        {
+            Line++;
+            Column = 1;
+        }
+        else if (n != -1)
+        {
+            Column++;
+        }
+    }
+}

--- a/src/Editor/LibreLancer.ContentEdit/LibreLancer.ContentEdit.csproj
+++ b/src/Editor/LibreLancer.ContentEdit/LibreLancer.ContentEdit.csproj
@@ -28,4 +28,8 @@
       <EmbeddedResource Include="BlenderExport.py" />
     </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="LibreLancer.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/LibreLancer.Tests/Compilers/FrcFiles/ValidFrcInfocards.frc
+++ b/src/LibreLancer.Tests/Compilers/FrcFiles/ValidFrcInfocards.frc
@@ -1,0 +1,12 @@
+H 1
+    \bBold \BNot Bold
+I 2 MultiLine
+    String
+
+I 3 Two\nLines
+I 4 One \
+    Line
+I 5 \ Spacing \.
+I 6
+    Separate Line
+I 7 \x201CRead My Quote\x201D

--- a/src/LibreLancer.Tests/Compilers/FrcFiles/ValidFrcStrings.frc
+++ b/src/LibreLancer.Tests/Compilers/FrcFiles/ValidFrcStrings.frc
@@ -1,0 +1,11 @@
+S 1 File Starts Here
+S 2 MultiLine
+    String
+
+S 3 Two\nLines
+S 4 One \
+    Line
+S 5 \ Spacing \.
+S 6 
+    Separate Line
+S 7 \x201CRead My Quote\x201D

--- a/src/LibreLancer.Tests/Compilers/FrcTests.cs
+++ b/src/LibreLancer.Tests/Compilers/FrcTests.cs
@@ -172,6 +172,8 @@ public class FrcTests
         { @"I 1 \cdw", "<TRA color=\"#404040\"/>" },
         { """I 1 \<TRA bold="true"/>""", "<TRA bold=\"true\"/>" },
         { @"I 1 <>&", "<TEXT>&lt;&gt;&amp;</TEXT>" },
+        { @"I 1 \1", "<TEXT>\u2081</TEXT>" },
+        { @"I 1 \9", "<TEXT>\u2079</TEXT>" },
     };
 
     private string WrapInfocard(string infocard) => $"{FrcCompiler.InfocardStart}{infocard}{FrcCompiler.InfocardEnd}";

--- a/src/LibreLancer.Tests/Compilers/FrcTests.cs
+++ b/src/LibreLancer.Tests/Compilers/FrcTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 using LibreLancer.ContentEdit.Frc;
 using LibreLancer.ContentEdit.RandomMissions;
 using Xunit;
@@ -97,6 +98,27 @@ public class FrcTests
         Assert.Throws<CompileErrorException>(() => { _ = compiler.Compile($"I 1 \\f{font}", "TEST"); });
     }
 
+    [Theory]
+    [InlineData(1, 1, -1)]
+    [InlineData(65537, 1, 1)]
+    [InlineData(131071, 65535, 1)]
+    [InlineData(131071, 65535, -1)]
+    public void FrcShouldAllowAbsoluteIndexes(int absoluteId, int mappedId, int index)
+    {
+        var input = $"S {absoluteId} some text";
+
+        FrcCompiler compiler = new FrcCompiler();
+        var resourceDll = compiler.Compile(input, "TEST", index);
+
+        Assert.Contains(resourceDll.Strings, x => x.Key == mappedId);
+    }
+
+    [Fact]
+    public void BadResourceIndexShouldThrowExceptions()
+    {
+        FrcCompiler compiler = new FrcCompiler();
+        Assert.Throws<CompileErrorException>(() => { _ = compiler.Compile($"I 131071 EEE", "TEST", 0); });
+    }
 
     public static TheoryData<string, string> ValidInfocardFrcStrings { get; } = new()
     {

--- a/src/LibreLancer.Tests/Compilers/FrcTests.cs
+++ b/src/LibreLancer.Tests/Compilers/FrcTests.cs
@@ -1,0 +1,124 @@
+using System.IO;
+using LibreLancer.ContentEdit.Frc;
+using LibreLancer.ContentEdit.RandomMissions;
+using Xunit;
+
+namespace LibreLancer.Tests.Compilers;
+
+public class FrcTests
+{
+    [Fact]
+    public void ValidFrcStringsShouldReturnAValidResourceDll()
+    {
+        const string fileName = "Compilers/FrcFiles/ValidFrcStrings.frc";
+        var strings = File.ReadAllText(fileName);
+
+        FrcCompiler compiler = new FrcCompiler();
+        var resourceDll = compiler.Compile(strings, fileName);
+
+        Assert.NotNull(resourceDll);
+
+        Assert.Equal(expected: "File Starts Here", actual: resourceDll.Strings[1]);
+        Assert.Equal(expected: "MultiLine\nString", actual: resourceDll.Strings[2]);
+        Assert.Equal(expected: "Two\nLines", actual: resourceDll.Strings[3]);
+        Assert.Equal(expected: "One Line", actual: resourceDll.Strings[4]);
+        Assert.Equal(expected: " Spacing ", actual: resourceDll.Strings[5]);
+        Assert.Equal(expected: "Separate Line", actual: resourceDll.Strings[6]);
+        Assert.Equal(expected: "“Read My Quote”", actual: resourceDll.Strings[7]);
+    }
+
+    [Fact]
+    public void ValidFrcInfocardsShouldReturnAValidResourceDll()
+    {
+        const string fileName = "Compilers/FrcFiles/ValidFrcInfocards.frc";
+        var strings = File.ReadAllText(fileName);
+
+        FrcCompiler compiler = new FrcCompiler();
+        var resourceDll = compiler.Compile(strings, fileName);
+
+        Assert.NotNull(resourceDll);
+
+        Assert.Equal(expected: WrapInfocard("<TRA bold=\"true\"/>Bold <TRA bold=\"false\"/>Not Bold"),
+            actual: resourceDll.Infocards[1]);
+        Assert.Equal(expected: WrapInfocard("MultiLine<PARA/>String"), actual: resourceDll.Infocards[2]);
+        Assert.Equal(expected: WrapInfocard("Two<PARA/>Lines"), actual: resourceDll.Infocards[3]);
+        Assert.Equal(expected: WrapInfocard("One Line"), actual: resourceDll.Infocards[4]);
+        Assert.Equal(expected: WrapInfocard(" Spacing "), actual: resourceDll.Infocards[5]);
+        Assert.Equal(expected: WrapInfocard("Separate Line"), actual: resourceDll.Infocards[6]);
+        Assert.Equal(expected: WrapInfocard("“Read My Quote”"), actual: resourceDll.Infocards[7]);
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidInfocardFrcStrings))]
+    public void ValidFrcStringsShouldTransformToTheCorrectXml(string input, string expected)
+    {
+        FrcCompiler compiler = new FrcCompiler();
+        var resourceDll = compiler.Compile(input, "TEST");
+
+        Assert.NotNull(resourceDll);
+        Assert.Equal(expected: WrapInfocard(expected), actual: resourceDll.Infocards[1]);
+    }
+
+    [Theory]
+    [InlineData("white")]
+    [InlineData("ReD")]
+    [InlineData("Black")]
+    [InlineData("DarkBlue")]
+    [InlineData("ABCABCA")] // Bad Hex
+    public void BadColoursShouldThrowExceptions(string colour)
+    {
+        FrcCompiler compiler = new FrcCompiler();
+        Assert.Throws<CompileErrorException>(() =>
+        {
+            _ = compiler.Compile($"I 1 \\c{colour}", "TEST");
+        });
+    }
+
+    [Theory]
+    [InlineData("1000")]
+    [InlineData("-12")]
+    [InlineData("0")]
+    public void BadHeightShouldThrowExceptions(string height)
+    {
+        FrcCompiler compiler = new FrcCompiler();
+        Assert.Throws<CompileErrorException>(() =>
+        {
+            _ = compiler.Compile($"I 1 \\h{height}", "TEST");
+        });
+    }
+
+    [Theory]
+    [InlineData("100")]
+    [InlineData("-12")]
+    [InlineData("0")]
+    public void BadFontShouldThrowExceptions(string font)
+    {
+        FrcCompiler compiler = new FrcCompiler();
+        Assert.Throws<CompileErrorException>(() => { _ = compiler.Compile($"I 1 \\f{font}", "TEST"); });
+    }
+
+
+    public static TheoryData<string, string> ValidInfocardFrcStrings { get; } = new()
+    {
+        { @"I 1 \b", "<TRA bold=\"true\"/>" },
+        { @"I 1 \B", "<TRA bold=\"false\"/>" },
+        { @"I 1 \f12", "<TRA font=\"12\"/>" },
+        { @"I 1 \F", "<TRA font=\"default\"/>" },
+        { @"I 1 \i", "<TRA italic=\"true\"/>" },
+        { @"I 1 \I", "<TRA italic=\"false\"/>" },
+        { @"I 1 \u", "<TRA underline=\"true\"/>" },
+        { @"I 1 \U", "<TRA underline=\"false\"/>" },
+        { @"I 1 \n", "<PARA/>" },
+        { @"I 1 \r", "<JUST loc=\"r\"/>" },
+        { @"I 1 \m", "<JUST loc=\"c\"/>" },
+        { @"I 1 \l", "<JUST loc=\"l\"/>" },
+        { @"I 1 \h150", "<POS h=\"150\" relH=\"true\"/>" },
+        { @"I 1 \C", "<TRA color=\"default\"/>" },
+        { @"I 1 \cWhite", "<TRA color=\"white\"/>" },
+        { @"I 1 \cFFFFFF", "<TRA color=\"#FFFFFF\"/>" },
+    };
+
+
+
+    private string WrapInfocard(string infocard) => $"{FrcCompiler.InfocardStart}{infocard}{FrcCompiler.InfocardEnd}";
+}

--- a/src/LibreLancer.Tests/Compilers/FrcTests.cs
+++ b/src/LibreLancer.Tests/Compilers/FrcTests.cs
@@ -65,13 +65,12 @@ public class FrcTests
     [InlineData("ReD")]
     [InlineData("Black")]
     [InlineData("DarkBlue")]
-    [InlineData("ABCABCA")] // Bad Hex
     public void BadColoursShouldThrowExceptions(string colour)
     {
         FrcCompiler compiler = new FrcCompiler();
         Assert.Throws<CompileErrorException>(() =>
         {
-            _ = compiler.Compile($"I 1 \\c{colour}", "TEST");
+            _ = compiler.Compile($"I 1 \\c{colour} ", "TEST");
         });
     }
 
@@ -139,8 +138,6 @@ public class FrcTests
         { @"I 1 \cWhite", "<TRA color=\"white\"/>" },
         { @"I 1 \cFFFFFF", "<TRA color=\"#FFFFFF\"/>" },
     };
-
-
 
     private string WrapInfocard(string infocard) => $"{FrcCompiler.InfocardStart}{infocard}{FrcCompiler.InfocardEnd}";
 }

--- a/src/LibreLancer.Tests/Compilers/FrcTests.cs
+++ b/src/LibreLancer.Tests/Compilers/FrcTests.cs
@@ -39,14 +39,14 @@ public class FrcTests
 
         Assert.NotNull(resourceDll);
 
-        Assert.Equal(expected: WrapInfocard("<TRA bold=\"true\"/>Bold <TRA bold=\"false\"/>Not Bold"),
+        Assert.Equal(expected: WrapInfocard("<TRA bold=\"true\"/><TEXT>Bold </TEXT><TRA bold=\"false\"/><TEXT>Not Bold</TEXT>"),
             actual: resourceDll.Infocards[1]);
-        Assert.Equal(expected: WrapInfocard("MultiLine<PARA/>String"), actual: resourceDll.Infocards[2]);
-        Assert.Equal(expected: WrapInfocard("Two<PARA/>Lines"), actual: resourceDll.Infocards[3]);
-        Assert.Equal(expected: WrapInfocard("One Line"), actual: resourceDll.Infocards[4]);
-        Assert.Equal(expected: WrapInfocard(" Spacing "), actual: resourceDll.Infocards[5]);
-        Assert.Equal(expected: WrapInfocard("Separate Line"), actual: resourceDll.Infocards[6]);
-        Assert.Equal(expected: WrapInfocard("“Read My Quote”"), actual: resourceDll.Infocards[7]);
+        Assert.Equal(expected: WrapInfocard("<TEXT>MultiLine</TEXT><PARA/><TEXT>String</TEXT>"), actual: resourceDll.Infocards[2]);
+        Assert.Equal(expected: WrapInfocard("<TEXT>Two</TEXT><PARA/><TEXT>Lines</TEXT>"), actual: resourceDll.Infocards[3]);
+        Assert.Equal(expected: WrapInfocard("<TEXT>One Line</TEXT>"), actual: resourceDll.Infocards[4]);
+        Assert.Equal(expected: WrapInfocard("<TEXT> Spacing </TEXT>"), actual: resourceDll.Infocards[5]);
+        Assert.Equal(expected: WrapInfocard("<TEXT>Separate Line</TEXT>"), actual: resourceDll.Infocards[6]);
+        Assert.Equal(expected: WrapInfocard("<TEXT>“Read My Quote”</TEXT>"), actual: resourceDll.Infocards[7]);
     }
 
     [Theory]
@@ -61,7 +61,6 @@ public class FrcTests
     }
 
     [Theory]
-    [InlineData("white")]
     [InlineData("ReD")]
     [InlineData("Black")]
     [InlineData("DarkBlue")]
@@ -139,6 +138,16 @@ public class FrcTests
         Assert.Contains(resourceDll.Strings, x => x.Value == "Some Text");
     }
 
+    [Fact]
+    public void BlockCommentsShouldBeIgnored()
+    {
+        FrcCompiler compiler = new FrcCompiler();
+        const string input = @";+ S 1 Some Text ; Comment\nsomsada\n\nasdasd ;-";
+        var resourceDll = compiler.Compile(input, "TEST");
+
+        Assert.Empty(resourceDll.Strings);
+    }
+
     public static TheoryData<string, string> ValidInfocardFrcStrings { get; } = new()
     {
         { @"I 1 \b", "<TRA bold=\"true\"/>" },
@@ -157,6 +166,12 @@ public class FrcTests
         { @"I 1 \C", "<TRA color=\"default\"/>" },
         { @"I 1 \cWhite", "<TRA color=\"white\"/>" },
         { @"I 1 \cFFFFFF", "<TRA color=\"#FFFFFF\"/>" },
+        { @"I 1 \cr", "<TRA color=\"#FF0000\"/>" },
+        { @"I 1 \clr", "<TRA color=\"#C00000\"/>" },
+        { @"I 1 \chg", "<TRA color=\"#008000\"/>" },
+        { @"I 1 \cdw", "<TRA color=\"#404040\"/>" },
+        { """I 1 \<TRA bold="true"/>""", "<TRA bold=\"true\"/>" },
+        { @"I 1 <>&", "<TEXT>&lt;&gt;&amp;</TEXT>" },
     };
 
     private string WrapInfocard(string infocard) => $"{FrcCompiler.InfocardStart}{infocard}{FrcCompiler.InfocardEnd}";

--- a/src/LibreLancer.Tests/Compilers/FrcTests.cs
+++ b/src/LibreLancer.Tests/Compilers/FrcTests.cs
@@ -119,6 +119,26 @@ public class FrcTests
         Assert.Throws<CompileErrorException>(() => { _ = compiler.Compile($"I 131071 EEE", "TEST", 0); });
     }
 
+    [Fact]
+    public void LeadingCommentsShouldBeIgnored()
+    {
+        FrcCompiler compiler = new FrcCompiler();
+        const string input = @"; S 1 Some Text\nS 2 Some Text";
+        var resourceDll = compiler.Compile(input, "TEST");
+
+        Assert.DoesNotContain(resourceDll.Strings, x => x.Key == 1);
+    }
+
+    [Fact]
+    public void TrailingCommentsShouldBeIgnored()
+    {
+        FrcCompiler compiler = new FrcCompiler();
+        const string input = @"S 1 Some Text ; Comment";
+        var resourceDll = compiler.Compile(input, "TEST");
+
+        Assert.Contains(resourceDll.Strings, x => x.Value == "Some Text");
+    }
+
     public static TheoryData<string, string> ValidInfocardFrcStrings { get; } = new()
     {
         { @"I 1 \b", "<TRA bold=\"true\"/>" },

--- a/src/LibreLancer.Tests/LibreLancer.Tests.csproj
+++ b/src/LibreLancer.Tests/LibreLancer.Tests.csproj
@@ -32,6 +32,14 @@
     </ItemGroup>
     <ItemGroup>
       <Content Include="Models\**\*.*" CopyToOutputDirectory="PreserveNewest" />
+      <None Remove="Compilers\FrcFiles\ValidFrcStrings.frc" />
+      <Content Include="Compilers\FrcFiles\ValidFrcStrings.frc">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </Content>
+      <None Remove="Compilers\FrcFiles\ValidFrcInfocards.frc" />
+      <Content Include="Compilers\FrcFiles\ValidFrcInfocards.frc">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </Content>
     </ItemGroup>
     <ItemGroup>
       <Content Include="Thorn\Scripts\**\*.*" CopyToOutputDirectory="PreserveNewest" />


### PR DESCRIPTION
Adds support to LancerEdit to compile files that would normally be consumed by Freelancer Resource Compiler. 

ToDo:
- [x] Convert FRC file into a ResourceDll with the FrcCompiler class
- [x] Ensure that all the infocards have the correct numbers (resourceIndex)
- [x] Create a cs-script that can invoke the compiler