### PR TITLE
Audio checks

### DIFF
--- a/src/LibreLancer.Media/AudioManager.cs
+++ b/src/LibreLancer.Media/AudioManager.cs
@@ -181,17 +181,17 @@ namespace LibreLancer.Media
         {
             Al.alSourcei(src, Al.AL_SOURCE_RELATIVE, prop.Is3D ? 0 : 1);
             SetAttenuation(src, prop.Attenuation, category);
-            Al.alSourcef(src, Al.AL_PITCH, prop.Pitch);
+            Al.alSourcef(src, Al.AL_PITCH, Math.Max(0.001f, prop.Pitch)); // Clamp pitch > 0
             if (prop.Is3D)
             {
                 Al.alSource3f(src, Al.AL_POSITION, prop.Position.X, prop.Position.Y, prop.Position.Z);
                 Al.alSource3f(src, Al.AL_VELOCITY, prop.Velocity.X, prop.Velocity.Y, prop.Velocity.Z);
                 Al.alSource3f(src, Al.AL_DIRECTION, prop.Direction.X, prop.Direction.Y, prop.Direction.Z);
-                Al.alSourcef(src, Al.AL_REFERENCE_DISTANCE, prop.ReferenceDistance);
-                Al.alSourcef(src, Al.AL_MAX_DISTANCE, prop.MaxDistance);
-                Al.alSourcef(src, Al.AL_CONE_INNER_ANGLE, prop.ConeInnerAngle);
-                Al.alSourcef(src, Al.AL_CONE_OUTER_ANGLE, prop.ConeOuterAngle);
-                Al.alSourcef(src, Al.AL_CONE_OUTER_GAIN, prop.ConeOuterGain);
+                Al.alSourcef(src, Al.AL_REFERENCE_DISTANCE, Math.Max(0.001f, prop.ReferenceDistance));
+                Al.alSourcef(src, Al.AL_MAX_DISTANCE, Math.Max(0.001f, prop.MaxDistance));
+                Al.alSourcef(src, Al.AL_CONE_INNER_ANGLE, Math.Clamp(prop.ConeInnerAngle, 0, 360));
+                Al.alSourcef(src, Al.AL_CONE_OUTER_ANGLE, Math.Clamp(prop.ConeOuterAngle, 0, 360));
+                Al.alSourcef(src, Al.AL_CONE_OUTER_GAIN, Math.Clamp(prop.ConeOuterGain, 0, 1));
             }
             else
             {
@@ -509,9 +509,9 @@ namespace LibreLancer.Media
                             if (message.Instance.Source != -1)
                             {
                                 Al.alSourcef((uint)message.Instance.Source,
-                                    Al.AL_PITCH, message.Data.X);
+                                    Al.AL_PITCH, Math.Max(0.001f, message.Data.X));
                             }
-                            message.Instance.SetProperties.Pitch = message.Data.X;
+                            message.Instance.SetProperties.Pitch = Math.Max(0.001f, message.Data.X);
                             break;
                         case AudioEvent.SetAttenuation:
                             if (message.Instance.Source != -1)
@@ -524,26 +524,26 @@ namespace LibreLancer.Media
                             if (message.Instance.Source != -1)
                             {
                                 Al.alSourcef((uint)message.Instance.Source,
-                                    Al.AL_CONE_INNER_ANGLE, message.Data.X);
+                                    Al.AL_CONE_INNER_ANGLE, Math.Clamp(message.Data.X, 0, 360));
                                 Al.alSourcef((uint)message.Instance.Source,
-                                    Al.AL_CONE_OUTER_ANGLE, message.Data.Y);
+                                    Al.AL_CONE_OUTER_ANGLE, Math.Clamp(message.Data.Y, 0, 360));
                                 Al.alSourcef((uint)message.Instance.Source,
-                                    Al.AL_CONE_OUTER_GAIN, message.Data.Z);
+                                    Al.AL_CONE_OUTER_GAIN, Math.Clamp(message.Data.Z, 0, 1));
                             }
-                            message.Instance.SetProperties.ConeInnerAngle = message.Data.X;
-                            message.Instance.SetProperties.ConeOuterAngle = message.Data.Y;
-                            message.Instance.SetProperties.ConeOuterGain = message.Data.Z;
+                            message.Instance.SetProperties.ConeInnerAngle = Math.Clamp(message.Data.X, 0, 360);
+                            message.Instance.SetProperties.ConeOuterAngle = Math.Clamp(message.Data.Y, 0, 360);
+                            message.Instance.SetProperties.ConeOuterGain = Math.Clamp(message.Data.Z, 0, 1);
                             break;
                         case AudioEvent.SetDistance:
                             if (message.Instance.Source != -1)
                             {
                                 Al.alSourcef((uint)message.Instance.Source,
-                                    Al.AL_REFERENCE_DISTANCE, message.Data.X);
+                                    Al.AL_REFERENCE_DISTANCE, Math.Max(0.001f, message.Data.X));
                                 Al.alSourcef((uint)message.Instance.Source,
-                                    Al.AL_MAX_DISTANCE, message.Data.Y);
+                                    Al.AL_MAX_DISTANCE, Math.Max(0.001f, message.Data.Y));
                             }
-                            message.Instance.SetProperties.ReferenceDistance = message.Data.X;
-                            message.Instance.SetProperties.MaxDistance = message.Data.Y;
+                            message.Instance.SetProperties.ReferenceDistance = Math.Max(0.001f, message.Data.X);
+                            message.Instance.SetProperties.MaxDistance = Math.Max(0.001f, message.Data.Y);
                             break;
                         case AudioEvent.SetListenerPosition:
                             Al.alListener3f(Al.AL_POSITION, message.Data.X,  message.Data.Y,  message.Data.Z);

--- a/src/LibreLancer/GameDataManager.cs
+++ b/src/LibreLancer/GameDataManager.cs
@@ -665,11 +665,21 @@ namespace LibreLancer
         public IEnumerable<Data.Audio.AudioEntry> AllSounds => fldata.Audio.Entries;
         public Data.Audio.AudioEntry GetAudioEntry(string id)
         {
-            return fldata.Audio.Entries.Where((arg) => arg.Nickname.ToLowerInvariant() == id.ToLowerInvariant()).First();
+            var audio = fldata.Audio.Entries.FirstOrDefault((arg) => arg.Nickname.ToLowerInvariant() == id.ToLowerInvariant());
+            if (audio == null)
+            {
+                FLLog.Warning("Audio", $"Audio entry '{id}' not found");
+            }
+            return audio;
         }
         public Stream GetAudioStream(string id)
         {
-            var audio = fldata.Audio.Entries.Where((arg) => arg.Nickname.ToLowerInvariant() == id.ToLowerInvariant()).First();
+            var audio = fldata.Audio.Entries.FirstOrDefault((arg) => arg.Nickname.ToLowerInvariant() == id.ToLowerInvariant());
+            if (audio == null)
+            {
+                FLLog.Warning("Audio", $"Audio entry '{id}' not found");
+                return null;
+            }
             if (VFS.FileExists(DataPath(audio.File)))
                 return VFS.Open(DataPath(audio.File));
             return null;

--- a/src/LibreLancer/Sounds/SoundManager.cs
+++ b/src/LibreLancer/Sounds/SoundManager.cs
@@ -116,6 +116,11 @@ namespace LibreLancer.Sounds
             var loaded = new LoadedSound();
             loaded.Entry = data.GetAudioEntry(name);
             loaded.Name = name;
+            if (loaded.Entry == null)
+            {
+                loaded.Data = null;
+                return loaded;
+            }
             if (loaded.Entry.File.ToLowerInvariant().Replace('\\', '/') == "audio/null.wav")
             {
                 //HACK: Don't bother with sounds using null.wav, makes awful popping noise
@@ -124,12 +129,19 @@ namespace LibreLancer.Sounds
             else
             {
                 var path = data.GetAudioStream(name);
-                var snd = new SoundData();
-                loaded.LoadTask = Task.Run(() =>
+                if (path == null)
                 {
-                    snd.LoadStream(path);
-                    loaded.Data = snd;
-                });
+                    loaded.Data = null;
+                }
+                else
+                {
+                    var snd = new SoundData();
+                    loaded.LoadTask = Task.Run(() =>
+                    {
+                        snd.LoadStream(path);
+                        loaded.Data = snd;
+                    });
+                }
             }
             return loaded;
         }
@@ -137,6 +149,7 @@ namespace LibreLancer.Sounds
         SoundCategory EntryType(string name)
         {
             var e = GetEntry(name);
+            if (e == null) return SoundCategory.Sfx;
             if (e.Type == AudioType.Voice)
                 return SoundCategory.Voice;
             return SoundCategory.Sfx;


### PR DESCRIPTION
- Added audio checks for when audios doesn't exists, it will warn about them and not try to play them

- Added clamps at AudioManager.cs to restrict audio-related values within safe, valid ranges. This prevents the audio library from receiving invalid inputs that could cause errors, crashes, or audio artifacts.

--GameDataManager.cs line 668
--SoundManager.cs line 118
--AudioManager.cs lines 184 and 512