### PR TITLE
VS2026 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 3.15)
 
 project (librelancernatives)
 set(CMAKE_C_STANDARD 99)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 set(LIBOUTPUTDIR ${CMAKE_BINARY_DIR}/binaries)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${LIBOUTPUTDIR})

--- a/scripts/BuildLL/Program.cs
+++ b/scripts/BuildLL/Program.cs
@@ -256,12 +256,12 @@ namespace BuildLL
                 if (IsWindows) {
                     CMake.Run("extern/SPIRV-Cross", new CMakeSettings() {
                         OutputPath = "obj/spirvcross",
-                        Generator = "Visual Studio 17 2022",
+                        Generator = "Visual Studio 18 2026",
                         Platform = "x64",
                         BuildType = "MinSizeRel",
                         Options = new[] { "-DSPIRV_CROSS_SHARED=ON", "-DSPIRV_CROSS_STATIC=OFF", "-DSPIRV_CROSS_CLI=OFF", "-DSPIRV_CROSS_ENABLE_TESTS=OFF"}
                     });
-                    MSBuild.Run("./obj/spirvcross/SPIRV-Cross.sln", "/m /p:Configuration=MinSizeRel", VSVersion.VS2022, MSBuildPlatform.x86);
+                    MSBuild.Run("./obj/spirvcross/SPIRV-Cross.slnx", "/m /p:Configuration=MinSizeRel", VSVersion.VS2026, MSBuildPlatform.x86);
                 } else {
                     CMake.Run("extern/SPIRV-Cross", new CMakeSettings()
                     {
@@ -307,23 +307,23 @@ namespace BuildLL
                         CMake.Run(".", new CMakeSettings()
                         {
                             OutputPath = "obj/x86",
-                            Generator = "Visual Studio 17 2022",
+                            Generator = "Visual Studio 18 2026",
                             Platform = "Win32",
                             BuildType = config
                         });
-                        MSBuild.Run("./obj/x86/librelancernatives.sln", $"/m /p:Configuration={config}",
-                            VSVersion.VS2022, MSBuildPlatform.x86);
+                        MSBuild.Run("./obj/x86/librelancernatives.slnx", $"/m /p:Configuration={config}",
+                            VSVersion.VS2026, MSBuildPlatform.x86);
                         CopyDirContents("./obj/x86/binaries/", "./bin/natives/x86", false, "*.dll");
                         if (buildDebug || buildO0) CopyDirContents("./obj/x86/binaries/", "./bin/natives/x86", false, "*.pdb");
                     }
                     //build 64-bit
                     CMake.Run(".", new CMakeSettings() {
                         OutputPath = "obj/x64",
-                        Generator = "Visual Studio 17 2022",
+                        Generator = "Visual Studio 18 2026",
                         Platform = "x64",
                         BuildType = config
                     });
-                    MSBuild.Run("./obj/x64/librelancernatives.sln", $"/m /p:Configuration={config}", VSVersion.VS2022, MSBuildPlatform.x64);
+                    MSBuild.Run("./obj/x64/librelancernatives.slnx", $"/m /p:Configuration={config}", VSVersion.VS2026, MSBuildPlatform.x64);
                     CopyDirContents("./obj/x64/binaries/", "./bin/natives/x64", false, "*.dll");
                     if (buildDebug || buildO0) CopyDirContents("./obj/x64/binaries/", "./bin/natives/x64", false, "*.pdb");
 

--- a/scripts/BuildLL/Runtime/MSBuild.cs
+++ b/scripts/BuildLL/Runtime/MSBuild.cs
@@ -8,7 +8,8 @@ namespace BuildLL
     public enum VSVersion
     {
         VS2019,
-        VS2022
+        VS2022,
+        VS2026
     }
     public enum MSBuildPlatform
     {
@@ -59,6 +60,11 @@ namespace BuildLL
              if (vs == VSVersion.VS2022) {
                 msbuild = VSPath("2022", _editions, "Current", platform);
                 if (msbuild == null) msbuild = VSPath("2022", _editions, "17.0", platform);
+            }
+
+            if (vs == VSVersion.VS2026) {
+                msbuild = VSPath("18", _editions, "Current", platform);
+                if (msbuild == null) msbuild = VSPath("18", _editions, "18.0", platform);
             }
 
             if (msbuild == null)


### PR DESCRIPTION
This is not to be merged but to be reviewed.

Bumped CXX standard to 20 to stop `expr.h` from failing the build.

`MSBuild.cs` can be merged as-is. Note that the VS product folder naming convention has changed from *year* to *version*.

Program.cs is hardcoded in such a way that VS2026 will not build without editing it as I have done here. Ideally we can come up with a solution here that works for VS2022 onwards with some sort of automated detection.

Also note that the generated solution files for VS2026 are sln**x** files instead of sln. I had to edit the solution path definitions accordingly. I have no idea how to change this behaviour in CMake or Visual Studio. If it isn't possible then a switch will be required if VS2026 or higher is detected.