### PR TITLE
No scroll whilee creating zones in 2dmap

### DIFF
--- a/src/Editor/LancerEdit/GameContent/EditMap2D.cs
+++ b/src/Editor/LancerEdit/GameContent/EditMap2D.cs
@@ -115,7 +115,7 @@ public class EditMap2D
             cameraCenter -= delta / mapSize;
         }
         // Zoom
-        else if (ImGui.IsWindowHovered() && ImGui.GetIO().MouseWheel != 0f)
+        else if (ImGui.IsWindowHovered() && ImGui.GetIO().MouseWheel != 0f && !CreationTools.IsAnyToolActive)
         {
             float wheel = ImGui.GetIO().MouseWheel;
             float oldZoom = Zoom;


### PR DESCRIPTION
Just a small fix, When you create an ellipsoid, one of the controls is the scroll wheel which modifies the "fatness" of the ellipsoid, this was interfering with the zoom controls of the view, making it zoom and making the placement very difficult.