### PR TITLE
Mission Editor: Allow reordering of actions and conditions

### DIFF
--- a/src/Editor/LancerEdit/GameContent/MissionEditor/NodeTypes/Actions/ActActivateNodeTrigger.cs
+++ b/src/Editor/LancerEdit/GameContent/MissionEditor/NodeTypes/Actions/ActActivateNodeTrigger.cs
@@ -10,7 +10,7 @@ namespace LancerEdit.GameContent.MissionEditor.NodeTypes.Actions;
 
 public sealed class ActActivateNodeTrigger : NodeTriggerEntry
 {
-    public override string Name => "Activate Trigger";
+    public override string Name => string.IsNullOrWhiteSpace(Data.Trigger) ? "Activate Trigger" : $"Activate {Data.Trigger}";
 
     public readonly Act_ActTrig Data;
     public ActActivateNodeTrigger(MissionAction action): base( NodeColours.Action)

--- a/src/Editor/LancerEdit/GameContent/MissionEditor/NodeTypes/NodeMissionTrigger.cs
+++ b/src/Editor/LancerEdit/GameContent/MissionEditor/NodeTypes/NodeMissionTrigger.cs
@@ -56,57 +56,36 @@ public class NodeMissionTrigger : Node
     {
         reorder = 0;
         var node = list[index];
-        ImGui.BeginGroup();
         ImGui.PushStyleColor(ImGuiCol.Header, node.Color);
         ImGui.PushStyleColor(ImGuiCol.Button, node.Color);
         ImGui.PushStyleVar(ImGuiStyleVar.FrameRounding, 0);
+        ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(0,0));
 
-        var buttonSize = new Vector2(28, 21);
-
-        if (list.Count > 1)
+        ImGui.BeginDisabled(list.Count <= 1 || index == 0);
+        if (ImGui.Button(ImGuiExt.IDWithExtra($"{Icons.ArrowUp}", node.Id)))
         {
-            if (index != list.Count - 1)
-            {
-                if (ImGui.Button(ImGuiExt.IDWithExtra($"{Icons.ArrowDown}", node.Id)))
-                {
-                    reorder = 1;
-                }
-            }
-            else
-            {
-                ImGui.Dummy(buttonSize);
-            }
-
-            ImGui.SameLine();
-            if (index != 0)
-            {
-                if (ImGui.Button(ImGuiExt.IDWithExtra($"{Icons.ArrowUp}", node.Id)))
-                {
-                    reorder = -1;
-                }
-            }
-            else
-            {
-                ImGui.Dummy(buttonSize);
-            }
-
-            ImGui.SameLine();
-        }
-        else
-        {
-            ImGui.Dummy(buttonSize);
-            ImGui.SameLine();
-            ImGui.Dummy(buttonSize);
-            ImGui.SameLine();
+            reorder = -1;
         }
 
-        remove = ImGui.Button(ImGuiExt.IDWithExtra($"{Icons.TrashAlt}", node.Id));
+        ImGui.EndDisabled();
         ImGui.SameLine();
-        var render = ImGui.CollapsingHeader(ImGuiExt.IDWithExtra(node.Name, (long)node.Id));
+        ImGui.BeginDisabled(list.Count <= 1 || index == list.Count - 1);
+        if (ImGui.Button(ImGuiExt.IDWithExtra($"{Icons.ArrowDown}", node.Id)))
+        {
+            reorder = 1;
+        }
+        ImGui.EndDisabled();
 
-        ImGui.PopStyleVar();
-        ImGui.PopStyleColor();
-        ImGui.PopStyleColor();
+        ImGui.SameLine();
+        remove = ImGui.Button(ImGuiExt.IDWithExtra($"{Icons.TrashAlt}", node.Id));
+
+        ImGui.SameLine();
+        var render = ImGui.CollapsingHeader($"{node.Name}##{node.Id}");
+
+        ImGui.PopStyleVar(2);
+        ImGui.PopStyleColor(2);
+
+        ImGui.BeginGroup();
         return render;
     }
 


### PR DESCRIPTION
Implements #337 

Required due to ordering of mission triggers having game implications (at least in vanilla game).

Current preview:
<img width="1611" height="688" alt="image" src="https://github.com/user-attachments/assets/a38aab82-031b-4517-99ce-d59e638203ad" />

I am not too thrilled with this design, so open to ideas to improve it.