### PR TITLE
Net: Send statistics packet update when destroying ships

### DIFF
--- a/src/LibreLancer.Data/Ships/Ship.cs
+++ b/src/LibreLancer.Data/Ships/Ship.cs
@@ -11,6 +11,17 @@ using LibreLancer.Data.Solar;
 
 namespace LibreLancer.Data.Ships
 {
+    public enum ShipType
+    {
+        Fighter,
+        Freighter,
+        Gunboat,
+        Cruiser,
+        Transport,
+        Capital,
+        Mining,
+    }
+
     [ParsedSection]
 	public partial class Ship
 	{
@@ -51,7 +62,7 @@ namespace LibreLancer.Data.Ships
         [Entry("ship_class")]
 		public int ShipClass;
         [Entry("type")]
-		public string Type;
+		public ShipType Type;
         [Entry("steering_torque")]
 		public Vector3 SteeringTorque;
         [Entry("angular_drag")]

--- a/src/LibreLancer/GameData/Ship.cs
+++ b/src/LibreLancer/GameData/Ship.cs
@@ -6,12 +6,13 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using LibreLancer.Data.Equipment;
+using LibreLancer.Data.Ships;
 
 namespace LibreLancer.GameData
 {
 	public class Ship : IdentifiableItem
 	{
-        public string ShipType;
+        public ShipType ShipType;
         public int Class;
         public int HoldSize;
         public float[] LODRanges;

--- a/src/LibreLancer/Server/Components/SHealthComponent.cs
+++ b/src/LibreLancer/Server/Components/SHealthComponent.cs
@@ -3,7 +3,9 @@
 // LICENSE, which is part of this source code package
 
 using System;
+using LibreLancer.Data.Ships;
 using LibreLancer.GameData.Items;
+using LibreLancer.Net.Protocol;
 using LibreLancer.World;
 using LibreLancer.World.Components;
 
@@ -66,7 +68,7 @@ namespace LibreLancer.Server.Components
                 shield.Health = shield.Equip.Def.MaxCapacity;
         }
 
-        public void Damage(float hullDamage, float energyDamage)
+        public void Damage(float hullDamage, float energyDamage, GameObject attacker)
         {
             if (energyDamage <= 0) energyDamage = hullDamage / 2.0f;
 
@@ -76,8 +78,11 @@ namespace LibreLancer.Server.Components
             {
                 if (InfiniteHealth) return;
                 CurrentHealth -= hullDamage;
-                if (Parent.TryGetComponent<SNPCComponent>(out var n))
-                    n.TakingDamage(hullDamage);
+                if (Parent.TryGetComponent<SNPCComponent>(out var npc))
+                {
+                    npc.TakingDamage(hullDamage);
+                }
+
                 if (Invulnerable && CurrentHealth < (MaxHealth * 0.09f)) {
                     CurrentHealth = MaxHealth * 0.09f;
                 }
@@ -89,6 +94,32 @@ namespace LibreLancer.Server.Components
                     if (!isKilled)
                     {
                         isKilled = true;
+
+                        // If the attacker is a player, and the thing being destroyed is an NPC, increment stats
+                        if (attacker is not null && npc is not null && attacker.TryGetComponent<SPlayerComponent>(out var attackingPlayer))
+                        {
+                            var ship = Parent.GetComponent<ShipPhysicsComponent>().Ship;
+
+                            NetPlayerStatistics statistics = attackingPlayer.Player.Character.Statistics;
+                            switch (ship.ShipType)
+                            {
+                                case ShipType.Fighter:
+                                    statistics.FightersKilled++;
+                                    break;
+                                case ShipType.Freighter:
+                                    statistics.FreightersKilled++;
+                                    break;
+                                case ShipType.Capital:
+                                    statistics.BattleshipsKilled++;
+                                    break;
+                                case ShipType.Transport:
+                                    statistics.TransportsKilled++;
+                                    break;
+                            }
+
+                            attackingPlayer.Player.UpdateStatistics(statistics);
+                        }
+
                         fuseRunner?.RunAtHealth(0);
                         if(fuseRunner == null || !fuseRunner.RunningDeathFuse)
                         {

--- a/src/LibreLancer/Server/Components/SPlayerComponent.cs
+++ b/src/LibreLancer/Server/Components/SPlayerComponent.cs
@@ -10,6 +10,7 @@ using LibreLancer.Net;
 using LibreLancer.Net.Protocol;
 using LibreLancer.World;
 using LibreLancer.World.Components;
+using LiteNetLib;
 
 namespace LibreLancer.Server.Components
 {

--- a/src/LibreLancer/Server/ConsoleCommands/DamageSelfCommand.cs
+++ b/src/LibreLancer/Server/ConsoleCommands/DamageSelfCommand.cs
@@ -17,7 +17,7 @@ public class DamageSelfCommand : IConsoleCommand
         player.Space?.World?.EnqueueAction(() =>
         {
             var component = player.Space.World.Players[player].GetComponent<SHealthComponent>();
-            component.Damage(x, x);
+            component.Damage(x, x, null);
         });
     }
 }

--- a/src/LibreLancer/Server/NetCharacter.cs
+++ b/src/LibreLancer/Server/NetCharacter.cs
@@ -25,6 +25,7 @@ namespace LibreLancer.Server
         public Vector3 Position { get; private set; }
         public Quaternion Orientation { get; private set; } = Quaternion.Identity;
         public long Credits { get; private set; }
+        public NetPlayerStatistics Statistics { get; internal set; }
 
         public uint Rank { get; private set; }
 

--- a/src/LibreLancer/Server/Player.cs
+++ b/src/LibreLancer/Server/Player.cs
@@ -92,6 +92,12 @@ namespace LibreLancer.Server
             }
         }
 
+        public void UpdateStatistics(NetPlayerStatistics statistics)
+        {
+            Character.Statistics = statistics;
+            RpcClient.UpdateStatistics(statistics);
+        }
+
         public bool InTradelane;
         public void StartTradelane()
         {

--- a/src/LibreLancer/Server/ServerWorld.cs
+++ b/src/LibreLancer/Server/ServerWorld.cs
@@ -106,7 +106,7 @@ namespace LibreLancer.Server
                     if (other.Tag is GameObject g &&
                         g.TryGetComponent<SHealthComponent>(out var health))
                     {
-                        health.Damage(missile.Missile.Explosion.HullDamage, missile.Missile.Explosion.EnergyDamage);
+                        health.Damage(missile.Missile.Explosion.HullDamage, missile.Missile.Explosion.EnergyDamage, missile.Owner);
                         health.OnProjectileHit(missile.Owner);
                     }
                 }
@@ -271,7 +271,7 @@ namespace LibreLancer.Server
         {
             if (obj.TryGetComponent<SHealthComponent>(out var health))
             {
-                health.Damage(munition.Def.HullDamage, munition.Def.EnergyDamage);
+                health.Damage(munition.Def.HullDamage, munition.Def.EnergyDamage, owner);
                 health.OnProjectileHit(owner);
             }
         }


### PR DESCRIPTION
Implements the updating of user statistics when ships are destroyed, does not persist data in the save yet.