### PR TITLE
StorageBuffer v2

### DIFF
--- a/src/BindingsGen/GLBindingsGen/GLBindingsGen/bindings.json
+++ b/src/BindingsGen/GLBindingsGen/GLBindingsGen/bindings.json
@@ -1,440 +1,448 @@
 [
-  {
-    "function": "void glEnable(int flags)",
-    "name": "Enable"
-  },
-  {
-    "function": "void glDisable(int flags)",
-    "name": "Disable"
-  },
-  {
-    "function": "void glGetIntegerv(int val, out int param)",
-    "name": "GetIntegerv"
-  },
-  {
-    "function": "string glGetStringi(int name, int index)",
-    "name": "GetStringi"
-  },
-  {
-    "function": "string glGetString(int name)",
-    "name": "GetString"
-  },
-  {
-    "function": "void glClearColor(float r, float g, float b, float a)",
-    "name": "ClearColor"
-  },
-  {
-    "function": "void glClear(int flags)",
-    "name": "Clear"
-  },
-  {
-    "function": "void glViewport(int x, int y, int width, int height)",
-    "name": "Viewport"
-  },
-  {
-    "function": "void glScissor(int x, int y, int width, int height)",
-    "name": "Scissor"
-  },
-  {
-    "function": "void glBlendFunc(int sfactor, int dfactor)",
-    "name": "BlendFunc"
-  },
-  {
-    "function": "void glBlendFuncSeparate(int srcRGB, int dstRGB, int srcAlpha, int dstAlpha)",
-    "name": "BlendFuncSeparate"
-  },
-  {
-    "function": "void glDepthRangef(float near, float far)",
-    "name": "DepthRange"
-  },
-  {
-    "function": "void glPolygonMode(int faces, int mode)",
-    "name": "PolygonMode"
-  },
-  {
-    "function": "void glLineWidth(float width)",
-    "name": "LineWidth"
-  },
-  {
-    "function": "void glDepthFunc(int func)",
-    "name": "DepthFunc"
-  },
-  {
-    "function": "void glCullFace(int face)",
-    "name": "CullFace"
-  },
-  {
-    "function": "void glPixelStorei(int pname, int param)",
-    "name": "PixelStorei"
-  },
-  {
-    "function": "void glDepthMask(bool flag)",
-    "name": "DepthMask"
-  },
-  {
-    "function": "void glColorMask(bool r, bool g, bool b, bool a)",
-    "name": "ColorMask"
-  },
-  {
-    "function": "void glAlphaFunc(int func, float _ref)",
-    "name": "AlphaFunc"
-  },
-  {
-    "function": "void glPolygonOffset(float factor, float units)",
-    "name": "PolygonOffset"
-  },
-  {
-    "function": "void glGenTextures(int n, out uint textures)",
-    "name": "GenTextures"
-  },
-  {
-    "function": "void glDeleteTextures(int n, ref uint textures)",
-    "name": "DeleteTextures"
-  },
-  {
-    "function": "void glTexParameteri(int target, int pname, int param)",
-    "name": "TexParameteri"
-  },
-  {
-    "function": "void glTexParameterf(int target, int pname, float param)",
-    "name": "TexParameterf"
-  },
-  {
-    "function": "void glTexParameterfv(int target, int pname, ref Vector4 param)",
-    "name": "TexParameterfv"
-  },
-  {
-    "function": "void glBindTexture(int target, uint id)",
-    "name": "BindTexture"
-  },
-  {
-    "function": "void glActiveTexture(int unit)",
-    "name": "ActiveTexture"
-  },
-  {
-    "function": "void glTexImage2D(int target, int level, int internalFormat, int width, int height, int border, int format, int type, IntPtr data)",
-    "name": "TexImage2D"
-  },
-  {
-    "function": "void glTexStorage2DMultisample(int target, int samples, int internalFormat, int width, int height, bool fixedsamplelocations)",
-    "name": "TexStorage2DMultisample"
-  },
-  {
-    "function": "void glTexImage2DMultisample(int target, int samples, int internalFormat, int width, int height, bool fixedsamplelocations)",
-    "name": "TexImage2DMultisample"
-  },
-  {
-    "function": "void glCompressedTexImage2D(int target, int level, int internalFormat, int width, int height, int border, int imageSize, IntPtr data)",
-    "name": "CompressedTexImage2D"
-  },
-  {
-    "function": "void glTexSubImage2D(int target, int level, int xoffset, int yoffset, int width, int height, int format, int type, IntPtr data)",
-    "name": "TexSubImage2D"
-  },
-  {
-    "function": "void glGetTexImage(int target, int level, int format, int type, IntPtr pixels)",
-    "name": "GetTexImage"
-  },
-  {
-    "function": "void glDispatchCompute(uint num_groups_x, uint num_groups_y, uint num_groups_z)",
-    "name": "DispatchCompute"
-  },
-  {
-    "function": "uint glCreateShader(int shaderType)",
-    "name": "CreateShader"
-  },
-  {
-    "function": "void glShaderSource(uint shader, int count, ref IntPtr str, IntPtr length)",
-    "name": "ShaderSource",
-    "manual": true
-  },
-  {
-    "function": "void glCompileShader(uint shader)",
-    "name": "CompileShader"
-  },
-  {
-    "function": "void glGetShaderInfoLog(uint shader, int maxLength, out int length, IntPtr infoLog)",
-    "name": "GetShaderInfoLog",
-    "manual": true
-  },
-  {
-    "function": "void glGetProgramInfoLog(uint shader, int maxLength, out int length, IntPtr infoLog)",
-    "name": "GetProgramInfoLog",
-    "manual": true
-  },
-  {
-    "function": "uint glCreateProgram()",
-    "name": "CreateProgram"
-  },
-  {
-    "function": "void glAttachShader(uint program, uint shader)",
-    "name": "AttachShader"
-  },
-  {
-    "function": "void glDetachShader(uint program, uint shader)",
-    "name": "DetachShader"
-  },
-  {
-    "function": "void glDeleteShader(uint shader)",
-    "name": "DeleteShader"
-  },
-  {
-    "function": "void glBindAttribLocation(uint program, uint index, string name)",
-    "name": "BindAttribLocation"
-  },
-  {
-    "function": "void glBindFragDataLocation(uint program, uint colorNumber, string name)",
-    "name": "BindFragDataLocation"
-  },
-  {
-    "function": "void glLinkProgram(uint program)",
-    "name": "LinkProgram"
-  },
-  {
-    "function": "void glUseProgram(uint program)",
-    "name": "UseProgram"
-  },
-  {
-    "function": "void glGetShaderiv(uint shader, int pname, out int param)",
-    "name": "GetShaderiv"
-  },
-  {
-    "function": "void glGetProgramiv(uint program, int pname, out int param)",
-    "name": "GetProgramiv"
-  },
-  {
-    "function": "int glGetUniformLocation(uint program, string name)",
-    "name": "GetUniformLocation"
-  },
-  {
-    "function": "void glUniform1i(int location, int v0)",
-    "name": "Uniform1i"
-  },
-  {
-    "function": "void glUniform1f(int location, float v0)",
-    "name": "Uniform1f"
-  },
-  {
-    "function": "void glUniform2i(int location, int v1, int v2)",
-    "name": "Uniform2i"
-  },
-  {
-    "function": "void glUniform2f(int location, float v0, float v1)",
-    "name": "Uniform2f"
-  },
-  {
-    "function": "void glUniform3f(int location, float v0, float v1, float v2)",
-    "name": "Uniform3f"
-  },
-  {
-    "function": "void glUniform3fv(int location, int count, IntPtr values)",
-    "name": "Uniform3fv"
-  },
-  {
-    "function": "void glUniform4f(int location, float v0, float v1, float v2, float v3)",
-    "name": "Uniform4f"
-  },
-  {
-    "function": "void glUniform4fv(int location, int count, IntPtr values)",
-    "name": "Uniform4fv"
-  },
-  {
-    "function": "void glUniform4i(int location, int v0, int v1, int v2, int v3)",
-    "name": "Uniform4i"
-  },
-  {
-    "function": "void glUniform4iv(int location, int count, IntPtr values)",
-    "name": "Uniform4iv"
-  },
-  {
-    "function": "void glUniformMatrix4fv(int location, int count, bool transpose, IntPtr value)",
-    "name": "UniformMatrix4fv"
-  },
-  {
-    "function": "void glUniformBlockBinding(uint program, uint uniformBlockIndex, uint uniformBlockBinding)",
-    "name": "UniformBlockBinding"
-  },
-  {
-    "function": "int glGetUniformBlockIndex(uint program, string name)",
-    "name": "GetUniformBlockIndex"
-  },
-  {
-    "function": "void glGenBuffers(int n, out uint buffers)",
-    "name": "GenBuffers"
-  },
-  {
-    "function": "void glDeleteBuffers(int n, ref uint id)",
-    "name": "DeleteBuffers"
-  },
-  {
-    "function": "void glBindBuffer(int target, uint id)",
-    "name": "BindBuffer"
-  },
-  {
-    "function": "void glBindBufferRange(int target, uint index, uint buffer, IntPtr offset, IntPtr size)",
-    "name": "BindBufferRange"
-  },
-  {
-    "function": "void glBufferData(int target, IntPtr size, IntPtr data, int usage)",
-    "name": "BufferData"
-  },
-  {
-    "function": "void glBufferSubData(int target, IntPtr offset, IntPtr size, IntPtr data)",
-    "name": "BufferSubData"
-  },
-  {
-    "function": "void glCopyBufferSubData(int readtarget, int writetarget, IntPtr readoffset, IntPtr writeoffset, IntPtr size)",
-    "name": "CopyBufferSubData"
-  },
-  {
-    "function": "void glGenVertexArrays(int n, out uint arrays)",
-    "name": "GenVertexArrays"
-  },
-  {
-    "function": "void glDeleteVertexArrays(int n, ref uint id)",
-    "name": "DeleteVertexArrays"
-  },
-  {
-    "function": "void glBindVertexArray(uint array)",
-    "name": "BindVertexArray"
-  },
-  {
-    "function": "void glEnableVertexAttribArray(int index)",
-    "name": "EnableVertexAttribArray"
-  },
-  {
-    "function": "void glVertexAttribPointer(uint index, int size, int type, bool normalized, int stride, IntPtr data)",
-    "name": "VertexAttribPointer"
-  },
-  {
-    "function": "void glVertexAttribIPointer(uint index, int size, int type, int stride, IntPtr data)",
-    "name": "VertexAttribIPointer"
-  },
-  {
-    "function": "void glDrawBuffer(int buffer)",
-    "name": "DrawBuffer",
-    "manual": true
-  },
-  {
-    "function": "void glDrawBuffers(int count, ref int buffer)",
-    "name": "DrawBuffers",
-    "manual": true
-  },
-  {
-    "function": "IntPtr glMapBuffer(uint target, uint access)",
-    "name": "MapBuffer"
-  },
-  {
-    "function": "IntPtr glMapBufferRange(uint target, IntPtr offset, IntPtr length, uint access)",
-    "name": "MapBufferRange"
-  },
-  {
-    "function": "bool glUnmapBuffer(uint target)",
-    "name": "UnmapBuffer"
-  },
-  {
-    "function": "void glBindBufferBase(uint target, uint index, uint buffer)",
-    "name": "BindBufferBase"
-  },
-  {
-    "function": "void glMemoryBarrier(int barriers)",
-    "name": "MemoryBarrier"
-  },
-  {
-    "function": "void glDrawElements(int mode, int count, int type, IntPtr indices)",
-    "name": "DrawElements"
-  },
-  {
-    "function": "void glDrawArrays(int mode, int first, int count)",
-    "name": "DrawArrays"
-  },
-  {
-    "function": "void glDrawElementsBaseVertex(int mode, int count, int type, IntPtr indices, int basevertex)",
-    "name": "DrawElementsBaseVertex"
-  },
-  {
-    "function": "void glGenFramebuffers(int n, out uint framebuffers)",
-    "name": "GenFramebuffers"
-  },
-  {
-    "function": "int glCheckFramebufferStatus(int target)",
-    "name": "CheckFramebufferStatus"
-  },
-  {
-    "function": "void glBindFramebuffer(int target, uint framebuffer)",
-    "name": "BindFramebuffer"
-  },
-  {
-    "function": "void glBlitFramebuffer(int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, int mask, int filter)",
-    "name": "BlitFramebuffer"
-  },
-  {
-    "function": "void glGenRenderbuffers(int n, out uint renderbuffers)",
-    "name": "GenRenderbuffers"
-  },
-  {
-    "function": "void glBindRenderbuffer(int target, uint renderbuffer)",
-    "name": "BindRenderbuffer"
-  },
-  {
-    "function": "void glRenderbufferStorage(int target, int internalformat, int width, int height)",
-    "name": "RenderbufferStorage"
-  },
-  {
-    "function": "void glRenderbufferStorageMultisample(int target, int samples, int internalformat, int width, int height)",
-    "name": "RenderbufferStorageMultisample"
-  },
-  {
-    "function": "void glFramebufferRenderbuffer(int target, int attachment, int renderbuffertarget, uint renderbuffer)",
-    "name": "FramebufferRenderbuffer"
-  },
-  {
-    "function": "void glFramebufferTexture2D(int target, int attachment, int textarget, uint texture, int level)",
-    "name": "FramebufferTexture2D"
-  },
-  {
-    "function": "void glDeleteFramebuffers(int n, ref uint framebuffers)",
-    "name": "DeleteFramebuffers"
-  },
-  {
-    "function": "void glDeleteRenderbuffers(int n, ref uint renderbuffers)",
-    "name": "DeleteRenderbuffers"
-  },
-  {
-    "function": "void glReadBuffer(int buffer)",
-    "name": "ReadBuffer"
-  },
-  {
-    "function": "void glReadPixels(int x, int y, int width, int height, int format, int type, IntPtr data)",
-    "name": "ReadPixels"
-  },
-  {
-    "function": "int glGetError()",
-    "name": "GetError"
-  },
-  {
-    "function": "void glDebugMessageCallback(IntPtr callback, IntPtr userParam)",
-    "name": "DebugMessageCallback",
-    "manual": true
-  },
-  {
-    "function": "void glDebugMessageControl(int source, int type, int severity, int count, IntPtr ids, bool enabled)",
-    "name": "DebugMessageControl"
-  },
-  {
-    "function": "IntPtr glFenceSync(uint condition, uint flags)",
-    "name": "FenceSync"
-  },
-  {
-    "function": "void glDeleteSync(IntPtr sync)",
-    "name": "DeleteSync"
-  },
-  {
-    "function": "uint glClientWaitSync(IntPtr sync, uint flags, ulong timeout)",
-    "name": "ClientWaitSync"
-  },
-  {
-    "function": "void glFlush()",
-    "name": "Flush"
-  }
+    {
+        "function": "void glEnable(int flags)",
+        "name": "Enable"
+    },
+    {
+        "function": "void glDisable(int flags)",
+        "name": "Disable"
+    },
+    {
+        "function": "void glGetIntegerv(int val, out int param)",
+        "name": "GetIntegerv"
+    },
+    {
+        "function": "string glGetStringi(int name, int index)",
+        "name": "GetStringi"
+    },
+    {
+        "function": "string glGetString(int name)",
+        "name": "GetString"
+    },
+    {
+        "function": "void glClearColor(float r, float g, float b, float a)",
+        "name": "ClearColor"
+    },
+    {
+        "function": "void glClear(int flags)",
+        "name": "Clear"
+    },
+    {
+        "function": "void glViewport(int x, int y, int width, int height)",
+        "name": "Viewport"
+    },
+    {
+        "function": "void glScissor(int x, int y, int width, int height)",
+        "name": "Scissor"
+    },
+    {
+        "function": "void glBlendFunc(int sfactor, int dfactor)",
+        "name": "BlendFunc"
+    },
+    {
+        "function": "void glBlendFuncSeparate(int srcRGB, int dstRGB, int srcAlpha, int dstAlpha)",
+        "name": "BlendFuncSeparate"
+    },
+    {
+        "function": "void glDepthRangef(float near, float far)",
+        "name": "DepthRange"
+    },
+    {
+        "function": "void glPolygonMode(int faces, int mode)",
+        "name": "PolygonMode"
+    },
+    {
+        "function": "void glLineWidth(float width)",
+        "name": "LineWidth"
+    },
+    {
+        "function": "void glDepthFunc(int func)",
+        "name": "DepthFunc"
+    },
+    {
+        "function": "void glCullFace(int face)",
+        "name": "CullFace"
+    },
+    {
+        "function": "void glPixelStorei(int pname, int param)",
+        "name": "PixelStorei"
+    },
+    {
+        "function": "void glDepthMask(bool flag)",
+        "name": "DepthMask"
+    },
+    {
+        "function": "void glColorMask(bool r, bool g, bool b, bool a)",
+        "name": "ColorMask"
+    },
+    {
+        "function": "void glAlphaFunc(int func, float _ref)",
+        "name": "AlphaFunc"
+    },
+    {
+        "function": "void glPolygonOffset(float factor, float units)",
+        "name": "PolygonOffset"
+    },
+    {
+        "function": "void glGenTextures(int n, out uint textures)",
+        "name": "GenTextures"
+    },
+    {
+        "function": "void glDeleteTextures(int n, ref uint textures)",
+        "name": "DeleteTextures"
+    },
+    {
+        "function": "void glTexParameteri(int target, int pname, int param)",
+        "name": "TexParameteri"
+    },
+    {
+        "function": "void glTexParameterf(int target, int pname, float param)",
+        "name": "TexParameterf"
+    },
+    {
+        "function": "void glTexParameterfv(int target, int pname, ref Vector4 param)",
+        "name": "TexParameterfv"
+    },
+    {
+        "function": "void glBindTexture(int target, uint id)",
+        "name": "BindTexture"
+    },
+    {
+        "function": "void glActiveTexture(int unit)",
+        "name": "ActiveTexture"
+    },
+    {
+        "function": "void glTexImage2D(int target, int level, int internalFormat, int width, int height, int border, int format, int type, IntPtr data)",
+        "name": "TexImage2D"
+    },
+    {
+        "function": "void glTexStorage2DMultisample(int target, int samples, int internalFormat, int width, int height, bool fixedsamplelocations)",
+        "name": "TexStorage2DMultisample"
+    },
+    {
+        "function": "void glTexImage2DMultisample(int target, int samples, int internalFormat, int width, int height, bool fixedsamplelocations)",
+        "name": "TexImage2DMultisample"
+    },
+    {
+        "function": "void glCompressedTexImage2D(int target, int level, int internalFormat, int width, int height, int border, int imageSize, IntPtr data)",
+        "name": "CompressedTexImage2D"
+    },
+    {
+        "function": "void glTexSubImage2D(int target, int level, int xoffset, int yoffset, int width, int height, int format, int type, IntPtr data)",
+        "name": "TexSubImage2D"
+    },
+    {
+        "function": "void glGetTexImage(int target, int level, int format, int type, IntPtr pixels)",
+        "name": "GetTexImage"
+    },
+    {
+        "function": "void glDispatchCompute(uint num_groups_x, uint num_groups_y, uint num_groups_z)",
+        "name": "DispatchCompute"
+    },
+    {
+        "function": "uint glCreateShader(int shaderType)",
+        "name": "CreateShader"
+    },
+    {
+        "function": "void glShaderSource(uint shader, int count, ref IntPtr str, IntPtr length)",
+        "name": "ShaderSource",
+        "manual": true
+    },
+    {
+        "function": "void glCompileShader(uint shader)",
+        "name": "CompileShader"
+    },
+    {
+        "function": "void glGetShaderInfoLog(uint shader, int maxLength, out int length, IntPtr infoLog)",
+        "name": "GetShaderInfoLog",
+        "manual": true
+    },
+    {
+        "function": "void glGetProgramInfoLog(uint shader, int maxLength, out int length, IntPtr infoLog)",
+        "name": "GetProgramInfoLog",
+        "manual": true
+    },
+    {
+        "function": "uint glCreateProgram()",
+        "name": "CreateProgram"
+    },
+    {
+        "function": "void glAttachShader(uint program, uint shader)",
+        "name": "AttachShader"
+    },
+    {
+        "function": "void glDetachShader(uint program, uint shader)",
+        "name": "DetachShader"
+    },
+    {
+        "function": "void glDeleteShader(uint shader)",
+        "name": "DeleteShader"
+    },
+    {
+        "function": "void glBindAttribLocation(uint program, uint index, string name)",
+        "name": "BindAttribLocation"
+    },
+    {
+        "function": "void glBindFragDataLocation(uint program, uint colorNumber, string name)",
+        "name": "BindFragDataLocation"
+    },
+    {
+        "function": "void glLinkProgram(uint program)",
+        "name": "LinkProgram"
+    },
+    {
+        "function": "void glUseProgram(uint program)",
+        "name": "UseProgram"
+    },
+    {
+        "function": "void glGetShaderiv(uint shader, int pname, out int param)",
+        "name": "GetShaderiv"
+    },
+    {
+        "function": "void glGetProgramiv(uint program, int pname, out int param)",
+        "name": "GetProgramiv"
+    },
+    {
+        "function": "int glGetUniformLocation(uint program, string name)",
+        "name": "GetUniformLocation"
+    },
+    {
+        "function": "void glUniform1i(int location, int v0)",
+        "name": "Uniform1i"
+    },
+    {
+        "function": "void glUniform1f(int location, float v0)",
+        "name": "Uniform1f"
+    },
+    {
+        "function": "void glUniform2i(int location, int v1, int v2)",
+        "name": "Uniform2i"
+    },
+    {
+        "function": "void glUniform2f(int location, float v0, float v1)",
+        "name": "Uniform2f"
+    },
+    {
+        "function": "void glUniform3f(int location, float v0, float v1, float v2)",
+        "name": "Uniform3f"
+    },
+    {
+        "function": "void glUniform3fv(int location, int count, IntPtr values)",
+        "name": "Uniform3fv"
+    },
+    {
+        "function": "void glUniform4f(int location, float v0, float v1, float v2, float v3)",
+        "name": "Uniform4f"
+    },
+    {
+        "function": "void glUniform4fv(int location, int count, IntPtr values)",
+        "name": "Uniform4fv"
+    },
+    {
+        "function": "void glUniform4i(int location, int v0, int v1, int v2, int v3)",
+        "name": "Uniform4i"
+    },
+    {
+        "function": "void glUniform4iv(int location, int count, IntPtr values)",
+        "name": "Uniform4iv"
+    },
+    {
+        "function": "void glUniformMatrix4fv(int location, int count, bool transpose, IntPtr value)",
+        "name": "UniformMatrix4fv"
+    },
+    {
+        "function": "void glUniformBlockBinding(uint program, uint uniformBlockIndex, uint uniformBlockBinding)",
+        "name": "UniformBlockBinding"
+    },
+    {
+        "function": "int glGetUniformBlockIndex(uint program, string name)",
+        "name": "GetUniformBlockIndex"
+    },
+    {
+        "function": "void glShaderStorageBlockBinding(uint program, uint storageBlockIndex, uint storageBlockBinding)",
+        "name": "ShaderStorageBlockBinding"
+    },
+    {
+        "function": "int glGetProgramResourceIndex(uint program, int programInterface, string name)",
+        "name": "GetProgramResourceIndex"
+    },
+    {
+        "function": "void glGenBuffers(int n, out uint buffers)",
+        "name": "GenBuffers"
+    },
+    {
+        "function": "void glDeleteBuffers(int n, ref uint id)",
+        "name": "DeleteBuffers"
+    },
+    {
+        "function": "void glBindBuffer(int target, uint id)",
+        "name": "BindBuffer"
+    },
+    {
+        "function": "void glBindBufferRange(int target, uint index, uint buffer, IntPtr offset, IntPtr size)",
+        "name": "BindBufferRange"
+    },
+    {
+        "function": "void glBufferData(int target, IntPtr size, IntPtr data, int usage)",
+        "name": "BufferData"
+    },
+    {
+        "function": "void glBufferSubData(int target, IntPtr offset, IntPtr size, IntPtr data)",
+        "name": "BufferSubData"
+    },
+    {
+        "function": "void glCopyBufferSubData(int readtarget, int writetarget, IntPtr readoffset, IntPtr writeoffset, IntPtr size)",
+        "name": "CopyBufferSubData"
+    },
+    {
+        "function": "void glGenVertexArrays(int n, out uint arrays)",
+        "name": "GenVertexArrays"
+    },
+    {
+        "function": "void glDeleteVertexArrays(int n, ref uint id)",
+        "name": "DeleteVertexArrays"
+    },
+    {
+        "function": "void glBindVertexArray(uint array)",
+        "name": "BindVertexArray"
+    },
+    {
+        "function": "void glEnableVertexAttribArray(int index)",
+        "name": "EnableVertexAttribArray"
+    },
+    {
+        "function": "void glVertexAttribPointer(uint index, int size, int type, bool normalized, int stride, IntPtr data)",
+        "name": "VertexAttribPointer"
+    },
+    {
+        "function": "void glVertexAttribIPointer(uint index, int size, int type, int stride, IntPtr data)",
+        "name": "VertexAttribIPointer"
+    },
+    {
+        "function": "void glDrawBuffer(int buffer)",
+        "name": "DrawBuffer",
+        "manual": true
+    },
+    {
+        "function": "void glDrawBuffers(int count, ref int buffer)",
+        "name": "DrawBuffers",
+        "manual": true
+    },
+    {
+        "function": "IntPtr glMapBuffer(uint target, uint access)",
+        "name": "MapBuffer"
+    },
+    {
+        "function": "IntPtr glMapBufferRange(uint target, IntPtr offset, IntPtr length, uint access)",
+        "name": "MapBufferRange"
+    },
+    {
+        "function": "bool glUnmapBuffer(uint target)",
+        "name": "UnmapBuffer"
+    },
+    {
+        "function": "void glBindBufferBase(uint target, uint index, uint buffer)",
+        "name": "BindBufferBase"
+    },
+    {
+        "function": "void glMemoryBarrier(int barriers)",
+        "name": "MemoryBarrier"
+    },
+    {
+        "function": "void glDrawElements(int mode, int count, int type, IntPtr indices)",
+        "name": "DrawElements"
+    },
+    {
+        "function": "void glDrawArrays(int mode, int first, int count)",
+        "name": "DrawArrays"
+    },
+    {
+        "function": "void glDrawElementsBaseVertex(int mode, int count, int type, IntPtr indices, int basevertex)",
+        "name": "DrawElementsBaseVertex"
+    },
+    {
+        "function": "void glGenFramebuffers(int n, out uint framebuffers)",
+        "name": "GenFramebuffers"
+    },
+    {
+        "function": "int glCheckFramebufferStatus(int target)",
+        "name": "CheckFramebufferStatus"
+    },
+    {
+        "function": "void glBindFramebuffer(int target, uint framebuffer)",
+        "name": "BindFramebuffer"
+    },
+    {
+        "function": "void glBlitFramebuffer(int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, int mask, int filter)",
+        "name": "BlitFramebuffer"
+    },
+    {
+        "function": "void glGenRenderbuffers(int n, out uint renderbuffers)",
+        "name": "GenRenderbuffers"
+    },
+    {
+        "function": "void glBindRenderbuffer(int target, uint renderbuffer)",
+        "name": "BindRenderbuffer"
+    },
+    {
+        "function": "void glRenderbufferStorage(int target, int internalformat, int width, int height)",
+        "name": "RenderbufferStorage"
+    },
+    {
+        "function": "void glRenderbufferStorageMultisample(int target, int samples, int internalformat, int width, int height)",
+        "name": "RenderbufferStorageMultisample"
+    },
+    {
+        "function": "void glFramebufferRenderbuffer(int target, int attachment, int renderbuffertarget, uint renderbuffer)",
+        "name": "FramebufferRenderbuffer"
+    },
+    {
+        "function": "void glFramebufferTexture2D(int target, int attachment, int textarget, uint texture, int level)",
+        "name": "FramebufferTexture2D"
+    },
+    {
+        "function": "void glDeleteFramebuffers(int n, ref uint framebuffers)",
+        "name": "DeleteFramebuffers"
+    },
+    {
+        "function": "void glDeleteRenderbuffers(int n, ref uint renderbuffers)",
+        "name": "DeleteRenderbuffers"
+    },
+    {
+        "function": "void glReadBuffer(int buffer)",
+        "name": "ReadBuffer"
+    },
+    {
+        "function": "void glReadPixels(int x, int y, int width, int height, int format, int type, IntPtr data)",
+        "name": "ReadPixels"
+    },
+    {
+        "function": "int glGetError()",
+        "name": "GetError"
+    },
+    {
+        "function": "void glDebugMessageCallback(IntPtr callback, IntPtr userParam)",
+        "name": "DebugMessageCallback",
+        "manual": true
+    },
+    {
+        "function": "void glDebugMessageControl(int source, int type, int severity, int count, IntPtr ids, bool enabled)",
+        "name": "DebugMessageControl"
+    },
+    {
+        "function": "IntPtr glFenceSync(uint condition, uint flags)",
+        "name": "FenceSync"
+    },
+    {
+        "function": "void glDeleteSync(IntPtr sync)",
+        "name": "DeleteSync"
+    },
+    {
+        "function": "uint glClientWaitSync(IntPtr sync, uint flags, ulong timeout)",
+        "name": "ClientWaitSync"
+    },
+    {
+        "function": "void glFlush()",
+        "name": "Flush"
+    }
 ]

--- a/src/LLShaderCompiler/Translation/GLTranslator.cs
+++ b/src/LLShaderCompiler/Translation/GLTranslator.cs
@@ -234,42 +234,50 @@ public static class GLTranslator
      *
      * And replaces instance._m0 access with instance
      */
-    static bool ProcessStorageBuffer(Dictionary<string, int> bufferSizes, ref string source)
+    static void ProcessStorageBuffers(Dictionary<string, int> bufferSizes, ref string source)
     {
         const string SSBO_DEF = "layout(std430) readonly buffer";
 
-        var idx = source.IndexOf(SSBO_DEF, StringComparison.Ordinal);
-        if (idx == -1)
-            return false;
+        int idx = 0;
+        while ((idx = source.IndexOf(SSBO_DEF, idx, StringComparison.Ordinal)) != -1)
+        {
+            var idxBlockStart = source.IndexOf("{", idx + SSBO_DEF.Length, StringComparison.Ordinal);
 
-        var idxBlockStart = source.IndexOf("{", idx + SSBO_DEF.Length, StringComparison.Ordinal);
-
-        var blockName = source.Substring(idx + SSBO_DEF.Length, idxBlockStart - idx - SSBO_DEF.Length).Trim();
-
-        int braces = 1;
-        int idxBlockEnd;
-        for (idxBlockEnd = idxBlockStart + 1; idxBlockEnd < source.Length; idxBlockEnd++) {
-            if (source[idxBlockEnd] == '}')
-            {
-                braces--;
+            var blockName = source.Substring(idx + SSBO_DEF.Length, idxBlockStart - idx - SSBO_DEF.Length).Trim();
+            int braces = 1;
+            int idxBlockEnd;
+            for (idxBlockEnd = idxBlockStart + 1; idxBlockEnd < source.Length; idxBlockEnd++) {
+                if (source[idxBlockEnd] == '}')
+                {
+                    braces--;
+                }
+                if (braces == 0)
+                {
+                    break;
+                }
             }
-            if (braces == 0)
-            {
-                break;
-            }
+            idxBlockEnd++;
+            var identifierEnd = source.IndexOf(";", idxBlockEnd, StringComparison.Ordinal);
+            var identifier = source.Substring(idxBlockEnd, identifierEnd - idxBlockEnd).Trim();
+
+            var std430buf = source.Substring(idx, idxBlockEnd - idx) + ";";
+
+            var sz = bufferSizes[blockName];
+
+            std430buf = std430buf.Replace("_m0", $"{identifier}");
+
+            var newBufDef = $@"#if USE_SSBO
+{std430buf}
+#else
+{std430buf.Replace("[]", $"[{sz}]").Replace(SSBO_DEF, "layout (std140) uniform")}
+#endif
+";
+            var newStr = source.Substring(0, idx) +
+                         newBufDef +
+                         source.Substring(identifierEnd + 1);
+            source = newStr.Replace($"{identifier}._m0", identifier);
+            idx += newBufDef.Length;
         }
-        idxBlockEnd++;
-        var identifierEnd = source.IndexOf(";", idxBlockEnd, StringComparison.Ordinal);
-        var identifier = source.Substring(idxBlockEnd, identifierEnd - idxBlockEnd).Trim();
-
-        var sz = bufferSizes[blockName];
-        // Remove the generated SPIRV-Cross block instance name as that is invalid GLSL 140.
-        // And set a fixed size for the SSBO->UBO translation
-        source = ReplaceFirst(source, idxBlockEnd, identifier, "");
-        source = ReplaceFirst(source, idxBlockStart, "_m0[]", $"{identifier}[{sz}]");
-        source = ReplaceFirst(source, idx, SSBO_DEF, "layout(std140) uniform");
-        source = source.Replace($"{identifier}._m0", $"{identifier}");
-        return true;
     }
 
     private const string ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_";
@@ -446,7 +454,7 @@ public static class GLTranslator
         var source = ReplaceFirst(Marshal.PtrToStringUTF8((IntPtr)translatedSource)!, 0, "#version 140\n",
             "");
 
-        while (ProcessStorageBuffer(bufferSizes, ref source)) ;
+        ProcessStorageBuffers(bufferSizes, ref source);
 
         return (source, varyingResults);
     }

--- a/src/LibreLancer.Base/Graphics/Backends/IRenderContext.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/IRenderContext.cs
@@ -41,7 +41,7 @@ internal interface IRenderContext
 
     IMultisampleTarget CreateMultisampleTarget(int width, int height, int samples);
 
-    IStorageBuffer CreateUniformBuffer(int size, int stride, Type type);
+    IStorageBuffer CreateStorageBuffer(int size, int stride);
 
     void SetCamera(ICamera camera);
     void SetIdentityCamera();

--- a/src/LibreLancer.Base/Graphics/Backends/Null/NullRenderContext.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/Null/NullRenderContext.cs
@@ -78,8 +78,6 @@ internal class NullRenderContext : IRenderContext
     {
     }
 
-    public IShader CreateShader(string vertex_source, string fragment_source) =>
-        new NullShader();
 
     public IShader CreateShader(ReadOnlySpan<byte> program) =>
         new NullShader();
@@ -111,7 +109,7 @@ internal class NullRenderContext : IRenderContext
     public IMultisampleTarget CreateMultisampleTarget(int width, int height, int samples) =>
         new NullMultisampleTarget(width, height);
 
-    public IStorageBuffer CreateUniformBuffer(int size, int stride, Type type) =>
+    public IStorageBuffer CreateStorageBuffer(int size, int stride) =>
         new NullStorageBuffer(size, stride);
 
     public bool HasFeature(GraphicsFeature feature) => false;

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GL.Constants.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GL.Constants.cs
@@ -180,4 +180,6 @@ internal static partial class GL
     public const int GL_SYNC_GPU_COMMANDS_COMPLETE = 0x9117;
     public const int GL_ALREADY_SIGNALED = 0x911A;
     public const int GL_CONDITION_SATISFIED = 0x911C;
+
+    public const int GL_MAX_VERTEX_SHADER_STORAGE_BLOCKS = 0x90d6;
 }

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GL.Constants.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GL.Constants.cs
@@ -25,6 +25,7 @@ internal static partial class GL
     public const int GL_COMPILE_STATUS = 0x8B81;
     public const int GL_LINK_STATUS = 0x8B82;
     public const int GL_INVALID_INDEX = -1;
+    public const int GL_SHADER_STORAGE_BLOCK = 0x92e6;
 
     public const int GL_TEXTURE_2D = 0x0DE1;
     public const int GL_TEXTURE_2D_MULTISAMPLE = 0x9100;

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GL.Generated.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GL.Generated.cs
@@ -71,6 +71,8 @@ namespace LibreLancer.Graphics.Backends.OpenGL
         private static delegate* unmanaged<int,int,int,IntPtr,void> _glUniformMatrix4fv;
         private static delegate* unmanaged<uint,uint,uint,void> _glUniformBlockBinding;
         private static delegate* unmanaged<uint,byte*,int> _glGetUniformBlockIndex;
+        private static delegate* unmanaged<uint,uint,uint,void> _glShaderStorageBlockBinding;
+        private static delegate* unmanaged<uint,int,byte*,int> _glGetProgramResourceIndex;
         private static delegate* unmanaged<int,uint*,void> _glGenBuffers;
         private static delegate* unmanaged<int,uint*,void> _glDeleteBuffers;
         private static delegate* unmanaged<int,uint,void> _glBindBuffer;
@@ -115,7 +117,7 @@ namespace LibreLancer.Graphics.Backends.OpenGL
         private static delegate* unmanaged<IntPtr,void> _glDeleteSync;
         private static delegate* unmanaged<IntPtr,uint,ulong,uint> _glClientWaitSync;
         private static delegate* unmanaged<void> _glFlush;
-        
+
         public static void Load(Func<string,IntPtr> getProcAddress, bool isGles)
         {
             _glEnable = (delegate* unmanaged<int,void>)getProcAddress("glEnable");
@@ -182,6 +184,8 @@ namespace LibreLancer.Graphics.Backends.OpenGL
             _glUniformMatrix4fv = (delegate* unmanaged<int,int,int,IntPtr,void>)getProcAddress("glUniformMatrix4fv");
             _glUniformBlockBinding = (delegate* unmanaged<uint,uint,uint,void>)getProcAddress("glUniformBlockBinding");
             _glGetUniformBlockIndex = (delegate* unmanaged<uint,byte*,int>)getProcAddress("glGetUniformBlockIndex");
+            _glShaderStorageBlockBinding = (delegate* unmanaged<uint,uint,uint,void>)getProcAddress("glShaderStorageBlockBinding");
+            _glGetProgramResourceIndex = (delegate* unmanaged<uint,int,byte*,int>)getProcAddress("glGetProgramResourceIndex");
             _glGenBuffers = (delegate* unmanaged<int,uint*,void>)getProcAddress("glGenBuffers");
             _glDeleteBuffers = (delegate* unmanaged<int,uint*,void>)getProcAddress("glDeleteBuffers");
             _glBindBuffer = (delegate* unmanaged<int,uint,void>)getProcAddress("glBindBuffer");
@@ -584,6 +588,23 @@ namespace LibreLancer.Graphics.Backends.OpenGL
             ErrorCheck();
             return retval;
         }
+        public static void ShaderStorageBlockBinding(uint program, uint storageBlockIndex, uint storageBlockBinding)
+        {
+            _glShaderStorageBlockBinding(program, storageBlockIndex, storageBlockBinding);
+            ErrorCheck();
+        }
+        public static int GetProgramResourceIndex(uint program, int programInterface, string name)
+        {
+            int retval;
+            Span<byte> _name_stack = stackalloc byte[256];
+            using var _name_utf8 = new UTF8ZHelper(_name_stack, name);
+            fixed (byte* _name_ptr = _name_utf8.ToUTF8Z())
+            {
+                retval = _glGetProgramResourceIndex(program, programInterface, _name_ptr);
+            }
+            ErrorCheck();
+            return retval;
+        }
         public static void GenBuffers(int n, out uint buffers)
         {
             fixed (uint* _buffers_ptr = &buffers)
@@ -828,4 +849,3 @@ namespace LibreLancer.Graphics.Backends.OpenGL
         }
     }
 }
-

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLCycledBuffer.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLCycledBuffer.cs
@@ -1,0 +1,82 @@
+using System;
+
+namespace LibreLancer.Graphics.Backends.OpenGL;
+
+abstract class GLCycledBuffer(GLRenderContext ctx) : IDisposable
+{
+    private bool allAllocated = false;
+    internal SyncPoint?[] Fences = new SyncPoint?[3];
+    internal uint[] IDs = [0, 0, 0];
+    internal int ActiveIdx = 0;
+
+    protected abstract uint GenerateBuffer();
+
+    protected void AllocateBufferIndex(int idx)
+    {
+        IDs[idx] = GenerateBuffer();
+        allAllocated = true;
+        for (int i = 0; i < IDs.Length; i++)
+        {
+            if (IDs[i] == 0)
+            {
+                allAllocated = false;
+                break;
+            }
+        }
+    }
+
+    protected int GetNextBuffer()
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            int idx = (ActiveIdx + i) % 3;
+            if (IDs[idx] == 0)
+                continue;
+            if (Fences[idx] == null)
+            {
+                return idx;
+            }
+            if (Fences[idx]!.Passed())
+            {
+                Fences[idx] = null;
+                return idx;
+            }
+        }
+
+        if (allAllocated)
+        {
+            int idx = (ActiveIdx + 1);
+            Fences[idx]!.Wait();
+            Fences[idx] = null;
+            return idx;
+        }
+
+        for (int i = 0; i < IDs.Length; i++)
+        {
+            if (IDs[i] == 0)
+            {
+                AllocateBufferIndex(i);
+                return i;
+            }
+        }
+
+        throw new InvalidOperationException("Unreachable");
+    }
+
+    public void Dispose()
+    {
+        for (int i = 0; i < ctx.BoundBuffers.Length; i++)
+        {
+            if (ctx.BoundBuffers[i] == this)
+            {
+                ctx.BoundBuffers[i] = null;
+            }
+        }
+
+        for (int i = 0; i < IDs.Length; i++)
+        {
+            if (IDs[i] != 0)
+                GL.DeleteBuffer(IDs[i]);
+        }
+    }
+}

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLExtensions.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLExtensions.cs
@@ -88,6 +88,23 @@ internal static class GLExtensions
         }
     }
 
+    public static bool? _arbComputeShader;
+
+    public static bool GL430
+    {
+        get
+        {
+            if (_arbComputeShader == null)
+            {
+                PopulateExtensions();
+                _arbComputeShader = ExtensionList!.Contains("GL_ARB_compute_shader");
+                if (_arbComputeShader.Value) FLLog.Info("GL", "GL 4.3 available, using SSBOs.");
+            }
+            return _arbComputeShader.Value;
+        }
+    }
+
+
     //Global method for checking extensions. Called upon GraphicsDevice creation
     public static void PopulateExtensions()
     {

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLExtensions.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLExtensions.cs
@@ -88,19 +88,20 @@ internal static class GLExtensions
         }
     }
 
-    public static bool? _arbComputeShader;
+    public static bool? _ssbo;
 
-    public static bool GL430
+    public static bool ShaderStorageBufferObjects
     {
         get
         {
-            if (_arbComputeShader == null)
+            if (_ssbo == null)
             {
                 PopulateExtensions();
-                _arbComputeShader = ExtensionList!.Contains("GL_ARB_compute_shader");
-                if (_arbComputeShader.Value) FLLog.Info("GL", "GL 4.3 available, using SSBOs.");
+                _ssbo = ExtensionList!.Contains("GL_ARB_compute_shader") &&
+                                    ExtensionList.Contains("GL_ARB_shader_storage_buffer_object");
+                if (_ssbo.Value) FLLog.Info("GL", "Using SSBOs");
             }
-            return _arbComputeShader.Value;
+            return _ssbo.Value;
         }
     }
 

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLExtensions.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLExtensions.cs
@@ -99,7 +99,6 @@ internal static class GLExtensions
                 PopulateExtensions();
                 _ssbo = ExtensionList!.Contains("GL_ARB_compute_shader") &&
                                     ExtensionList.Contains("GL_ARB_shader_storage_buffer_object");
-                if (_ssbo.Value) FLLog.Info("GL", "Using SSBOs");
             }
             return _ssbo.Value;
         }

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLExtensions.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLExtensions.cs
@@ -97,8 +97,26 @@ internal static class GLExtensions
             if (_ssbo == null)
             {
                 PopulateExtensions();
-                _ssbo = ExtensionList!.Contains("GL_ARB_compute_shader") &&
+                var extensionAvail = ExtensionList!.Contains("GL_ARB_compute_shader") &&
                                     ExtensionList.Contains("GL_ARB_shader_storage_buffer_object");
+                if (extensionAvail)
+                {
+                    int maxBlocks;
+                    GL.GetIntegerv(GL.GL_MAX_VERTEX_SHADER_STORAGE_BLOCKS, out maxBlocks);
+                    if (maxBlocks >= 2)
+                    {
+                        _ssbo = true;
+                    }
+                    else
+                    {
+                        FLLog.Info("GL", $"GL_MAX_VERTEX_SHADER_STORAGE_BLOCKS reports {maxBlocks}, disabling SSBO (require >=2).");
+                        _ssbo = false;
+                    }
+                }
+                else
+                {
+                    _ssbo = false;
+                }
             }
             return _ssbo.Value;
         }

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLRenderContext.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLRenderContext.cs
@@ -27,12 +27,29 @@ internal class GLRenderContext : IRenderContext
 
     public uint NullVAO;
 
+    public bool FencedUBO;
+    public bool SSBO;
+
     private GLRenderContext(IntPtr glContext)
     {
         this.glContext = glContext;
         glVersion = GL.GetString(GL.GL_VERSION);
         glRenderer = GL.GetString(GL.GL_RENDERER);
         renderName = $"OpenGL Renderer - {glVersion} ({glRenderer})";
+
+        FencedUBO = GLExtensions.Sync;
+        if (glRenderer.Contains("V3D") || !Platform.GetHintBoolean("librelancer_fencedubo", true))
+        {
+            FencedUBO = false;
+        }
+        SSBO = GLExtensions.ShaderStorageBufferObjects;
+        if (Platform.GetHintBoolean("librelancer_nossbo", true))
+        {
+            SSBO = false;
+        }
+
+        string storageTarget = SSBO ? "SSBOs" : FencedUBO ? "Fenced UBOs" : "Invalidated UBOs";
+        FLLog.Info("GL", $"Storage target: {storageTarget}");
     }
 
     public static GLRenderContext? Create(IntPtr sdlWindow)
@@ -50,7 +67,7 @@ internal class GLRenderContext : IRenderContext
     {
         IntPtr glcontext = IntPtr.Zero;
 
-        if ("GLES".Equals(Environment.GetEnvironmentVariable("LIBRELANCER_RENDERER"), StringComparison.OrdinalIgnoreCase) ||
+        if (Platform.GetHintString("librelancer_renderer", "").Equals("gles", StringComparison.OrdinalIgnoreCase) ||
             !CreateContextCore(sdlWin, out glcontext))
         {
             if (!CreateContextES(sdlWin, out glcontext))
@@ -97,8 +114,7 @@ internal class GLRenderContext : IRenderContext
 
     private static bool CreateContextCore(IntPtr sdlWin, out IntPtr ctx)
     {
-        var use32 = Environment.GetEnvironmentVariable("LIBRELANCER_GL32");
-        int minorVersion = use32 == "1" ? 2 : 1;
+        int minorVersion = Platform.GetHintBoolean("librelancer_gl32", false) ? 2 : 1;
         ctx = SDLGL_Create(sdlWin, 3, minorVersion, false);
         if (ctx == IntPtr.Zero) return false;
         if (!GL.CheckStringSDL())
@@ -515,7 +531,7 @@ internal class GLRenderContext : IRenderContext
     {
         GraphicsFeature.Anisotropy => GLExtensions.Anisotropy,
         GraphicsFeature.DebugInfo => GLExtensions.DebugInfo,
-        GraphicsFeature.LargeStorageBuffers => GLExtensions.ShaderStorageBufferObjects,
+        GraphicsFeature.LargeStorageBuffers => SSBO,
         GraphicsFeature.S3TC => GLExtensions.S3TC,
         GraphicsFeature.GLES => GL.GLES,
         _ => false
@@ -585,7 +601,7 @@ internal class GLRenderContext : IRenderContext
         => new GLMultisampleTarget(this, width, height, samples);
 
     public IStorageBuffer CreateStorageBuffer(int size, int stride)
-        => GLExtensions.ShaderStorageBufferObjects
+        => SSBO
             ? new GLStorageBuffer(size, stride, this)
             : new GLUniformStorageBuffer(size, stride, this);
 }

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLRenderContext.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLRenderContext.cs
@@ -43,7 +43,7 @@ internal class GLRenderContext : IRenderContext
             FencedUBO = false;
         }
         SSBO = GLExtensions.ShaderStorageBufferObjects;
-        if (Platform.GetHintBoolean("librelancer_nossbo", true))
+        if (Platform.GetHintBoolean("librelancer_nossbo", false))
         {
             SSBO = false;
         }

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLRenderContext.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLRenderContext.cs
@@ -22,13 +22,15 @@ internal class GLRenderContext : IRenderContext
     private string renderName;
     private GraphicsState applied;
     private IntPtr glContext;
-    internal GLUniformStorageBuffer?[] BoundBuffers = new GLUniformStorageBuffer?[32];
+    internal GLCycledBuffer?[] BoundBuffers = new GLCycledBuffer?[32];
     internal int[] BoundBufferIndex = new int[32];
-
     public uint NullVAO;
 
     public bool FencedUBO;
     public bool SSBO;
+
+    Queue<SyncPoint> frameSyncs = new();
+    SyncPoint currentFrame = new();
 
     private GLRenderContext(IntPtr glContext)
     {
@@ -38,7 +40,7 @@ internal class GLRenderContext : IRenderContext
         renderName = $"OpenGL Renderer - {glVersion} ({glRenderer})";
 
         FencedUBO = GLExtensions.Sync;
-        if (glRenderer.Contains("V3D") || !Platform.GetHintBoolean("librelancer_fencedubo", true))
+        if (!Platform.GetHintBoolean("librelancer_fencedubo", true))
         {
             FencedUBO = false;
         }
@@ -201,12 +203,12 @@ internal class GLRenderContext : IRenderContext
         }
     }
 
-    internal void BindToIndex(int binding, IntPtr startPtr, IntPtr length, GLUniformStorageBuffer uniformStorageBuffer)
+    internal void BindToIndex(int target, int binding, IntPtr startPtr, IntPtr length, GLCycledBuffer storageBuffer)
     {
-        GL.BindBufferRange(GL.GL_UNIFORM_BUFFER, (uint) binding,
-            uniformStorageBuffer.IDs[uniformStorageBuffer.ActiveIdx], startPtr, length);
-        BoundBuffers[binding] = uniformStorageBuffer;
-        BoundBufferIndex[binding] = uniformStorageBuffer.ActiveIdx;
+        GL.BindBufferRange(target, (uint) binding,
+            storageBuffer.IDs[storageBuffer.ActiveIdx], startPtr, length);
+        BoundBuffers[binding] = storageBuffer;
+        BoundBufferIndex[binding] = storageBuffer.ActiveIdx;
     }
 
     void SyncBoundBuffer(int binding)
@@ -215,27 +217,21 @@ internal class GLRenderContext : IRenderContext
         var index = BoundBufferIndex[binding];
         if (buf == null)
             return;
-        if (buf.Fences[index] != 0)
-        {
-            GL.DeleteSync(buf.Fences[index]);
-        }
-        buf.Fences[index] = GL.FenceSync(GL.GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+        buf.Fences[index] = currentFrame;
     }
 
     internal void ShaderResourcesUsed()
     {
-        if (!GLExtensions.Sync)
+        if (!FencedUBO)
             return;
         var a = applied.Shader as GLShader;
         if (a == null)
             return;
-        for (int i = 0; i < a.UsedUniformBuffers.Count; i++)
+        for (int i = 0; i < a.UsedStorageBindings.Count; i++)
         {
-            SyncBoundBuffer(a.UsedUniformBuffers[i]);
+            SyncBoundBuffer(a.UsedStorageBindings[i]);
         }
     }
-
-
 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     private struct CameraMatrices
@@ -550,10 +546,20 @@ internal class GLRenderContext : IRenderContext
 
     public void SwapWindow(IntPtr sdlWindow, bool vsync, bool fullscreen)
     {
+        currentFrame.Set();
         lastHeight = GetDrawableSize(sdlWindow).Y;
         GLSwap.SwapWindow(sdlWindow, vsync, fullscreen);
         if (GL.FrameHadErrors()) //If there was a GL error, track it down.
             GL.ErrorChecking = true;
+        while(frameSyncs.TryPeek(out var sp))
+        {
+            if(sp.Passed())
+                frameSyncs.Dequeue();
+            else
+                break;
+        }
+        frameSyncs.Enqueue(currentFrame);
+        currentFrame = new();
     }
 
     public Point GetDrawableSize(IntPtr sdlWindow)

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLRenderContext.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLRenderContext.cs
@@ -515,6 +515,7 @@ internal class GLRenderContext : IRenderContext
     {
         GraphicsFeature.Anisotropy => GLExtensions.Anisotropy,
         GraphicsFeature.DebugInfo => GLExtensions.DebugInfo,
+        GraphicsFeature.LargeStorageBuffers => GLExtensions.GL430,
         GraphicsFeature.S3TC => GLExtensions.S3TC,
         GraphicsFeature.GLES => GL.GLES,
         _ => false
@@ -583,8 +584,8 @@ internal class GLRenderContext : IRenderContext
     public IMultisampleTarget CreateMultisampleTarget(int width, int height, int samples)
         => new GLMultisampleTarget(this, width, height, samples);
 
-    public IStorageBuffer CreateUniformBuffer(int size, int stride, Type type)
+    public IStorageBuffer CreateStorageBuffer(int size, int stride)
         => GLExtensions.GL430
             ? new GLStorageBuffer(size, stride, this)
-            : new GLUniformStorageBuffer(size, stride, type, this);
+            : new GLUniformStorageBuffer(size, stride, this);
 }

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLRenderContext.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLRenderContext.cs
@@ -515,7 +515,7 @@ internal class GLRenderContext : IRenderContext
     {
         GraphicsFeature.Anisotropy => GLExtensions.Anisotropy,
         GraphicsFeature.DebugInfo => GLExtensions.DebugInfo,
-        GraphicsFeature.LargeStorageBuffers => GLExtensions.GL430,
+        GraphicsFeature.LargeStorageBuffers => GLExtensions.ShaderStorageBufferObjects,
         GraphicsFeature.S3TC => GLExtensions.S3TC,
         GraphicsFeature.GLES => GL.GLES,
         _ => false
@@ -585,7 +585,7 @@ internal class GLRenderContext : IRenderContext
         => new GLMultisampleTarget(this, width, height, samples);
 
     public IStorageBuffer CreateStorageBuffer(int size, int stride)
-        => GLExtensions.GL430
+        => GLExtensions.ShaderStorageBufferObjects
             ? new GLStorageBuffer(size, stride, this)
             : new GLUniformStorageBuffer(size, stride, this);
 }

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLRenderContext.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLRenderContext.cs
@@ -22,7 +22,7 @@ internal class GLRenderContext : IRenderContext
     private string renderName;
     private GraphicsState applied;
     private IntPtr glContext;
-    internal GLStorageBuffer?[] BoundBuffers = new GLStorageBuffer?[32];
+    internal GLUniformStorageBuffer?[] BoundBuffers = new GLUniformStorageBuffer?[32];
     internal int[] BoundBufferIndex = new int[32];
 
     public uint NullVAO;
@@ -185,12 +185,12 @@ internal class GLRenderContext : IRenderContext
         }
     }
 
-    internal void BindToIndex(int binding, IntPtr startPtr, IntPtr length, GLStorageBuffer storageBuffer)
+    internal void BindToIndex(int binding, IntPtr startPtr, IntPtr length, GLUniformStorageBuffer uniformStorageBuffer)
     {
         GL.BindBufferRange(GL.GL_UNIFORM_BUFFER, (uint) binding,
-            storageBuffer.IDs[storageBuffer.ActiveIdx], startPtr, length);
-        BoundBuffers[binding] = storageBuffer;
-        BoundBufferIndex[binding] = storageBuffer.ActiveIdx;
+            uniformStorageBuffer.IDs[uniformStorageBuffer.ActiveIdx], startPtr, length);
+        BoundBuffers[binding] = uniformStorageBuffer;
+        BoundBufferIndex[binding] = uniformStorageBuffer.ActiveIdx;
     }
 
     void SyncBoundBuffer(int binding)
@@ -584,5 +584,7 @@ internal class GLRenderContext : IRenderContext
         => new GLMultisampleTarget(this, width, height, samples);
 
     public IStorageBuffer CreateUniformBuffer(int size, int stride, Type type)
-        => new GLStorageBuffer(size, stride, type, this);
+        => GLExtensions.GL430
+            ? new GLStorageBuffer(size, stride, this)
+            : new GLUniformStorageBuffer(size, stride, type, this);
 }

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLShader.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLShader.cs
@@ -41,7 +41,7 @@ internal class GLShader : IShader
     private UniformBlock[] blocks;
     private ulong[] tags;
 
-    public List<int> UsedUniformBuffers = [];
+    public List<int> UsedStorageBindings = [];
 
 
     public unsafe GLShader(GLRenderContext context, ReadOnlySpan<byte> program)
@@ -193,6 +193,8 @@ internal class GLShader : IShader
                 var index = GL.GetProgramResourceIndex(programID, GL.GL_SHADER_STORAGE_BLOCK, buf.Identifier);
                 if (index != GL.GL_INVALID_INDEX)
                 {
+                    if(!UsedStorageBindings.Contains(buf.Location))
+                        UsedStorageBindings.Add(buf.Location);
                     GL.ShaderStorageBlockBinding(programID, (uint)index, (uint)buf.Location);
                 }
             }
@@ -204,8 +206,8 @@ internal class GLShader : IShader
                 var index = GL.GetUniformBlockIndex(programID, buf.Identifier);
                 if (index != GL.GL_INVALID_INDEX)
                 {
-                    if(!UsedUniformBuffers.Contains(buf.Location))
-                        UsedUniformBuffers.Add(buf.Location);
+                    if(!UsedStorageBindings.Contains(buf.Location))
+                        UsedStorageBindings.Add(buf.Location);
                     GL.UniformBlockBinding(programID, (uint)index, (uint)buf.Location);
                 }
             }

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLShader.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLShader.cs
@@ -80,7 +80,7 @@ internal class GLShader : IShader
         string fragmentSource = reader.ReadUTF8();
         var version = GL.GLES
             ? "#version 300 es\nprecision highp float;\nprecision highp int;\n"
-            : GLExtensions.GL430 ? "#version 430\n#define USE_SSBO 1\n" : "#version 140\n";
+            : GLExtensions.ShaderStorageBufferObjects ? "#version 400\n#extension GL_ARB_shader_storage_buffer_object: enable\n#define USE_SSBO 1\n" : "#version 140\n";
 
         //compile shaders
         var vertexHandle = GL.CreateShader (GL.GL_VERTEX_SHADER);
@@ -186,7 +186,7 @@ internal class GLShader : IShader
         }
 
         // Bind storage
-        if (GLExtensions.GL430)
+        if (GLExtensions.ShaderStorageBufferObjects)
         {
             foreach (var buf in buffers)
             {

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLShader.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLShader.cs
@@ -80,7 +80,7 @@ internal class GLShader : IShader
         string fragmentSource = reader.ReadUTF8();
         var version = GL.GLES
             ? "#version 300 es\nprecision highp float;\nprecision highp int;\n"
-            : GLExtensions.ShaderStorageBufferObjects ? "#version 400\n#extension GL_ARB_shader_storage_buffer_object: enable\n#define USE_SSBO 1\n" : "#version 140\n";
+            : context.SSBO ? "#version 400\n#extension GL_ARB_shader_storage_buffer_object: enable\n#define USE_SSBO 1\n" : "#version 140\n";
 
         //compile shaders
         var vertexHandle = GL.CreateShader (GL.GL_VERTEX_SHADER);
@@ -186,7 +186,7 @@ internal class GLShader : IShader
         }
 
         // Bind storage
-        if (GLExtensions.ShaderStorageBufferObjects)
+        if (context.SSBO)
         {
             foreach (var buf in buffers)
             {

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLShader.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLShader.cs
@@ -78,8 +78,10 @@ internal class GLShader : IShader
 
         string vertexSource = reader.ReadUTF8();
         string fragmentSource = reader.ReadUTF8();
-        var version =
-            GL.GLES ? "#version 300 es\nprecision highp float;\nprecision highp int;\n" : "#version 140\n";
+        var version = GL.GLES
+            ? "#version 300 es\nprecision highp float;\nprecision highp int;\n"
+            : GLExtensions.GL430 ? "#version 430\n#define USE_SSBO 1\n" : "#version 140\n";
+
         //compile shaders
         var vertexHandle = GL.CreateShader (GL.GL_VERTEX_SHADER);
         var fragmentHandle = GL.CreateShader (GL.GL_FRAGMENT_SHADER);
@@ -184,14 +186,28 @@ internal class GLShader : IShader
         }
 
         // Bind storage
-        foreach (var buf in buffers)
+        if (GLExtensions.GL430)
         {
-            var index = GL.GetUniformBlockIndex(programID, buf.Identifier);
-            if (index != GL.GL_INVALID_INDEX)
+            foreach (var buf in buffers)
             {
-                if(!UsedUniformBuffers.Contains(buf.Location))
-                    UsedUniformBuffers.Add(buf.Location);
-                GL.UniformBlockBinding(programID, (uint)index, (uint)buf.Location);
+                var index = GL.GetProgramResourceIndex(programID, GL.GL_SHADER_STORAGE_BLOCK, buf.Identifier);
+                if (index != GL.GL_INVALID_INDEX)
+                {
+                    GL.ShaderStorageBlockBinding(programID, (uint)index, (uint)buf.Location);
+                }
+            }
+        }
+        else
+        {
+            foreach (var buf in buffers)
+            {
+                var index = GL.GetUniformBlockIndex(programID, buf.Identifier);
+                if (index != GL.GL_INVALID_INDEX)
+                {
+                    if(!UsedUniformBuffers.Contains(buf.Location))
+                        UsedUniformBuffers.Add(buf.Location);
+                    GL.UniformBlockBinding(programID, (uint)index, (uint)buf.Location);
+                }
             }
         }
     }

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLStorageBuffer.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLStorageBuffer.cs
@@ -1,5 +1,4 @@
 using System;
-using LibreLancer.Graphics.Backends.OpenGL;
 
 namespace LibreLancer.Graphics.Backends.OpenGL;
 
@@ -11,7 +10,6 @@ class GLStorageBuffer : IStorageBuffer
     private int stride;
     private int size;
 
-
     public GLStorageBuffer(int size, int stride, GLRenderContext ctx)
     {
         this.stride = stride;
@@ -20,12 +18,6 @@ class GLStorageBuffer : IStorageBuffer
         ID = GL.GenBuffer();
         GL.BindBuffer(GL.GL_SHADER_STORAGE_BUFFER, ID);
         GL.BufferData(GL.GL_SHADER_STORAGE_BUFFER, new IntPtr(size * stride), IntPtr.Zero, GL.GL_DYNAMIC_DRAW);
-    }
-
-
-    public void Dispose()
-    {
-        // TODO release managed resources here
     }
 
     public int GetAlignedIndex(int input)
@@ -74,5 +66,10 @@ class GLStorageBuffer : IStorageBuffer
         mapping = IntPtr.Zero;
         GL.BindBuffer(GL.GL_SHADER_STORAGE_BUFFER, ID);
         GL.UnmapBuffer(GL.GL_SHADER_STORAGE_BUFFER);
+    }
+
+    public void Dispose()
+    {
+        GL.DeleteBuffer(ID);
     }
 }

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLStorageBuffer.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLStorageBuffer.cs
@@ -2,22 +2,18 @@ using System;
 
 namespace LibreLancer.Graphics.Backends.OpenGL;
 
-class GLStorageBuffer : IStorageBuffer
+class GLStorageBuffer : GLCycledBuffer, IStorageBuffer
 {
-    private uint ID;
     private IntPtr mapping;
-    private GLRenderContext ctx;
     private int stride;
     private int size;
+    private GLRenderContext ctx;
 
-    public GLStorageBuffer(int size, int stride, GLRenderContext ctx)
+    public GLStorageBuffer(int size, int stride, GLRenderContext ctx) : base(ctx)
     {
         this.stride = stride;
         this.size = size;
         this.ctx = ctx;
-        ID = GL.GenBuffer();
-        GL.BindBuffer(GL.GL_SHADER_STORAGE_BUFFER, ID);
-        GL.BufferData(GL.GL_SHADER_STORAGE_BUFFER, new IntPtr(size * stride), IntPtr.Zero, GL.GL_DYNAMIC_DRAW);
     }
 
     public int GetAlignedIndex(int input)
@@ -33,7 +29,7 @@ class GLStorageBuffer : IStorageBuffer
         var length = (IntPtr)((count <= 0 ? size : count) * stride);
         if ((long)startPtr + (long)length > (size * stride))
             throw new IndexOutOfRangeException();
-        GL.BindBufferRange(GL.GL_SHADER_STORAGE_BUFFER, (uint)binding, ID, startPtr, length);
+        ctx.BindToIndex(GL.GL_SHADER_STORAGE_BUFFER, binding, startPtr, length, this);
     }
 
     public unsafe ref T Data<T>(int i) where T : unmanaged
@@ -54,9 +50,10 @@ class GLStorageBuffer : IStorageBuffer
     public IntPtr BeginStreaming()
     {
         if (mapping != IntPtr.Zero) throw new InvalidOperationException("Already mapped!");
-        GL.BindBuffer(GL.GL_SHADER_STORAGE_BUFFER, ID);
+        ActiveIdx = GetNextBuffer();
+        GL.BindBuffer(GL.GL_SHADER_STORAGE_BUFFER, IDs[ActiveIdx]);
         mapping = GL.MapBufferRange(GL.GL_SHADER_STORAGE_BUFFER, 0, size * stride,
-            GL.GL_MAP_WRITE_BIT | GL.GL_MAP_INVALIDATE_BUFFER_BIT | GL.GL_MAP_UNSYNCHRONIZED_BIT);
+            GL.GL_MAP_WRITE_BIT | GL.GL_MAP_UNSYNCHRONIZED_BIT);
         return mapping;
     }
 
@@ -64,12 +61,15 @@ class GLStorageBuffer : IStorageBuffer
     {
         if (mapping == IntPtr.Zero) throw new InvalidOperationException("Not mapped!");
         mapping = IntPtr.Zero;
-        GL.BindBuffer(GL.GL_SHADER_STORAGE_BUFFER, ID);
+        GL.BindBuffer(GL.GL_SHADER_STORAGE_BUFFER, IDs[ActiveIdx]);
         GL.UnmapBuffer(GL.GL_SHADER_STORAGE_BUFFER);
     }
 
-    public void Dispose()
+    protected override uint GenerateBuffer()
     {
-        GL.DeleteBuffer(ID);
+        var id = GL.GenBuffer();
+        GL.BindBuffer(GL.GL_SHADER_STORAGE_BUFFER, id);
+        GL.BufferData(GL.GL_SHADER_STORAGE_BUFFER, new IntPtr(size * stride), IntPtr.Zero, GL.GL_DYNAMIC_DRAW);
+        return id;
     }
 }

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLStorageBuffer.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLStorageBuffer.cs
@@ -56,7 +56,7 @@ class GLStorageBuffer : IStorageBuffer
         if (mapping != IntPtr.Zero) throw new InvalidOperationException("Already mapped!");
         GL.BindBuffer(GL.GL_SHADER_STORAGE_BUFFER, ID);
         mapping = GL.MapBufferRange(GL.GL_SHADER_STORAGE_BUFFER, 0, size * stride,
-            GL.GL_MAP_WRITE_BIT | GL.GL_MAP_INVALIDATE_BUFFER_BIT);
+            GL.GL_MAP_WRITE_BIT | GL.GL_MAP_INVALIDATE_BUFFER_BIT | GL.GL_MAP_UNSYNCHRONIZED_BIT);
         return mapping;
     }
 

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLStorageBuffer.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLStorageBuffer.cs
@@ -1,92 +1,47 @@
-// MIT License - Copyright (c) Callum McGing
-// This file is subject to the terms and conditions defined in
-// LICENSE, which is part of this source code package
-
 using System;
-using System.Runtime.InteropServices;
+using LibreLancer.Graphics.Backends.OpenGL;
 
 namespace LibreLancer.Graphics.Backends.OpenGL;
 
-internal class GLStorageBuffer : IStorageBuffer
+class GLStorageBuffer : IStorageBuffer
 {
-    private Type storageType;
-    private int stride;
-    private int size;
-    private int gAlignment;
+    private uint ID;
     private IntPtr mapping;
     private GLRenderContext ctx;
-
-    private bool allAllocated = false;
-    internal IntPtr[] Fences = [0, 0, 0];
-    internal uint[] IDs = [0, 0, 0];
-    internal int ActiveIdx = 0;
+    private int stride;
+    private int size;
 
 
-    public GLStorageBuffer(int size, int stride, Type type, GLRenderContext ctx)
+    public GLStorageBuffer(int size, int stride, GLRenderContext ctx)
     {
-        if (stride % 16 != 0)
-        {
-            throw new Exception("Must be aligned to minimum 16");
-        }
-
         this.stride = stride;
         this.size = size;
         this.ctx = ctx;
-
-        storageType = type;
-        AllocateBufferIndex(0);
-
-        GL.GetIntegerv(GL.GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, out int align);
-
-        var lval = stride % align;
-        gAlignment = lval == 0 ? 0 : align;
-#if DEBUG
-        if (align < 256 && 256 % align != 0)
-            gAlignment = 256; //Set larger alignment on debug for testing
-#endif
+        ID = GL.GenBuffer();
+        GL.BindBuffer(GL.GL_SHADER_STORAGE_BUFFER, ID);
+        GL.BufferData(GL.GL_SHADER_STORAGE_BUFFER, new IntPtr(size * stride), IntPtr.Zero, GL.GL_DYNAMIC_DRAW);
     }
 
-    void AllocateBufferIndex(int idx)
+
+    public void Dispose()
     {
-        IDs[idx] = GL.GenBuffer();
-        GLBind.UniformBuffer(IDs[idx]);
-        GL.BufferData(GL.GL_UNIFORM_BUFFER, new IntPtr(size * stride), IntPtr.Zero, GL.GL_DYNAMIC_DRAW);
-        allAllocated = true;
-        for (int i = 0; i < IDs.Length; i++)
-        {
-            if (IDs[i] == 0)
-            {
-                allAllocated = false;
-                break;
-            }
-        }
+        // TODO release managed resources here
     }
 
     public int GetAlignedIndex(int input)
     {
-        if (gAlignment == 0)
-        {
-            return input;
-        }
-
         int offset = input * stride;
-        var aOffset = (offset + (gAlignment - 1)) & ~(gAlignment - 1);
+        var aOffset = (offset + (4 - 1)) & ~(4 - 1);
         return aOffset / stride;
     }
 
     public void BindTo(int binding, int start = 0, int count = 0)
     {
-        if (GetAlignedIndex(start) != start)
-        {
-            throw new InvalidOperationException("Uniform buffer alignment error");
-        }
-
         var startPtr = (IntPtr)(start * stride);
         var length = (IntPtr)((count <= 0 ? size : count) * stride);
         if ((long)startPtr + (long)length > (size * stride))
             throw new IndexOutOfRangeException();
-
-        ctx.BindToIndex(binding, startPtr, length, this);
+        GL.BindBufferRange(GL.GL_SHADER_STORAGE_BUFFER, (uint)binding, ID, startPtr, length);
     }
 
     public unsafe ref T Data<T>(int i) where T : unmanaged
@@ -104,74 +59,12 @@ internal class GLStorageBuffer : IStorageBuffer
         return ref ((T*)mapping)[i];
     }
 
-    int GetNextBuffer()
-    {
-        for (int i = 0; i < 3; i++)
-        {
-            int idx = (ActiveIdx + i) % 3;
-            if (IDs[idx] == 0)
-                continue;
-            if (Fences[idx] == 0)
-            {
-                return idx;
-            }
-
-            var r = GL.ClientWaitSync(Fences[idx], 0, 0);
-            if (r == GL.GL_CONDITION_SATISFIED ||
-                r == GL.GL_ALREADY_SIGNALED)
-            {
-                GL.DeleteSync(Fences[i]);
-                Fences[i] = 0;
-                return idx;
-            }
-        }
-
-        if (allAllocated)
-        {
-            int idx = (ActiveIdx + 1);
-            uint r;
-            do
-            {
-                r = GL.ClientWaitSync(Fences[idx], 0, 1000);
-            } while (r != GL.GL_CONDITION_SATISFIED && r != GL.GL_ALREADY_SIGNALED);
-
-            GL.DeleteSync(Fences[idx]);
-            Fences[idx] = 0;
-            return idx;
-        }
-
-        for (int i = 0; i < IDs.Length; i++)
-        {
-            if (IDs[i] == 0)
-            {
-                AllocateBufferIndex(i);
-                return i;
-            }
-        }
-
-        throw new InvalidOperationException("Unreachable");
-    }
-
-
-    // NOTE: Buffer orphaning doesn't seem to work for GL_UNIFORM_BUFFER
-    // under intel or renderdoc. Do some fancy work instead
     public IntPtr BeginStreaming()
     {
         if (mapping != IntPtr.Zero) throw new InvalidOperationException("Already mapped!");
-        if (GLExtensions.Sync)
-        {
-            ActiveIdx = GetNextBuffer();
-            GLBind.UniformBuffer(IDs[ActiveIdx]);
-            mapping = GL.MapBufferRange(GL.GL_UNIFORM_BUFFER, 0, size * stride,
-                GL.GL_MAP_WRITE_BIT | GL.GL_MAP_UNSYNCHRONIZED_BIT);
-        }
-        else
-        {
-            GLBind.UniformBuffer(IDs[ActiveIdx]);
-            mapping = GL.MapBufferRange(GL.GL_UNIFORM_BUFFER, 0, size * stride,
-                GL.GL_MAP_WRITE_BIT);
-        }
-
+        GL.BindBuffer(GL.GL_SHADER_STORAGE_BUFFER, ID);
+        mapping = GL.MapBufferRange(GL.GL_SHADER_STORAGE_BUFFER, 0, size * stride,
+            GL.GL_MAP_WRITE_BIT | GL.GL_MAP_INVALIDATE_BUFFER_BIT);
         return mapping;
     }
 
@@ -179,30 +72,7 @@ internal class GLStorageBuffer : IStorageBuffer
     {
         if (mapping == IntPtr.Zero) throw new InvalidOperationException("Not mapped!");
         mapping = IntPtr.Zero;
-        GLBind.UniformBuffer(IDs[ActiveIdx]);
-        GL.UnmapBuffer(GL.GL_UNIFORM_BUFFER);
-    }
-
-    public void Dispose()
-    {
-        for (int i = 0; i < ctx.BoundBuffers.Length; i++)
-        {
-            if (ctx.BoundBuffers[i] == this)
-            {
-                ctx.BoundBuffers[i] = null;
-            }
-        }
-
-        for (int i = 0; i < Fences.Length; i++)
-        {
-            if (Fences[i] != 0)
-                GL.DeleteSync(Fences[i]);
-        }
-
-        for (int i = 0; i < IDs.Length; i++)
-        {
-            if (IDs[i] != 0)
-                GL.DeleteBuffer(IDs[i]);
-        }
+        GL.BindBuffer(GL.GL_SHADER_STORAGE_BUFFER, ID);
+        GL.UnmapBuffer(GL.GL_SHADER_STORAGE_BUFFER);
     }
 }

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLUniformStorageBuffer.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLUniformStorageBuffer.cs
@@ -3,13 +3,11 @@
 // LICENSE, which is part of this source code package
 
 using System;
-using System.Runtime.InteropServices;
 
 namespace LibreLancer.Graphics.Backends.OpenGL;
 
 internal class GLUniformStorageBuffer : IStorageBuffer
 {
-    private Type storageType;
     private int stride;
     private int size;
     private int gAlignment;
@@ -22,7 +20,7 @@ internal class GLUniformStorageBuffer : IStorageBuffer
     internal int ActiveIdx = 0;
 
 
-    public GLUniformStorageBuffer(int size, int stride, Type type, GLRenderContext ctx)
+    public GLUniformStorageBuffer(int size, int stride, GLRenderContext ctx)
     {
         if (stride % 16 != 0)
         {
@@ -33,7 +31,6 @@ internal class GLUniformStorageBuffer : IStorageBuffer
         this.size = size;
         this.ctx = ctx;
 
-        storageType = type;
         AllocateBufferIndex(0);
 
         GL.GetIntegerv(GL.GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, out int align);
@@ -153,8 +150,21 @@ internal class GLUniformStorageBuffer : IStorageBuffer
     }
 
 
-    // NOTE: Buffer orphaning doesn't seem to work for GL_UNIFORM_BUFFER
-    // under intel or renderdoc. Do some fancy work instead
+    /*
+     *  HERE BE DRAGONS
+     *
+     *  Ideally your hardware supports GL 4.3 and is using the GLStorageBuffer class
+     *  instead of all this mess. HOWEVER! This may not be the case
+     *
+     *  Hardware not yet tested: Intel Sandybridge, Intel Ivybridge,
+     *  AMD+nVidia not new enough to support GL 4.3
+     *
+     *  The sync structure here is to avoid GL_MAP_INVALIDATE_BUFFER_BIT causing large
+     *  frametime spikes on Intel+Mesa with GL_UNIFORM_BUFFER.
+     *
+     * Note: glBufferData NULL orphaning also does not work here. It also causes
+     * performance issues when running under renderdoc.
+     */
     public IntPtr BeginStreaming()
     {
         if (mapping != IntPtr.Zero) throw new InvalidOperationException("Already mapped!");

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLUniformStorageBuffer.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLUniformStorageBuffer.cs
@@ -1,0 +1,208 @@
+// MIT License - Copyright (c) Callum McGing
+// This file is subject to the terms and conditions defined in
+// LICENSE, which is part of this source code package
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace LibreLancer.Graphics.Backends.OpenGL;
+
+internal class GLUniformStorageBuffer : IStorageBuffer
+{
+    private Type storageType;
+    private int stride;
+    private int size;
+    private int gAlignment;
+    private IntPtr mapping;
+    private GLRenderContext ctx;
+
+    private bool allAllocated = false;
+    internal IntPtr[] Fences = [0, 0, 0];
+    internal uint[] IDs = [0, 0, 0];
+    internal int ActiveIdx = 0;
+
+
+    public GLUniformStorageBuffer(int size, int stride, Type type, GLRenderContext ctx)
+    {
+        if (stride % 16 != 0)
+        {
+            throw new Exception("Must be aligned to minimum 16");
+        }
+
+        this.stride = stride;
+        this.size = size;
+        this.ctx = ctx;
+
+        storageType = type;
+        AllocateBufferIndex(0);
+
+        GL.GetIntegerv(GL.GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, out int align);
+
+        var lval = stride % align;
+        gAlignment = lval == 0 ? 0 : align;
+#if DEBUG
+        if (align < 256 && 256 % align != 0)
+            gAlignment = 256; //Set larger alignment on debug for testing
+#endif
+    }
+
+    void AllocateBufferIndex(int idx)
+    {
+        IDs[idx] = GL.GenBuffer();
+        GLBind.UniformBuffer(IDs[idx]);
+        GL.BufferData(GL.GL_UNIFORM_BUFFER, new IntPtr(size * stride), IntPtr.Zero, GL.GL_DYNAMIC_DRAW);
+        allAllocated = true;
+        for (int i = 0; i < IDs.Length; i++)
+        {
+            if (IDs[i] == 0)
+            {
+                allAllocated = false;
+                break;
+            }
+        }
+    }
+
+    public int GetAlignedIndex(int input)
+    {
+        if (gAlignment == 0)
+        {
+            return input;
+        }
+
+        int offset = input * stride;
+        var aOffset = (offset + (gAlignment - 1)) & ~(gAlignment - 1);
+        return aOffset / stride;
+    }
+
+    public void BindTo(int binding, int start = 0, int count = 0)
+    {
+        if (GetAlignedIndex(start) != start)
+        {
+            throw new InvalidOperationException("Uniform buffer alignment error");
+        }
+
+        var startPtr = (IntPtr)(start * stride);
+        var length = (IntPtr)((count <= 0 ? size : count) * stride);
+        if ((long)startPtr + (long)length > (size * stride))
+            throw new IndexOutOfRangeException();
+
+        ctx.BindToIndex(binding, startPtr, length, this);
+    }
+
+    public unsafe ref T Data<T>(int i) where T : unmanaged
+    {
+        if (i >= size)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        if (mapping == IntPtr.Zero)
+        {
+            throw new InvalidOperationException();
+        }
+
+        return ref ((T*)mapping)[i];
+    }
+
+    int GetNextBuffer()
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            int idx = (ActiveIdx + i) % 3;
+            if (IDs[idx] == 0)
+                continue;
+            if (Fences[idx] == 0)
+            {
+                return idx;
+            }
+
+            var r = GL.ClientWaitSync(Fences[idx], 0, 0);
+            if (r == GL.GL_CONDITION_SATISFIED ||
+                r == GL.GL_ALREADY_SIGNALED)
+            {
+                GL.DeleteSync(Fences[i]);
+                Fences[i] = 0;
+                return idx;
+            }
+        }
+
+        if (allAllocated)
+        {
+            int idx = (ActiveIdx + 1);
+            uint r;
+            do
+            {
+                r = GL.ClientWaitSync(Fences[idx], 0, 1000);
+            } while (r != GL.GL_CONDITION_SATISFIED && r != GL.GL_ALREADY_SIGNALED);
+
+            GL.DeleteSync(Fences[idx]);
+            Fences[idx] = 0;
+            return idx;
+        }
+
+        for (int i = 0; i < IDs.Length; i++)
+        {
+            if (IDs[i] == 0)
+            {
+                AllocateBufferIndex(i);
+                return i;
+            }
+        }
+
+        throw new InvalidOperationException("Unreachable");
+    }
+
+
+    // NOTE: Buffer orphaning doesn't seem to work for GL_UNIFORM_BUFFER
+    // under intel or renderdoc. Do some fancy work instead
+    public IntPtr BeginStreaming()
+    {
+        if (mapping != IntPtr.Zero) throw new InvalidOperationException("Already mapped!");
+        if (GLExtensions.Sync)
+        {
+            ActiveIdx = GetNextBuffer();
+            GLBind.UniformBuffer(IDs[ActiveIdx]);
+            mapping = GL.MapBufferRange(GL.GL_UNIFORM_BUFFER, 0, size * stride,
+                GL.GL_MAP_WRITE_BIT | GL.GL_MAP_UNSYNCHRONIZED_BIT);
+        }
+        else
+        {
+            GLBind.UniformBuffer(IDs[ActiveIdx]);
+            mapping = GL.MapBufferRange(GL.GL_UNIFORM_BUFFER, 0, size * stride,
+                GL.GL_MAP_WRITE_BIT);
+        }
+
+        return mapping;
+    }
+
+    public void EndStreaming(int count)
+    {
+        if (mapping == IntPtr.Zero) throw new InvalidOperationException("Not mapped!");
+        mapping = IntPtr.Zero;
+        GLBind.UniformBuffer(IDs[ActiveIdx]);
+        GL.UnmapBuffer(GL.GL_UNIFORM_BUFFER);
+    }
+
+    public void Dispose()
+    {
+        for (int i = 0; i < ctx.BoundBuffers.Length; i++)
+        {
+            if (ctx.BoundBuffers[i] == this)
+            {
+                ctx.BoundBuffers[i] = null;
+            }
+        }
+
+        for (int i = 0; i < Fences.Length; i++)
+        {
+            if (Fences[i] != 0)
+                GL.DeleteSync(Fences[i]);
+        }
+
+        for (int i = 0; i < IDs.Length; i++)
+        {
+            if (IDs[i] != 0)
+                GL.DeleteBuffer(IDs[i]);
+        }
+    }
+}

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLUniformStorageBuffer.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLUniformStorageBuffer.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace LibreLancer.Graphics.Backends.OpenGL;
 
-internal class GLUniformStorageBuffer : IStorageBuffer
+internal sealed class GLUniformStorageBuffer : GLCycledBuffer, IStorageBuffer
 {
     private int stride;
     private int size;
@@ -14,13 +14,7 @@ internal class GLUniformStorageBuffer : IStorageBuffer
     private IntPtr mapping;
     private GLRenderContext ctx;
 
-    private bool allAllocated = false;
-    internal IntPtr[] Fences = [0, 0, 0];
-    internal uint[] IDs = [0, 0, 0];
-    internal int ActiveIdx = 0;
-
-
-    public GLUniformStorageBuffer(int size, int stride, GLRenderContext ctx)
+    public GLUniformStorageBuffer(int size, int stride, GLRenderContext ctx) : base(ctx)
     {
         if (stride % 16 != 0)
         {
@@ -43,20 +37,12 @@ internal class GLUniformStorageBuffer : IStorageBuffer
 #endif
     }
 
-    void AllocateBufferIndex(int idx)
+    protected override uint GenerateBuffer()
     {
-        IDs[idx] = GL.GenBuffer();
-        GLBind.UniformBuffer(IDs[idx]);
+        var id = GL.GenBuffer();
+        GLBind.UniformBuffer(id);
         GL.BufferData(GL.GL_UNIFORM_BUFFER, new IntPtr(size * stride), IntPtr.Zero, GL.GL_DYNAMIC_DRAW);
-        allAllocated = true;
-        for (int i = 0; i < IDs.Length; i++)
-        {
-            if (IDs[i] == 0)
-            {
-                allAllocated = false;
-                break;
-            }
-        }
+        return id;
     }
 
     public int GetAlignedIndex(int input)
@@ -83,7 +69,7 @@ internal class GLUniformStorageBuffer : IStorageBuffer
         if ((long)startPtr + (long)length > (size * stride))
             throw new IndexOutOfRangeException();
 
-        ctx.BindToIndex(binding, startPtr, length, this);
+        ctx.BindToIndex(GL.GL_UNIFORM_BUFFER, binding, startPtr, length, this);
     }
 
     public unsafe ref T Data<T>(int i) where T : unmanaged
@@ -101,74 +87,13 @@ internal class GLUniformStorageBuffer : IStorageBuffer
         return ref ((T*)mapping)[i];
     }
 
-    int GetNextBuffer()
-    {
-        for (int i = 0; i < 3; i++)
-        {
-            int idx = (ActiveIdx + i) % 3;
-            if (IDs[idx] == 0)
-                continue;
-            if (Fences[idx] == 0)
-            {
-                return idx;
-            }
 
-            var r = GL.ClientWaitSync(Fences[idx], 0, 0);
-            if (r == GL.GL_CONDITION_SATISFIED ||
-                r == GL.GL_ALREADY_SIGNALED)
-            {
-                GL.DeleteSync(Fences[i]);
-                Fences[i] = 0;
-                return idx;
-            }
-        }
-
-        if (allAllocated)
-        {
-            int idx = (ActiveIdx + 1);
-            uint r;
-            do
-            {
-                r = GL.ClientWaitSync(Fences[idx], 0, 1000);
-            } while (r != GL.GL_CONDITION_SATISFIED && r != GL.GL_ALREADY_SIGNALED);
-
-            GL.DeleteSync(Fences[idx]);
-            Fences[idx] = 0;
-            return idx;
-        }
-
-        for (int i = 0; i < IDs.Length; i++)
-        {
-            if (IDs[i] == 0)
-            {
-                AllocateBufferIndex(i);
-                return i;
-            }
-        }
-
-        throw new InvalidOperationException("Unreachable");
-    }
-
-
-    /*
-     *  HERE BE DRAGONS
-     *
-     *  Ideally your hardware supports GL 4.3 and is using the GLStorageBuffer class
-     *  instead of all this mess. HOWEVER! This may not be the case
-     *
-     *  Hardware not yet tested: Intel Sandybridge, Intel Ivybridge,
-     *  AMD+nVidia not new enough to support GL 4.3
-     *
-     *  The sync structure here is to avoid GL_MAP_INVALIDATE_BUFFER_BIT causing large
-     *  frametime spikes on Intel+Mesa with GL_UNIFORM_BUFFER.
-     *
-     * Note: glBufferData NULL orphaning also does not work here. It also causes
-     * performance issues when running under renderdoc.
-     */
+    // GL_MAP_INVALIDATE_BUFFER_BIT causes slowdowns on intel hardware.
+    // Use buffer cycling when possible, GL_ARB_sync not guaranteed to be supported.
     public IntPtr BeginStreaming()
     {
         if (mapping != IntPtr.Zero) throw new InvalidOperationException("Already mapped!");
-        if (GLExtensions.Sync)
+        if (ctx.FencedUBO)
         {
             ActiveIdx = GetNextBuffer();
             GLBind.UniformBuffer(IDs[ActiveIdx]);
@@ -191,28 +116,5 @@ internal class GLUniformStorageBuffer : IStorageBuffer
         mapping = IntPtr.Zero;
         GLBind.UniformBuffer(IDs[ActiveIdx]);
         GL.UnmapBuffer(GL.GL_UNIFORM_BUFFER);
-    }
-
-    public void Dispose()
-    {
-        for (int i = 0; i < ctx.BoundBuffers.Length; i++)
-        {
-            if (ctx.BoundBuffers[i] == this)
-            {
-                ctx.BoundBuffers[i] = null;
-            }
-        }
-
-        for (int i = 0; i < Fences.Length; i++)
-        {
-            if (Fences[i] != 0)
-                GL.DeleteSync(Fences[i]);
-        }
-
-        for (int i = 0; i < IDs.Length; i++)
-        {
-            if (IDs[i] != 0)
-                GL.DeleteBuffer(IDs[i]);
-        }
     }
 }

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLUniformStorageBuffer.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/GLUniformStorageBuffer.cs
@@ -16,11 +16,6 @@ internal sealed class GLUniformStorageBuffer : GLCycledBuffer, IStorageBuffer
 
     public GLUniformStorageBuffer(int size, int stride, GLRenderContext ctx) : base(ctx)
     {
-        if (stride % 16 != 0)
-        {
-            throw new Exception("Must be aligned to minimum 16");
-        }
-
         this.stride = stride;
         this.size = size;
         this.ctx = ctx;

--- a/src/LibreLancer.Base/Graphics/Backends/OpenGL/SyncPoint.cs
+++ b/src/LibreLancer.Base/Graphics/Backends/OpenGL/SyncPoint.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace LibreLancer.Graphics.Backends.OpenGL;
+
+class SyncPoint
+{
+	IntPtr handle = 0;
+	bool signalled = false;
+
+	public void Set()
+	{
+		handle = GL.FenceSync(GL.GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+	}
+
+	public bool Passed()
+	{
+		if(signalled)
+		{
+			return true;
+		}
+		if(handle == IntPtr.Zero)
+		{
+			return false;
+		}
+		uint r = GL.ClientWaitSync(handle, 0, 0);
+        if(r == GL.GL_CONDITION_SATISFIED || r == GL.GL_ALREADY_SIGNALED)
+        {
+			GL.DeleteSync(handle);
+			signalled = true;
+		}
+		return signalled;
+	}
+
+	public void Wait()
+	{
+		if(signalled || handle == IntPtr.Zero)
+			return;
+		uint r;
+        do
+        {
+            r = GL.ClientWaitSync(handle, 0, 1000);
+        } while (r != GL.GL_CONDITION_SATISFIED && r != GL.GL_ALREADY_SIGNALED);
+        signalled = true;
+        GL.DeleteSync(handle);
+        handle = IntPtr.Zero;
+	}
+}

--- a/src/LibreLancer.Base/Graphics/GraphicsFeature.cs
+++ b/src/LibreLancer.Base/Graphics/GraphicsFeature.cs
@@ -6,4 +6,5 @@ public enum GraphicsFeature
     Anisotropy,
     S3TC,
     DebugInfo,
+    LargeStorageBuffers
 }

--- a/src/LibreLancer.Base/Graphics/StorageBuffer.cs
+++ b/src/LibreLancer.Base/Graphics/StorageBuffer.cs
@@ -10,9 +10,9 @@ namespace LibreLancer.Graphics;
 public class StorageBuffer : IDisposable
 {
     private IStorageBuffer impl;
-    public StorageBuffer(RenderContext renderContext, int size, int stride, Type type)
+    public StorageBuffer(RenderContext renderContext, int size, int stride)
     {
-        impl = renderContext.Backend.CreateUniformBuffer(size, stride, type);
+        impl = renderContext.Backend.CreateStorageBuffer(size, stride);
     }
 
     public int GetAlignedIndex(int input) => impl.GetAlignedIndex(input);
@@ -21,7 +21,7 @@ public class StorageBuffer : IDisposable
     public void BindTo(int binding, int start = 0, int count = 0)
         => impl.BindTo(binding, start, count);
 
-    public unsafe ref T Data<T>(int i) where T : unmanaged
+    public ref T Data<T>(int i) where T : unmanaged
         => ref impl.Data<T>(i);
 
     public IntPtr BeginStreaming() => impl.BeginStreaming();

--- a/src/LibreLancer.Base/Graphics/StorageBuffer.cs
+++ b/src/LibreLancer.Base/Graphics/StorageBuffer.cs
@@ -12,6 +12,10 @@ public class StorageBuffer : IDisposable
     private IStorageBuffer impl;
     public StorageBuffer(RenderContext renderContext, int size, int stride)
     {
+        if (stride % 16 != 0)
+        {
+            throw new Exception("StorageBuffer must be aligned to minimum 16");
+        }
         impl = renderContext.Backend.CreateStorageBuffer(size, stride);
     }
 

--- a/src/LibreLancer.Base/Platform.cs
+++ b/src/LibreLancer.Base/Platform.cs
@@ -43,6 +43,22 @@ public static class Platform
         MountsChanged?.Invoke(mounts);
     }
 
+    private static readonly Dictionary<string, string> hintValues = new(StringComparer.OrdinalIgnoreCase);
+
+    internal static string GetHintString(string hint, string def) => hintValues.GetValueOrDefault(hint, def);
+
+    internal static bool GetHintBoolean(string hint, bool def)
+    {
+        if (hintValues.TryGetValue(hint, out var v))
+        {
+            if (v == "0" || v.Equals("false", StringComparison.OrdinalIgnoreCase))
+                return false;
+            if (v == "1" || v.Equals("true", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return def;
+    }
+
     static Platform ()
     {
         OSDescription = $"{RuntimeInformation.OSDescription} - {RuntimeInformation.ProcessArchitecture}";
@@ -83,6 +99,16 @@ public static class Platform
                 break;
         }
         RegisterDllMap(typeof(Platform).Assembly);
+        var env = Environment.GetEnvironmentVariables();
+        foreach (object key in env.Keys)
+        {
+            var k = key.ToString() ?? "";
+            if (!string.IsNullOrWhiteSpace(k))
+            {
+                string value = env[key]?.ToString() ?? "";
+                hintValues[k] = value;
+            }
+        }
     }
 
     internal static void Init(string sdlBackend) => RunningPlatform.Init(sdlBackend);

--- a/src/LibreLancer.Base/SDL/SDL3.cs
+++ b/src/LibreLancer.Base/SDL/SDL3.cs
@@ -15,7 +15,7 @@ internal static unsafe partial class SDL3
 
     static SDL3()
     {
-        if (Environment.GetEnvironmentVariable("LIBRELANCER_NO_SDL3") == "1")
+        if (Platform.GetHintBoolean("librelancer_no_sdl3", false))
         {
             Supported = false;
             return;

--- a/src/LibreLancer/Fx/ParticleEffectPool.cs
+++ b/src/LibreLancer/Fx/ParticleEffectPool.cs
@@ -48,6 +48,7 @@ namespace LibreLancer.Fx
         private StorageBuffer sbo;
 
         private CommandBuffer cmd;
+        private RenderContext ctx;
 
         private ParticleMaterial particleMaterial;
         private ParticleBeamMaterial beamMaterial;
@@ -58,9 +59,10 @@ namespace LibreLancer.Fx
         public ParticleEffectPool(RenderContext context, CommandBuffer commands)
         {
             cmd = commands;
+            ctx = context;
             // Set up vertices
             vbo = new VertexBuffer(context, typeof(VertexPositionColorTexture), 0);
-            sbo = new StorageBuffer(context, MaxParticles * PARTICLE_SIZE, PARTICLE_SIZE, typeof(ParticleData));
+            sbo = new StorageBuffer(context, MaxParticles * PARTICLE_SIZE, PARTICLE_SIZE);
             particleMaterial = new(sbo);
             beamMaterial = new(sbo);
         }
@@ -183,7 +185,8 @@ namespace LibreLancer.Fx
 
             int start = lastDrawCommand;
             int count = nextParticle - lastDrawCommand;
-            while (count > 256)
+            while (!ctx.HasFeature(GraphicsFeature.LargeStorageBuffers) &&
+                   count > 256)
             {
                 cmd.AddCommand(
                     particleMaterial, null,

--- a/src/LibreLancer/Render/CommandBuffer.cs
+++ b/src/LibreLancer/Render/CommandBuffer.cs
@@ -30,7 +30,7 @@ namespace LibreLancer.Render
         public CommandBuffer(RenderContext context)
         {
             rstate = context;
-            BonesBuffer = new StorageBuffer(context, 65536, 64, typeof(Matrix4x4));
+            BonesBuffer = new StorageBuffer(context, 65536, 64);
             WorldBuffer = new WorldMatrixBuffer();
         }
 


### PR DESCRIPTION
Changes the implementation of GLStorageBuffer to use the following strategy for mapping memory:

- When SSBOs are available, use a cycled SSBO with glFenceSync on the previous frame and GL_MAP_UNSYNCHRONIZED_BIT
- If no SSBOs, but GL_ARB_sync, cycled UBO with glFenceSync
- With no GL_ARB_sync, stall with just GL_MAP_WRITE_BIT

SSBO support is checked with the extension flags and GL_MAX_VERTEX_SHADER_STORAGE_BLOCKS, as some drivers (Zink) can return 0. SSBO support is also only currently enabled for desktop GL. Further work to `GLExtensions` and `GLShader` classes would be required for checking+enabling SSBO on GLES hardware.

SSBO support can be disabled with env var `librelancer_nossbo=1`. GL_ARB_sync for ubos can be disabled with `librelancer_fencedubo=0`.

**Implementation notes:**

- Previous buffer invalidation attempts for UBO/SSBO caused large frame drops on Intel hardware on Linux (TGL+HSW), with both GL_MAP_INVALIDATE_BUFFER_BIT or glBufferData NULL
- Cycling buffers seems to cause artifacting on Mesa+HSW, regardless of SSBO vs UBO. Solution is to direct HSW users to run with `MESA_LOADER_DRIVER_OVERRIDE=zink`
- We should be using SSBOs where supported, as that maps directly to the SPIR-V shaders we are using. UBOs work well but are an emulation of the StorageBuffer feature.
- Creating fences with glFenceSync multiple times a frame causes large frame drops on V3D (raspberry pi), so we can only realistically create one GL fence object per frame.

Misc:
- Moves environment variable checking to Platform.GetHint 


Thanks to @JimJamJamie for testing on TGL + HSW


