### PR TITLE
Tidied CMakeLists to resolve a compiler syntax warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,11 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${LIBOUTPUTDIR})
 
 MESSAGE(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
 MESSAGE(STATUS "Library Type: " ${LIB_TYPE})
-MESSAGE(STATUS "Compiler flags:" ${CMAKE_CXX_COMPILE_FLAGS})
-MESSAGE(STATUS "Compiler cxx release (debug info )flags:" ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
-MESSAGE(STATUS "Compiler cxx min size flags:" ${CMAKE_CXX_FLAGS_MINSIZEREL})
-MESSAGE(STATUS "Compiler cxx debug flags": ${CMAKE_CXX_FLAGS_DEBUG})
-MESSAGE(STATUS "Compiler cxx flags:" ${CMAKE_CXX_FLAGS})
+MESSAGE(STATUS "Compiler flags: " ${CMAKE_CXX_COMPILE_FLAGS})
+MESSAGE(STATUS "Compiler cxx release (debug info )flags: " ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
+MESSAGE(STATUS "Compiler cxx min size flags: " ${CMAKE_CXX_FLAGS_MINSIZEREL})
+MESSAGE(STATUS "Compiler cxx debug flags: " ${CMAKE_CXX_FLAGS_DEBUG})
+MESSAGE(STATUS "Compiler cxx flags: " ${CMAKE_CXX_FLAGS})
 
 # get the correct naming across MSVC and mingw
 if (WIN32)


### PR DESCRIPTION
The below build warning stems from lines 8-14 in ./CMakeLists.txt

```CMake Warning (dev) at CMakeLists.txt:13:
  Syntax Warning in cmake code at column 42

  Argument not separated from preceding token by whitespace.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

I addressed this by tidying up the messages so that they were all consistently formatted, and the warning is gone:
```
MESSAGE(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
MESSAGE(STATUS "Library Type: " ${LIB_TYPE})
MESSAGE(STATUS "Compiler flags: " ${CMAKE_CXX_COMPILE_FLAGS})
MESSAGE(STATUS "Compiler cxx release (debug info )flags: " ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
MESSAGE(STATUS "Compiler cxx min size flags: " ${CMAKE_CXX_FLAGS_MINSIZEREL})
MESSAGE(STATUS "Compiler cxx debug flags: " ${CMAKE_CXX_FLAGS_DEBUG})
MESSAGE(STATUS "Compiler cxx flags: " ${CMAKE_CXX_FLAGS})
```
