### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/src/cimgui_ext/CMakeLists.txt
+++ b/src/cimgui_ext/CMakeLists.txt
@@ -29,6 +29,8 @@ add_library(cimgui SHARED
     imgui_freetype.cpp
 )
 
+target_compile_features(cimgui PRIVATE cxx_std_20)
+
 target_include_directories(cimgui PRIVATE "." "../../extern/imgui" "ImGuiColorTextEdit" "imgui-node-editor" "include")
 
 target_compile_definitions (cimgui PRIVATE -DBUILDING_CIMGUI)


### PR DESCRIPTION

Fixes a Windows build failure caused by `cimgui_ext` using C++20 designated initializers
while its CMakeLists.txt explicitly forced C++14.

### Problem

Running `build.ps1` on Windows fails with MSVC errors like:

error C7555: use of designated initializers requires at least '/std:c++20'

This comes from `src/cimgui_ext/controls/expr.h`, which uses C++20 designated
initializers, but `src/cimgui_ext/CMakeLists.txt` sets:

```cmake
set(CMAKE_CXX_STANDARD 14)
```

### Fix
This change keeps the existing C++14 default but explicitly declares a C++20
requirement for the `cimgui` target, which already uses C++20 features.