### PR TITLE
Add macOS arm64 build support

### DIFF
--- a/build.config
+++ b/build.config
@@ -2,3 +2,4 @@ DOTNET_VERSION=10.0
 USE_SYSTEM_DXC=0
 DXC_WINX64=https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2502/dxc_2025_02_20.zip
 DXC_LINUXX64=https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2502/linux_dxc_2025_02_20.x86_64.tar.gz
+DXC_OSXARM64=https://raw.githubusercontent.com/MethanePowered/DirectXShaderCompilerBinary/main/binaries/MacOS.zip

--- a/scripts/BuildLL/Program.cs
+++ b/scripts/BuildLL/Program.cs
@@ -190,6 +190,40 @@ namespace BuildLL
                 Console.WriteLine("Pre-built dxc extracted");
                 return;
             }
+            if (rid == "osx-arm64")
+            {
+                if (!File.Exists("obj/dxc.zip"))
+                {
+                    DownloadFile(Config["DXC_OSXARM64"], "obj/dxc.zip");
+                }
+                using (var zip = File.OpenRead("obj/dxc.zip"))
+                {
+                    ZipFile.ExtractToDirectory(zip, "obj/dxc-osx", true);
+                }
+                Directory.CreateDirectory("bin/builddeps/bin");
+                Directory.CreateDirectory("bin/builddeps/lib");
+                CopyDirContents("obj/dxc-osx/MacOS/bin", "bin/builddeps/bin", false, "*");
+                CopyDirContents("obj/dxc-osx/MacOS/lib", "bin/builddeps/lib", false, "*");
+                // .NET ZipFile extracts symlinks as tiny text files containing the link target,
+                // not as the binary itself. Replace each with a copy of its versioned target.
+                foreach (var link in Directory.GetFiles("bin/builddeps/bin"))
+                {
+                    if (Path.GetFileName(link).Contains('-')) continue;
+                    if (new FileInfo(link).Length > 1024) continue;
+                    var target = File.ReadAllText(link).Trim();
+                    var resolved = Path.Combine("bin/builddeps/bin", target);
+                    if (File.Exists(resolved)) File.Copy(resolved, link, true);
+                }
+                foreach (var f in Directory.GetFiles("bin/builddeps/bin"))
+                {
+                    File.SetUnixFileMode(f,
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+                }
+                Console.WriteLine("Pre-built dxc extracted");
+                return;
+            }
             throw new Exception(
                 $"dxc not available, and platform is {rid}. Please install from source: https://github.com/microsoft/DirectXShaderCompiler");
         }
@@ -251,6 +285,7 @@ namespace BuildLL
                 }
                 CopyDirContents("obj/spirvcross", "bin/builddeps", false, "*.so");
                 CopyDirContents("obj/spirvcross", "bin/builddeps", false, "*.dll");
+                CopyDirContents("obj/spirvcross", "bin/builddeps", false, "*.dylib");
                 if(IsWindows)
                 {
                     CopyDirContents("obj/spirvcross/MinSizeRel", "bin/builddeps", false, "*.dll");

--- a/src/LLShaderCompiler/LLShaderCompiler.csproj
+++ b/src/LLShaderCompiler/LLShaderCompiler.csproj
@@ -14,6 +14,9 @@
       <Content Include="$(MSBuildThisFileDirectory)\..\..\bin\builddeps\*.dll">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
+      <Content Include="$(MSBuildThisFileDirectory)\..\..\bin\builddeps\*.dylib">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="ZstdSharp.Port" Version="0.8.6" />


### PR DESCRIPTION
on macOS arm64 the build currently fails in three spots: `FindDXC()` has no Apple branch (Microsoft doesn't ship a Mac dxc binary so the Linux/Windows download URLs don't help), the spirv-cross copy in `ShaderDependencies` only globs `*.so` and `*.dll` so `libspirv-cross-c-shared.dylib` never reaches `bin/builddeps`, and `LLShaderCompiler.csproj` only includes `*.so` and `*.dll` from `bin/builddeps` so even when the dylib is there it doesn't land next to the binary at runtime

this PR adds an `osx-arm64` branch in `FindDXC()` that downloads MethanePowered's prebuilt arm64 dxc (https://github.com/MethanePowered/DirectXShaderCompilerBinary, derived from upstream), unpacks it into `bin/builddeps/{bin,lib}`, and replaces the symlinks `System.IO.Compression.ZipFile` extracts as 7-byte text files with copies of the versioned binaries. adds `DXC_OSXARM64` to `build.config`, the `*.dylib` globs in both spots, and bumps the blurgtext submodule SHA to pick up the macOS fontconfig branch (depends on https://github.com/CallumDev/blurgtext/pull/2)

builds clean from a fresh checkout on Apple Silicon with `brew install dotnet cmake fontconfig openal-soft sdl2 pkg-config` and produces a working arm64 native binary. Windows and Linux paths untouched 🕺

<img width="1093" height="878" alt="Screenshot 2026-05-15 at 10 57 48" src="https://github.com/user-attachments/assets/67c3c1cd-c85b-45d5-9a68-18ecc1ab31cc" />
