### PR TITLE
BoneInstance: fix facial animations

### DIFF
--- a/src/LibreLancer/Render/BoneInstance.cs
+++ b/src/LibreLancer/Render/BoneInstance.cs
@@ -36,8 +36,8 @@ namespace LibreLancer.Render
 
         public void Update(Transform3D parentMatrix)
         {
-            LocalTransform = new Transform3D(Vector3.Zero, Rotation) *
-                             new Transform3D( Translation + Origin, OriginalRotation) * parentMatrix;
+            var r = Quaternion.Concatenate(OriginalRotation, Rotation);
+            LocalTransform = new Transform3D(Origin + Translation, r) * parentMatrix;
             BoneMatrix = (InvBindPose * LocalTransform).Matrix();
             foreach (var b in Children)
                 b.Update(LocalTransform);


### PR DESCRIPTION
I've been trying to track this down for **3+ years** in my own Freelancer re-implementation and finally cracked the ordering of the transforms today.

It took a lot of experimentation, but this was the order that unlocked much smoother animation:
1. Animation frame rotation (needs to be in local space)
2. Joint rotation (if you swap this with animation frame rotation, you'll get distorted animations again)
3. Translation (this can be both animation + joint translation, no concerns with ordering)
4. Parent transformation (normal skinning propagation)

With this updated ordering, the various animations in a new game (Trent speaking to the bartender, Juni talking to the diplomat, Juni talking to Trent) no longer have facial distortion. I didn't notice any regressions in other animations when doing an A/B comparison between the two scripts.

Before:

https://github.com/user-attachments/assets/e2e85565-0d82-4ee6-bd85-422b5df91c93

After:

https://github.com/user-attachments/assets/64ef4963-f934-41d0-b4dc-fb61928cb241