### PR TITLE
Add improved cruise and speed control for formations

### DIFF
--- a/src/LibreLancer.Tests/InputUpdatePacketTests.cs
+++ b/src/LibreLancer.Tests/InputUpdatePacketTests.cs
@@ -21,6 +21,7 @@ public class InputUpdatePacketTests
             Steering = Vector3.UnitY,
             Strafe = StrafeControls.Left,
             Throttle = 1,
+            CruiseSpeedOffset = -1,
             Thrust = false,
             Tick = 98
         };
@@ -36,6 +37,7 @@ public class InputUpdatePacketTests
         Assert.Equal(pkt.Acks, pkt2.Acks);
         Assert.Equal(pkt.SelectedObject, pkt2.SelectedObject);
         Assert.Equal(pkt.Current.Tick, pkt2.Current.Tick);
+        Assert.Equal(pkt.Current.CruiseSpeedOffset, pkt2.Current.CruiseSpeedOffset);
 
     }
 }

--- a/src/LibreLancer/Client/CGameSession.Space.cs
+++ b/src/LibreLancer/Client/CGameSession.Space.cs
@@ -30,6 +30,7 @@ public partial class CGameSession
         public Vector3 Steering;
         public Vector3 AimPoint;
         public float Throttle;
+        public float CruiseSpeedOffset;
         public StrafeControls Strafe;
         public bool Thrust;
         public bool EngineKill;
@@ -77,6 +78,7 @@ public partial class CGameSession
             Strafe = moveState[^i].Strafe,
             Throttle = moveState[^i].Throttle,
             Cruise = moveState[^i].CruiseEnabled,
+            CruiseSpeedOffset = moveState[^i].CruiseSpeedOffset,
             Thrust = moveState[^i].Thrust,
             EngineKill = moveState[^1].EngineKill,
             FireCommand = moveState[^i].FireCommand
@@ -113,6 +115,7 @@ public partial class CGameSession
                 AimPoint = wp.AimPoint,
                 Strafe = phys.CurrentStrafe,
                 Throttle = phys.EnginePower,
+                CruiseSpeedOffset = steering.Cruise ? steering.CruiseSpeedOffset : 0,
                 Thrust = steering.Thrust,
                 CruiseEnabled = steering.Cruise,
                 EngineKill = steering.EngineKill,
@@ -327,8 +330,7 @@ public partial class CGameSession
                 gp.player.SetLocalTransform(new Transform3D(state.Position, state.Orientation));
                 gp.player.PhysicsComponent!.Body!.LinearVelocity = state.LinearVelocity;
                 gp.player.PhysicsComponent.Body.AngularVelocity = state.AngularVelocity;
-                phys.ChargePercent = state.CruiseChargePct;
-                phys.CruiseAccelPct = state.CruiseAccelPct;
+                phys.SetCruiseState(state.CruiseChargePct, state.CruiseAccelPct);
 
                 // simulate inputs - only outside a tradelane. we go back in time for a tradelane a bit
                 for (i = i + 1; i < moveState.Count; i++)
@@ -353,6 +355,7 @@ public partial class CGameSession
         {
             eng.Speed = update.Throttle;
             eng.EngineKill = update.EngineKill;
+            eng.CruiseThrust = update.CruiseThrust;
             foreach (var comp in obj.GetChildComponents<CThrusterComponent>())
                 comp.Enabled = update.CruiseThrust == CruiseThrustState.Thrusting;
         }
@@ -390,6 +393,8 @@ public partial class CGameSession
         var player = gameplay.player;
         physComponent!.CurrentStrafe = moveState[i].Strafe;
         physComponent.EnginePower = moveState[i].Throttle;
+        physComponent.CruiseEnabled = moveState[i].CruiseEnabled;
+        physComponent.CruiseSpeedOffset = moveState[i].CruiseEnabled ? moveState[i].CruiseSpeedOffset : 0;
         physComponent.Steering = moveState[i].Steering;
         physComponent.ThrustEnabled = moveState[i].Thrust;
         physComponent.EngineKillEnabled = moveState[i].EngineKill;

--- a/src/LibreLancer/Net/Protocol/Packets.cs
+++ b/src/LibreLancer/Net/Protocol/Packets.cs
@@ -981,6 +981,7 @@ namespace LibreLancer.Net.Protocol
         public StrafeControls Strafe;
         public float Throttle;
         public bool Cruise;
+        public float CruiseSpeedOffset;
         public bool Thrust;
         public bool EngineKill;
         public ProjectileFireCommand? FireCommand;
@@ -1008,14 +1009,22 @@ namespace LibreLancer.Net.Protocol
         [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
         private static void WriteDelta(ref BitWriter writer, ref NetInputControls baseline, ref NetInputControls cur)
         {
+            cur.CruiseSpeedOffset = cur.Cruise ? cur.CruiseSpeedOffset : 0;
+            baseline.CruiseSpeedOffset = baseline.Cruise ? baseline.CruiseSpeedOffset : 0;
             writer.PutVarInt32((int)((long)cur.Tick - baseline.Tick));
             writer.PutUInt((uint)cur.Strafe, 4);
             writer.PutBool(cur.Cruise);
             writer.PutBool(cur.Thrust);
             writer.PutBool(cur.EngineKill);
+            writer.PutBool(cur.CruiseSpeedOffset != baseline.CruiseSpeedOffset);
             writer.PutBool(cur.Throttle != baseline.Throttle);
             writer.PutBool(cur.Steering != baseline.Steering);
             writer.PutBool(cur.AimPoint != baseline.AimPoint);
+            if (cur.CruiseSpeedOffset != baseline.CruiseSpeedOffset)
+            {
+                writer.PutFloat(cur.CruiseSpeedOffset);
+            }
+
             if(cur.Throttle != baseline.Throttle)
             {
                 writer.PutFloat(cur.Throttle);
@@ -1098,9 +1107,11 @@ namespace LibreLancer.Net.Protocol
                 Thrust = reader.GetBool(),
                 EngineKill = reader.GetBool(),
             };
+            bool readCruiseSpeedOffset = reader.GetBool();
             bool readThrottle = reader.GetBool();
             bool readSteering = reader.GetBool();
             bool readAimPoint = reader.GetBool();
+            nc.CruiseSpeedOffset = readCruiseSpeedOffset ? reader.GetFloat() : baseline.CruiseSpeedOffset;
             nc.Throttle = readThrottle ? reader.GetFloat() : baseline.Throttle;
             nc.Steering = readSteering ? reader.GetVector3() : baseline.Steering;
             nc.AimPoint = readAimPoint ? reader.GetVector3() : baseline.AimPoint;
@@ -1123,6 +1134,7 @@ namespace LibreLancer.Net.Protocol
             p.Current.Cruise = br.GetBool();
             p.Current.Thrust = br.GetBool();
             p.Current.EngineKill = br.GetBool();
+            p.Current.CruiseSpeedOffset = br.GetBool() ? br.GetFloat() : 0;
             var throttle = br.GetUInt(2);
             if (throttle == 0)
             {
@@ -1145,6 +1157,10 @@ namespace LibreLancer.Net.Protocol
         [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
         public void WriteContents(PacketWriter outPacket)
         {
+            Current.CruiseSpeedOffset = Current.Cruise ? Current.CruiseSpeedOffset : 0;
+            HistoryA.CruiseSpeedOffset = HistoryA.Cruise ? HistoryA.CruiseSpeedOffset : 0;
+            HistoryB.CruiseSpeedOffset = HistoryB.Cruise ? HistoryB.CruiseSpeedOffset : 0;
+            HistoryC.CruiseSpeedOffset = HistoryC.Cruise ? HistoryC.CruiseSpeedOffset : 0;
             var bw = new BitWriter();
             bw.PutVarUInt32(Acks.Tick);
             bw.PutUInt(Acks.History0, 32);
@@ -1157,9 +1173,15 @@ namespace LibreLancer.Net.Protocol
             bw.PutBool(Current.Cruise);
             bw.PutBool(Current.Thrust);
             bw.PutBool(Current.EngineKill);
+            bw.PutBool(Current.CruiseSpeedOffset != 0);
+            if (Current.CruiseSpeedOffset != 0)
+            {
+                bw.PutFloat(Current.CruiseSpeedOffset);
+            }
+
             if (Current.Throttle == 0){
                 bw.PutUInt(0, 2);
-            } else if (Current.Throttle >= 1){
+            } else if (Current.Throttle == 1){
                 bw.PutUInt(1,2);
             }else {
                 bw.PutUInt(2, 2);

--- a/src/LibreLancer/Server/Components/SEngineComponent.cs
+++ b/src/LibreLancer/Server/Components/SEngineComponent.cs
@@ -3,6 +3,7 @@
 // LICENSE, which is part of this source code package
 
 using LibreLancer.Data.GameData.Items;
+using LibreLancer.Net.Protocol;
 using LibreLancer.World;
 
 namespace LibreLancer.Server.Components
@@ -12,5 +13,6 @@ namespace LibreLancer.Server.Components
         public EngineEquipment Engine = engine;
         public float Speed;
         public bool EngineKill;
+        public CruiseThrustState CruiseThrust;
     }
 }

--- a/src/LibreLancer/Server/Components/SPlayerComponent.cs
+++ b/src/LibreLancer/Server/Components/SPlayerComponent.cs
@@ -238,6 +238,49 @@ namespace LibreLancer.Server.Components
         }
 
         private ulong formationHash = 0;
+        private const float FormationSlotCruiseCatchupDistance = 800;
+        private const float FormationLeaderCruiseCatchupDistance = 450;
+
+        private static Vector3 ShipPosition(GameObject ship) =>
+            ship.PhysicsComponent?.Body?.Position ?? ship.WorldTransform.Position;
+
+        private static bool LocalCruiseStarted(GameObject ship) =>
+            ship.TryGetComponent<ShipPhysicsComponent>(out var phys) &&
+            phys.CruiseEnabled &&
+            phys.EngineState is EngineStates.CruiseCharging or EngineStates.Cruise;
+
+        private static bool ShipIsCruising(GameObject ship)
+        {
+            if (LocalCruiseStarted(ship))
+            {
+                return true;
+            }
+
+            return ship.TryGetComponent<SEngineComponent>(out var engine) &&
+                   engine.CruiseThrust is CruiseThrustState.CruiseCharging or CruiseThrustState.Cruising;
+        }
+
+        private bool AllowFormationCruise()
+        {
+            if (Parent.Formation == null || Parent.Formation.LeadShip == Parent)
+            {
+                return true;
+            }
+
+            var body = Parent.PhysicsComponent?.Body;
+            if (body == null)
+            {
+                return false;
+            }
+
+            var lead = Parent.Formation.LeadShip;
+            var targetPoint = Parent.Formation.GetShipPosition(Parent, true);
+
+            return Vector3.Distance(targetPoint, body.Position) <= FormationSlotCruiseCatchupDistance ||
+                   Vector3.Distance(ShipPosition(lead), body.Position) > FormationLeaderCruiseCatchupDistance ||
+                   ShipIsCruising(lead) ||
+                   LocalCruiseStarted(Parent);
+        }
 
         public override void Update(double time, GameWorld world)
         {
@@ -254,17 +297,20 @@ namespace LibreLancer.Server.Components
                         phys.Steering = Vector3.Zero;
                         phys.CurrentStrafe = StrafeControls.None;
                         phys.EnginePower = 0;
+                        phys.CruiseSpeedOffset = 0;
                         phys.ThrustEnabled = false;
                         phys.CruiseEnabled = false;
                         phys.EngineKillEnabled = false;
                     }
                     else
                     {
+                        var cruise = input.Cruise && AllowFormationCruise();
                         phys.Steering = input.Steering;
                         phys.CurrentStrafe = input.Strafe;
                         phys.EnginePower = input.Throttle;
+                        phys.CruiseSpeedOffset = cruise ? input.CruiseSpeedOffset : 0;
                         phys.ThrustEnabled = input.Thrust;
-                        phys.CruiseEnabled = input.Cruise;
+                        phys.CruiseEnabled = cruise;
                         phys.EngineKillEnabled = input.EngineKill;
                         if (input.FireCommand != null)
                             world.Server!.FireProjectiles(input.FireCommand.Value, Player);

--- a/src/LibreLancer/Server/SpacePlayer.cs
+++ b/src/LibreLancer/Server/SpacePlayer.cs
@@ -4,6 +4,7 @@ using LibreLancer.Net;
 using LibreLancer.Net.Protocol;
 using LibreLancer.Server.Components;
 using LibreLancer.World;
+using LibreLancer.World.Components;
 
 namespace LibreLancer.Server;
 

--- a/src/LibreLancer/World/Components/AutopilotComponent.cs
+++ b/src/LibreLancer/World/Components/AutopilotComponent.cs
@@ -6,6 +6,7 @@ using System;
 using System.Linq;
 using System.Numerics;
 using LibreLancer.Client.Components;
+using LibreLancer.Net.Protocol;
 
 namespace LibreLancer.World.Components
 {
@@ -332,6 +333,100 @@ namespace LibreLancer.World.Components
     {
         public override AutopilotBehaviors Behavior => AutopilotBehaviors.Formation;
 
+        private const float CruiseDampenDistance = 250;
+        private const float ThrottleDampenDistance = 125;
+        private const float LeaderCruiseCatchupDistance = 450;
+        private const float FormationSpeedBoost = 0.1f;
+        private const float MaxFormationCruiseSpeedReduction = 5;
+        private const float FormationFacingDistance = 100;
+        private const float ThrottleMatchDistance = 100;
+        private const float MinCatchupThrottle = 0.35f;
+
+        private static bool LeadIsCruising(GameObject lead)
+        {
+            if (lead.TryGetComponent<ShipPhysicsComponent>(out var leadControl) &&
+                (leadControl.CruiseEnabled ||
+                 leadControl.EngineState is EngineStates.Cruise or EngineStates.CruiseCharging))
+            {
+                return true;
+            }
+
+            return lead.TryGetComponent<CEngineComponent>(out var eng) &&
+                   eng.CruiseThrust is CruiseThrustState.Cruising or CruiseThrustState.CruiseCharging;
+        }
+
+        private static float LeadThrottle(GameObject lead)
+        {
+            if (lead.TryGetComponent<ShipPhysicsComponent>(out var leadControl))
+            {
+                return leadControl.EnginePower;
+            }
+
+            if (lead.TryGetComponent<CEngineComponent>(out var eng))
+            {
+                return MathHelper.Clamp(eng.Speed / 0.9f, 0, 1);
+            }
+
+            return 0;
+        }
+
+        private static float ApproachThrottle(float distance, float leadThrottle)
+        {
+            if (distance > ThrottleDampenDistance)
+            {
+                return 1 + FormationSpeedBoost;
+            }
+
+            if (distance > ThrottleMatchDistance)
+            {
+                var throttle = MathHelper.Lerp(MinCatchupThrottle, 1, distance / ThrottleDampenDistance);
+                return MathF.Max(leadThrottle, throttle);
+            }
+
+            return leadThrottle;
+        }
+
+        private static float CruiseSpeedOffset(float distance)
+        {
+            var dampen = 1 - MathHelper.Clamp(distance / CruiseDampenDistance, 0, 1);
+            return -MaxFormationCruiseSpeedReduction * dampen;
+        }
+
+        private static Vector3 ShipPosition(GameObject ship) =>
+            ship.PhysicsComponent?.Body?.Position ?? ship.WorldTransform.Position;
+
+        private static float ShipSpeed(GameObject ship)
+        {
+            return ship.PhysicsComponent?.Body?.LinearVelocity.Length() ?? 0;
+        }
+
+        private bool ShouldCruise(GameObject lead)
+        {
+            var leaderDistance = Vector3.Distance(ShipPosition(lead), Parent.PhysicsComponent!.Body!.Position);
+            return LeadIsCruising(lead) || leaderDistance > LeaderCruiseCatchupDistance;
+        }
+
+        private static Vector3? FormationFacingPoint(GameObject self, GameObject lead, Vector3 targetPoint, float distance)
+        {
+            if (distance > FormationFacingDistance)
+            {
+                return targetPoint;
+            }
+
+            if (ShipSpeed(self) > ShipSpeed(lead) + 20)
+            {
+                return targetPoint;
+            }
+
+            var leadVelocity = lead.PhysicsComponent?.Body?.LinearVelocity ?? Vector3.Zero;
+            if (leadVelocity.LengthSquared() > 400)
+            {
+                return self.WorldTransform.Position + Vector3.Normalize(leadVelocity) * 1000;
+            }
+
+            return null;
+        }
+
         public override bool Update(ShipSteeringComponent control, ShipInputComponent? input, double time)
         {
             if (Parent.Formation == null ||
@@ -340,36 +435,26 @@ namespace LibreLancer.World.Components
                 return true;
             }
 
+            var body = Parent.PhysicsComponent!.Body!;
             var targetPoint = Parent.Formation.GetShipPosition(Parent, Component.LocalPlayer);
-            var distance = (targetPoint - Parent.PhysicsComponent!.Body!.Position).Length();
+            var distance = (targetPoint - body.Position).Length();
             var lead = Parent.Formation.LeadShip;
+            var leadThrottle = LeadThrottle(lead);
+            var selfPhysics = Parent.GetComponent<ShipPhysicsComponent>();
 
-            if (distance > 2000)
-            {
-                control.Cruise = true;
-            }
-            else if (distance > 100)
-            {
-                SetThrottle(1, control, input);
-            }
+            control.Cruise = ShouldCruise(lead);
+            control.CruiseSpeedOffset =
+                control.Cruise &&
+                selfPhysics?.EngineState == EngineStates.Cruise &&
+                distance < CruiseDampenDistance
+                    ? CruiseSpeedOffset(distance)
+                    : 0;
+            SetThrottle(ApproachThrottle(distance, leadThrottle), control, input);
 
-            var minThrottle = distance > 100 ? 1 : 0;
-
-            if (lead.TryGetComponent<ShipPhysicsComponent>(out var leadControl))
+            var facingPoint = FormationFacingPoint(Parent, lead, targetPoint, distance);
+            if (facingPoint != null)
             {
-                control.Cruise = distance > 2000 || leadControl.CruiseEnabled;
-                SetThrottle(MathF.Max(minThrottle, leadControl.EnginePower), control, input);
-            }
-            else if (lead.TryGetComponent<CEngineComponent>(out var eng))
-            {
-                control.Cruise = distance > 2000 || eng.Speed > 0.9f;
-                var pThrottle = MathHelper.Clamp(eng.Speed / 0.9f, 0, 1);
-                SetThrottle(MathF.Max(minThrottle, pThrottle), control, input);
-            }
-
-            if (distance > 30)
-            {
-                TurnTowards(time, targetPoint);
+                TurnTowards(time, facingPoint.Value);
             }
             else
             {
@@ -449,6 +534,24 @@ namespace LibreLancer.World.Components
 
         public void StartFormation()
         {
+            if (Parent.TryGetComponent<ShipPhysicsComponent>(out var physics))
+            {
+                physics.StopCruise();
+            }
+
+            if (Parent.TryGetComponent<ShipSteeringComponent>(out var steering))
+            {
+                steering.Cruise = false;
+                steering.CruiseSpeedOffset = 0;
+                steering.InThrottle = 1;
+            }
+
+            if (Parent.TryGetComponent<ShipInputComponent>(out var input))
+            {
+                input.AutopilotThrottle = 1;
+                input.InFormation = true;
+            }
+
             SetInstance(new FormationBehavior(this));
             instance?.Start(GotoKind.Goto, Vector3.Zero, 1, 10);
         }
@@ -468,6 +571,8 @@ namespace LibreLancer.World.Components
             {
                 return;
             }
+
+            control.CruiseSpeedOffset = 0;
 
             if (instance == null)
             {

--- a/src/LibreLancer/World/Components/AutopilotComponent.cs
+++ b/src/LibreLancer/World/Components/AutopilotComponent.cs
@@ -336,7 +336,7 @@ namespace LibreLancer.World.Components
         private const float CruiseDampenDistance = 250;
         private const float ThrottleDampenDistance = 125;
         private const float LeaderCruiseCatchupDistance = 450;
-        private const float FormationSpeedBoost = 0.1f;
+        private const float FormationSpeedBoost = 0.2f;
         private const float MaxFormationCruiseSpeedReduction = 5;
         private const float FormationFacingDistance = 100;
         private const float ThrottleMatchDistance = 100;

--- a/src/LibreLancer/World/Components/ShipPhysicsComponent.cs
+++ b/src/LibreLancer/World/Components/ShipPhysicsComponent.cs
@@ -35,7 +35,14 @@ namespace LibreLancer.World.Components
                                        // TODO: I forget how this is configured in .ini files. Constants.ini?
                                        // Some mods have a per-ship (engine?) cruise speed. Check how this is implemented, and include as native feature.
         public bool ThrustEnabled = false;
-        public bool CruiseEnabled = false;
+        private bool cruiseEnabled = false;
+        private bool previousCruiseEnabled = false;
+        public bool CruiseEnabled
+        {
+            get => cruiseEnabled;
+            set => cruiseEnabled = value;
+        }
+        public float CruiseSpeedOffset = 0;
         public bool EngineKillEnabled = false;
         public EngineStates EngineState { get; private set; }
         public StrafeControls CurrentStrafe = StrafeControls.None;
@@ -51,24 +58,67 @@ namespace LibreLancer.World.Components
 
         // TODO: Engine Kill
 
+        private void StartCruiseCharge()
+        {
+            EngineState = EngineStates.CruiseCharging;
+            ChargePercent = 0f;
+            CruiseAccelPct = 0f;
+        }
+
+        public void StopCruise()
+        {
+            cruiseEnabled = false;
+            previousCruiseEnabled = false;
+            CruiseSpeedOffset = 0f;
+            EngineState = EngineStates.Standard;
+            ChargePercent = 0f;
+            CruiseAccelPct = 0f;
+        }
+
+        public void SetCruiseState(float chargePercent, float accelPercent)
+        {
+            chargePercent = MathHelper.Clamp(chargePercent, 0f, 1f);
+            accelPercent = MathHelper.Clamp(accelPercent, 0f, 1f);
+
+            if (chargePercent <= 0f && accelPercent <= 0f)
+            {
+                StopCruise();
+                return;
+            }
+
+            cruiseEnabled = true;
+            previousCruiseEnabled = true;
+            ChargePercent = chargePercent;
+            CruiseAccelPct = accelPercent;
+            EngineState = chargePercent >= 1f ? EngineStates.Cruise : EngineStates.CruiseCharging;
+        }
+
         public void ResyncChargePercent(float prev, float time)
         {
-            if (EngineState is EngineStates.Cruise or EngineStates.CruiseCharging)
+            if (prev <= 0f && EngineState is not (EngineStates.Cruise or EngineStates.CruiseCharging))
             {
-                var engine = Parent.GetComponent<SEngineComponent>()!; // Get mounted engine
-                ChargePercent = prev + (1.0f / engine.Engine.Def.CruiseChargeTime) * (float) time;
-                if (ChargePercent >= 1) {
-                    ChargePercent = 1;
-                    EngineState = EngineStates.Cruise;
-                }
-                else {
-                    EngineState = EngineStates.CruiseCharging;
-                }
+                return;
+            }
+
+            SetCruiseState(prev, CruiseAccelPct);
+            var engine = Parent.GetComponent<SEngineComponent>()!; // Get mounted engine
+            ChargePercent = prev + (1.0f / engine.Engine.Def.CruiseChargeTime) * (float) time;
+            if (ChargePercent >= 1) {
+                ChargePercent = 1;
+                EngineState = EngineStates.Cruise;
+            }
+            else {
+                EngineState = EngineStates.CruiseCharging;
             }
         }
 
         public void ResyncCruiseAccel(float prev, float time)
         {
+            if (prev > 0f && EngineState != EngineStates.Cruise)
+            {
+                SetCruiseState(1f, prev);
+            }
+
             if (EngineState == EngineStates.Cruise)
             {
                 var engine = Parent.GetComponent<SEngineComponent>()!; // Get mounted engine
@@ -82,12 +132,12 @@ namespace LibreLancer.World.Components
             if (!Active) return;
             if (CruiseEnabled)
             {
-                if (EngineState != EngineStates.Cruise &&
+                if (!previousCruiseEnabled ||
+                    (EngineState != EngineStates.Cruise &&
                     EngineState != EngineStates.CruiseCharging)
+                   )
                 {
-                    EngineState = EngineStates.CruiseCharging;
-                    ChargePercent = 0f;
-                    CruiseAccelPct = 0f;
+                    StartCruiseCharge();
                 }
             }
             else if (EngineKillEnabled)
@@ -102,6 +152,7 @@ namespace LibreLancer.World.Components
                 ChargePercent = 0;
                 CruiseAccelPct = 0;
             }
+            previousCruiseEnabled = CruiseEnabled;
             // Component checks
             var engine = Parent.GetComponent<SEngineComponent>(); // Get mounted engine
             var power = Parent.GetComponent<PowerCoreComponent>();
@@ -194,7 +245,8 @@ namespace LibreLancer.World.Components
             { // Cruise has entirely different force calculation
                 CruiseAccelPct += (float)(time * 1.0f / engine.Engine.CruiseAccelTime);
                 if (CruiseAccelPct > 1.0f) CruiseAccelPct = 1.0f;
-                var cruise_force = engine.Engine.CruiseSpeed * engine.Engine.Def.LinearDrag;
+                var cruiseSpeed = MathF.Max(0, engine.Engine.CruiseSpeed + CruiseSpeedOffset);
+                var cruise_force = cruiseSpeed * engine.Engine.Def.LinearDrag;
                 engineForce = engine.Engine.Def.MaxForce + (cruise_force - engine.Engine.Def.MaxForce) * CruiseAccelPct;
                 // Set fx sparam. TODO: This is poorly named
                 engine.Speed = 1.0f;
@@ -202,7 +254,7 @@ namespace LibreLancer.World.Components
             }
             else
             {
-                engine.Speed = Math.Clamp(requestedEnginePower * 0.9f, 0, 1);
+                engine.Speed = MathHelper.Clamp(requestedEnginePower, 0, 1) * 0.9f;
             }
 
             Vector3 strafe = Vector3.Zero;

--- a/src/LibreLancer/World/Components/ShipSteeringComponent.cs
+++ b/src/LibreLancer/World/Components/ShipSteeringComponent.cs
@@ -17,6 +17,7 @@ namespace LibreLancer.World.Components
         public float InRoll;
         public float InThrottle;
         public bool Cruise;
+        public float CruiseSpeedOffset;
         public bool Thrust;
         public int Tick;
         public bool EngineKill;
@@ -59,6 +60,7 @@ namespace LibreLancer.World.Components
             physics.EnginePower = InThrottle;
             physics.ThrustEnabled = Thrust;
             physics.CruiseEnabled = Cruise;
+            physics.CruiseSpeedOffset = Cruise ? CruiseSpeedOffset : 0;
             physics.EngineKillEnabled = EngineKill;
         }
 


### PR DESCRIPTION
- Formation followers now request cruise when:
-- the formation leader is cruising, regardless of distance
-- or the follower is more than 450m from the leader

- Server-side formation cruise validation mirrors the client behavior.

- Formation speed dampening into different distances:
-- cruise speed offset dampens inside 250m
-- throttle dampens inside 125m
-- throttle matches leader inside 100m

- Formation throttle now gets a 10% catch-up boost outside the throttle dampening range. Same for cruise and their cruise dampen range
