### PR TITLE
Enhance PatrolEditor with Y-axis offset adjustment and path label fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Folders
 obj/
 out/
+build/
 [Bb]in/
 [Dd]ebug/
 [Rr]elease/

--- a/src/Editor/LancerEdit/GameContent/Popups/PatrolRouteDialog.cs
+++ b/src/Editor/LancerEdit/GameContent/Popups/PatrolRouteDialog.cs
@@ -45,7 +45,7 @@ public class PatrolRouteDialog : PopupWindow
         this.system = system;
         
         // Generate default path label using the current system's nickname
-        pathLabel = $"patrol";
+        pathLabel = $"{system.Nickname.ToLowerInvariant()}_patrol";
         
         // Initialize faction lookup with first available faction
         var defaultFaction = gameData.GameData.Factions.FirstOrDefault();
@@ -78,11 +78,17 @@ public class PatrolRouteDialog : PopupWindow
             // Path Label
             ImGui.TableNextRow();
             ImGui.TableNextColumn();
-            ImGui.TextUnformatted("Path Label");
+            ImGui.TextUnformatted("Base Path Name");
             ImGui.TableNextColumn();
             ImGui.PushItemWidth(-1);
             ImGui.InputText("##pathLabel", ref pathLabel, 128);
             ImGui.PopItemWidth();
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.BeginTooltip();
+                ImGui.TextUnformatted("This is the base name for the patrol route. It must be unique within the entire universe or Freelancer could confuse it with others.");
+                ImGui.EndTooltip();
+            }
 
             // Zone Properties
             ImGui.TableNextRow();


### PR DESCRIPTION
2D patrol depth controls

    Add scroll wheel support for adjusting Y-axis (height) in patrol route editor

Fixes

    Fixed unique naming system for patrol routes with proper PathLabel format
    Add helpful tooltips explaining to avoid naming paths the same between the universe as two paths with the same name confuses FL.
    Fix null reference exception in EncounterLookup with proper error handling"

