### PR TITLE
Improve NPC docking, patrol spawning, and ambient population behavior

### DIFF
--- a/src/LibreLancer.Data/GameData/Ship.cs
+++ b/src/LibreLancer.Data/GameData/Ship.cs
@@ -26,6 +26,7 @@ public class Ship : NamedItem
     public float StrafeForce;
     public float Hitpoints;
     public Explosion? Explosion;
+    public string? MissionProperty;
 
     public Vector3 ChaseOffset;
     public float MaxBankAngle;

--- a/src/LibreLancer.Data/GameItemDb.cs
+++ b/src/LibreLancer.Data/GameItemDb.cs
@@ -2193,6 +2193,7 @@ public class GameItemDb
                 IdsInfo = orig.IdsInfo,
                 ExtraIdsInfo = [orig.IdsInfo1, orig.IdsInfo2, orig.IdsInfo3],
                 ShipType = orig.Type,
+                MissionProperty = orig.MissionProperty,
                 Explosion = orig.ExplosionArch is not null ? Explosions.Get(orig.ExplosionArch) : null,
             };
             ship.CRC = FLHash.CreateID(ship.Nickname);

--- a/src/LibreLancer/Client/CGameSession.cs
+++ b/src/LibreLancer/Client/CGameSession.cs
@@ -387,7 +387,28 @@ public partial class CGameSession : IClientPlayer
 
         if (PlayerBase != null)
         {
-            Game.ChangeState(new RoomGameplay(Game, this, PlayerBase));
+            if (spaceGameplay != null)
+            {
+                var baseId = PlayerBase;
+                var oldSpace = spaceGameplay;
+                if (oldSpace.ShouldFadeToRoom)
+                {
+                    oldSpace.FadeToRoom(() =>
+                    {
+                        spaceGameplay = null;
+                        Game.ChangeState(new RoomGameplay(Game, this, baseId));
+                    });
+                }
+                else
+                {
+                    spaceGameplay = null;
+                    Game.ChangeState(new RoomGameplay(Game, this, baseId));
+                }
+            }
+            else
+            {
+                Game.ChangeState(new RoomGameplay(Game, this, PlayerBase));
+            }
         }
         else
         {

--- a/src/LibreLancer/GameStates/SpaceGameplay.cs
+++ b/src/LibreLancer/GameStates/SpaceGameplay.cs
@@ -98,6 +98,7 @@ World Time: {12:F2}
 
         private int updateStartDelay = -1;
         private DockCameraInfo? dockCameraInfo = null;
+        private bool fadeToRoom;
         public AutopilotComponent? pilotComponent = null;
 
         public bool ShowHud = true;
@@ -1057,6 +1058,13 @@ World Time: {12:F2}
             this.dockCameraInfo = info;
         }
 
+        public void FadeToRoom(Action changeState)
+        {
+            FadeOut(0.5, changeState);
+        }
+
+        public bool ShouldFadeToRoom => fadeToRoom;
+
         protected override void OnUnload()
         {
             Game.Keyboard.TextInput -= Game_TextInput;
@@ -1115,7 +1123,7 @@ World Time: {12:F2}
                         return false;
                     }
 
-                    if (!Selection.Selected.TryGetComponent<DockInfoComponent>(out _))
+                    if (!Selection.Selected.TryGetComponent<DockInfoComponent>(out var dock))
                     {
                         return false;
                     }
@@ -1127,6 +1135,11 @@ World Time: {12:F2}
                     }
 
                     pilotComponent!.StartDock(Selection.Selected, GotoKind.Goto);
+                    var dockCam = dock.GetDockCamera(0);
+                    if (dockCam != null)
+                    {
+                        SetDockCam(dockCam);
+                    }
                     session.RegisterRouteDock(Selection.Selected.NicknameCRC, sys.CRC);
                     session.SpaceRpc.RequestDock(Selection.Selected);
                     return true;
@@ -1205,7 +1218,7 @@ World Time: {12:F2}
             {
                 return Thn.CameraHandle;
             }
-            else if (dockCameraInfo != null && pilotComponent!.CurrentBehavior == AutopilotBehaviors.Undock)
+            else if (UseDockCamera())
             {
                 return undockCamera;
             }
@@ -1213,6 +1226,17 @@ World Time: {12:F2}
             {
                 return activeCamera;
             }
+        }
+
+        private bool UseDockCamera()
+        {
+            var dockCameraActive = pilotComponent?.DockCameraActive == true;
+            if (dockCameraActive && pilotComponent?.CurrentBehavior == AutopilotBehaviors.Dock)
+                fadeToRoom = true;
+
+            return dockCameraInfo != null &&
+                   (pilotComponent?.CurrentBehavior == AutopilotBehaviors.Undock ||
+                    dockCameraActive);
         }
 
         private bool IsSpecialCamera() => GetCurrentCamera() != activeCamera;
@@ -1386,7 +1410,7 @@ World Time: {12:F2}
             // Has to be here or glitches
             if (!Dead)
             {
-                if (dockCameraInfo != null && pilotComponent?.CurrentBehavior == AutopilotBehaviors.Undock)
+                if (UseDockCamera())
                 {
                     var tr = dockCameraInfo.DockHardpoint.Transform * dockCameraInfo.Parent.WorldTransform;
                     undockCamera.Update(Game.Width, Game.Height, tr.Position, player.LocalTransform.Position);

--- a/src/LibreLancer/Server/Ai/AiDockState.cs
+++ b/src/LibreLancer/Server/Ai/AiDockState.cs
@@ -29,7 +29,7 @@ namespace LibreLancer.Server.Ai
             if (obj.TryGetComponent<AutopilotComponent>(out _) &&
                target.TryGetComponent<SDockableComponent>(out var dock))
             {
-                dock.StartDock(obj, 0, GotoKind);
+                dock.StartDock(obj, 0, GotoKind, world);
             }
         }
 

--- a/src/LibreLancer/Server/Components/SDockableComponent.cs
+++ b/src/LibreLancer/Server/Components/SDockableComponent.cs
@@ -10,12 +10,14 @@ using LibreLancer.Data;
 using LibreLancer.Data.GameData.World;
 using LibreLancer.World;
 using LibreLancer.World.Components;
+using DockSphereType = LibreLancer.Data.Schema.Solar.DockSphereType;
 
 namespace LibreLancer.Server.Components
 {
     public class DockingPoint
     {
         public bool Open;
+        public bool OpenAnimationStarted;
         public float CloseTimer;
         public DockSphere DockSphere;
 
@@ -26,34 +28,36 @@ namespace LibreLancer.Server.Components
 
         private const float OPEN_DURATION = 10;
 
-        public void TriggerOpen(GameObject parent, GameWorld world)
+        public void TriggerOpen(GameObject parent, GameWorld world, bool force = false)
         {
             CloseTimer = OPEN_DURATION;
-            if (Open)
+            if (Open && (!force || OpenAnimationStarted))
             {
                 return;
             }
 
-            Animate(false, parent, world);
+            OpenAnimationStarted = Animate(false, parent, world) || OpenAnimationStarted;
             Open = true;
         }
 
-        private void Animate(bool close, GameObject parent, GameWorld world)
+        private bool Animate(bool close, GameObject parent, GameWorld world)
         {
             var component = parent.GetComponent<AnimationComponent>();
             if (component == null)
             {
-                return;
+                return false;
             }
 
             if (!component.HasAnimation(DockSphere.Script))
             {
-                return;
+                FLLog.Debug("Server", $"dock animation missing for {parent.Nickname}: {DockSphere.Script ?? "<none>"}");
+                return false;
             }
 
             component.StartAnimation(DockSphere.Script!, false, 0, 1, 0, close);
             world.Server!.StartAnimation(parent);
             FLLog.Debug("Server", $"{(close ? "closing" : "opening")} {parent.Nickname} {DockSphere.Script}");
+            return true;
         }
 
         public void Update(GameObject parent, GameWorld world, float dt)
@@ -65,6 +69,7 @@ namespace LibreLancer.Server.Components
                 if (CloseTimer < 0)
                 {
                     Open = false;
+                    OpenAnimationStarted = false;
                     Animate(true, parent, world);
                 }
             }
@@ -73,11 +78,12 @@ namespace LibreLancer.Server.Components
 
     public class SDockableComponent : GameComponent
     {
+        private const double NPC_MOOR_TIME = 60.0;
+
         public DockAction Action;
 
         public DockingPoint[] DockPoints;
-        private DockHardpoints hardpoints;
-        private Random r = new();
+        private readonly DockHardpoints hardpoints;
 
         public SDockableComponent(GameObject parent, DockAction action, DockSphere[] dockSpheres) : base(parent)
         {
@@ -86,9 +92,17 @@ namespace LibreLancer.Server.Components
             hardpoints = new(Action, DockPoints);
         }
 
+        private bool HasDockAnimation(int i) =>
+            Parent.GetComponent<AnimationComponent>()?.HasAnimation(DockPoints[i].DockSphere.Script) == true;
+
         private void TryTriggerAnimation(int i, GameObject obj, GameWorld world)
         {
-            float animRadius = 30;
+            if (i < 0 || i >= DockPoints.Length)
+            {
+                return;
+            }
+
+            float animRadius = 100;
             if (Action.Kind == DockKinds.Tradelane)
             {
                 animRadius = 300;
@@ -96,19 +110,30 @@ namespace LibreLancer.Server.Components
 
             var rad = obj.PhysicsComponent?.Body.Collider.Radius ?? 15;
             var pos = obj.WorldTransform.Position;
-
-            foreach (var hps in hardpoints.GetDockHardpoints(Parent, i, Vector3.Zero, false))
+            var hp = hardpoints.GetDockHardpoints(Parent, i, Vector3.Zero, false).FirstOrDefault();
+            if (hp == null)
             {
-                var targetPos = (hps.Transform * Parent.WorldTransform).Position;
-                var dist = (targetPos - pos).Length();
+                return;
+            }
 
-                if (dist < animRadius + rad)
-                {
-                    TriggerAnimation(i, world);
-                    break;
-                }
+            var targetPos = (hp.Transform * Parent.WorldTransform).Position;
+            var dist = (targetPos - pos).Length();
+
+            var forceAnimation = HasDockAnimation(i) &&
+                                 DockPoints[i].Open &&
+                                 !DockPoints[i].OpenAnimationStarted;
+            if ((!DockPoints[i].Open || forceAnimation) &&
+                dist < animRadius + rad)
+            {
+                TriggerAnimation(i, world, forceAnimation);
             }
         }
+
+        private bool IsDockingRingIndex(int index) =>
+            Action.Kind == DockKinds.Base &&
+            index == 0 &&
+            index < DockPoints.Length &&
+            DockPoints[index].DockSphere.Type == DockSphereType.ring;
 
         private bool CanPlayerTradelane(GameObject ship, string tradelaneNickname)
         {
@@ -140,7 +165,7 @@ namespace LibreLancer.Server.Components
             var hp = Parent.GetHardpoint(tlHP ?? DockPoints[i].DockSphere.Hardpoint);
             var targetPos = (hp!.Transform * Parent.WorldTransform).Position;
 
-            if ((targetPos - pos).Length() < (DockPoints[i].DockSphere.Radius * 2 + rad))
+            if ((targetPos - pos).Length() < (DockPoints[i].DockSphere.Radius + rad))
             {
                 return true;
             }
@@ -148,65 +173,131 @@ namespace LibreLancer.Server.Components
             return false;
         }
 
-        private bool leftActive = false;
-        private bool rightActive = false;
+        private float DistanceToDockMount(int i, GameObject obj)
+        {
+            var hp = Parent.GetHardpoint(DockPoints[i].DockSphere.Hardpoint);
+            if (hp == null)
+            {
+                return float.MaxValue;
+            }
+
+            var targetPos = (hp.Transform * Parent.WorldTransform).Position;
+            return (targetPos - obj.WorldTransform.Position).Length();
+        }
+
+        private float GetRingFlyThroughRange(int i, GameObject obj)
+        {
+            var rad = obj.PhysicsComponent?.Body.Collider.Radius ?? 15;
+            return Math.Max(250, DockPoints[i].DockSphere.Radius + rad);
+        }
 
         private int inactiveTicksLeft = 0;
         private int inactiveTicksRight = 0;
         private const int INACTIVE_TIME = 16;
 
-        private void TriggerAnimation(int i, GameWorld world)
+        private void TriggerAnimation(int i, GameWorld world, bool force = false)
         {
             if (Action.Kind == DockKinds.Tradelane &&
                 DockPoints[i].DockSphere.Hardpoint.Equals("hpleftlane", StringComparison.OrdinalIgnoreCase))
             {
                 world.Server!.ActivateLane(Parent, true);
                 inactiveTicksLeft = INACTIVE_TIME;
-                leftActive = true;
             }
             else if (Action.Kind == DockKinds.Tradelane &&
                      DockPoints[i].DockSphere.Hardpoint.Equals("hprightlane", StringComparison.OrdinalIgnoreCase))
             {
                 world.Server!.ActivateLane(Parent, false);
                 inactiveTicksRight = INACTIVE_TIME;
-                rightActive = true;
             }
 
-            DockPoints[i].TriggerOpen(Parent, world);
+            DockPoints[i].TriggerOpen(Parent, world, force);
         }
+
+        private DockSphereType GetDockTypeForShip(GameObject ship)
+        {
+            if (Action.Kind == DockKinds.Tradelane)
+            {
+                return DockSphereType.ring;
+            }
+
+            if (!ship.TryGetComponent<ShipComponent>(out var shipComponent))
+            {
+                return DockSphereType.berth;
+            }
+
+            return shipComponent.Ship.MissionProperty switch
+            {
+                string p when p.Equals("can_use_large_moors", StringComparison.OrdinalIgnoreCase) =>
+                    DockSphereType.moor_large,
+                string p when p.Equals("can_use_med_moors", StringComparison.OrdinalIgnoreCase) =>
+                    DockSphereType.moor_medium,
+                _ => DockSphereType.berth
+            };
+        }
+
+        private bool CanUseDockIndex(GameObject ship, int index)
+        {
+            if (index < 0 || index >= DockPoints.Length)
+            {
+                return false;
+            }
+
+            var dockType = DockPoints[index].DockSphere.Type;
+            return IsDockingRingIndex(index) ||
+                   dockType == DockSphereType.ring ||
+                   dockType == GetDockTypeForShip(ship);
+        }
+
+        private bool HasCompatibleDockIndex(GameObject ship) =>
+            Enumerable.Range(0, DockPoints.Length).Any(i => CanUseDockIndex(ship, i));
+
+        private static bool IsMoor(DockSphereType type) =>
+            type is DockSphereType.moor_small or DockSphereType.moor_medium or DockSphereType.moor_large;
 
         private class DockingAction
         {
             public int Dock;
             public required GameObject Ship;
-            public int LastTargetHp = 0;
             public string? TLHardpoint;
+            public bool Moored;
+            public double MoorTimeLeft;
+            public bool RingDocking;
+            public double RingDockTimeLeft;
         }
 
-        private List<DockingAction> activeDockings = [];
+        private readonly List<DockingAction> activeDockings = [];
 
-        private readonly List<(GameObject Ship, int RequestedIndex, GotoKind Kind)> dockQueue = [];
+        private readonly List<(GameObject Ship, int RequestedIndex, GotoKind Kind, DockSphereType Type)> dockQueue = [];
 
         public bool IsQueuedForDock(GameObject ship) =>
             dockQueue.Any(x => x.Ship == ship);
 
-        public void StartDock(GameObject obj, int index, GotoKind kind = GotoKind.Goto)
+        public void StartDock(GameObject obj, int index, GotoKind kind = GotoKind.Goto, GameWorld? world = null)
         {
             if (activeDockings.Any(x => x.Ship == obj) || IsQueuedForDock(obj))
                 return;
 
             var dockIndex = index;
+            if (Action.Kind == DockKinds.Base && !HasCompatibleDockIndex(obj))
+            {
+                var dockType = GetDockTypeForShip(obj);
+                FLLog.Warning(
+                    "Docking",
+                    $"{obj.Nickname ?? obj.NetID.ToString()} cannot dock at {Parent.Nickname}: no {dockType} dock spheres");
+                return;
+            }
+
             if (Action.Kind == DockKinds.Base &&
-                !TryGetAvailableDockIndex(index, out dockIndex))
+                !TryGetAvailableDockIndex(obj, index, out dockIndex))
             {
                 QueueDock(obj, index, kind);
                 return;
             }
 
-            StartDockNow(obj, dockIndex, kind);
+            StartDockNow(obj, dockIndex, kind, world);
         }
 
-        private void StartDockNow(GameObject obj, int index, GotoKind kind)
+        private void StartDockNow(GameObject obj, int index, GotoKind kind, GameWorld? world)
         {
             var pos = obj.WorldTransform.Position;
 
@@ -224,8 +315,13 @@ namespace LibreLancer.Server.Components
                 activeDockings.Add(new DockingAction() { Dock = index, Ship = obj });
             }
 
+            if (world != null)
+            {
+                TryTriggerAnimation(index, obj, world);
+            }
+
             if (obj.TryGetComponent<AutopilotComponent>(out var ap))
-                ap.StartDock(Parent, kind);
+                ap.StartDock(Parent, kind, index);
         }
 
         private void QueueDock(GameObject ship, int requestedIndex, GotoKind kind)
@@ -233,29 +329,39 @@ namespace LibreLancer.Server.Components
             if (activeDockings.Any(x => x.Ship == ship) || IsQueuedForDock(ship))
                 return;
 
-            var entry = (ship, requestedIndex, kind);
+            var dockType = GetQueueDockType(ship, requestedIndex);
+            var entry = (ship, requestedIndex, kind, dockType);
             if (!ship.TryGetComponent<SPlayerComponent>(out _))
             {
                 dockQueue.Add(entry);
                 return;
             }
 
-            var insert = dockQueue.FindIndex(x => !x.Ship.TryGetComponent<SPlayerComponent>(out _));
+            var insert = dockQueue.FindIndex(x =>
+                x.Type == dockType &&
+                !x.Ship.TryGetComponent<SPlayerComponent>(out _));
             if (insert < 0)
                 dockQueue.Add(entry);
             else
                 dockQueue.Insert(insert, entry);
         }
 
-        private bool TryGetAvailableDockIndex(int requestedIndex, out int index)
+        private bool TryGetAvailableDockIndex(GameObject ship, int requestedIndex, out int index)
         {
             index = requestedIndex;
-            if (IsDockIndexAvailableForDocking(requestedIndex))
+            if (CanUseDockIndex(ship, requestedIndex) &&
+                IsDockIndexAvailableForDocking(requestedIndex))
                 return true;
+
+            if (IsDockingRingIndex(requestedIndex))
+            {
+                return false;
+            }
 
             for (int i = 0; i < DockPoints.Length; i++)
             {
-                if (IsDockIndexAvailableForDocking(i))
+                if (CanUseDockIndex(ship, i) &&
+                    IsDockIndexAvailableForDocking(i))
                 {
                     index = i;
                     return true;
@@ -265,12 +371,15 @@ namespace LibreLancer.Server.Components
             return false;
         }
 
+        private DockSphereType GetQueueDockType(GameObject ship, int requestedIndex) =>
+            IsDockingRingIndex(requestedIndex) ? DockSphereType.ring : GetDockTypeForShip(ship);
+
         private bool IsDockIndexAvailableForDocking(int index) =>
             index >= 0 &&
             index < DockPoints.Length &&
             !IsUndockIndexBusy(index);
 
-        private void ProcessDockQueue()
+        private void ProcessDockQueue(GameWorld world)
         {
             if (Action.Kind != DockKinds.Base)
                 return;
@@ -285,11 +394,14 @@ namespace LibreLancer.Server.Components
                     continue;
                 }
 
-                if (!TryGetAvailableDockIndex(queued.RequestedIndex, out var index))
-                    return;
+                if (!TryGetAvailableDockIndex(queued.Ship, queued.RequestedIndex, out var index))
+                {
+                    i++;
+                    continue;
+                }
 
                 dockQueue.RemoveAt(i);
-                StartDockNow(queued.Ship, index, queued.Kind);
+                StartDockNow(queued.Ship, index, queued.Kind, world);
             }
         }
 
@@ -304,6 +416,29 @@ namespace LibreLancer.Server.Components
                 formation.Remove(follower);
             formation.Remove(lead);
             return followers;
+        }
+
+        private void StartDockingRingFlyThrough(DockingAction dock)
+        {
+            if (dock.Ship.TryGetComponent<ShipPhysicsComponent>(out var physics))
+            {
+                physics.Active = false;
+            }
+
+            dock.Ship.PhysicsComponent!.Collidable = false;
+            dock.Ship.PhysicsComponent.Body.Collidable = false;
+            dock.Ship.PhysicsComponent.Body.LinearVelocity =
+                Vector3.Transform(-Vector3.UnitZ, dock.Ship.PhysicsComponent.Body.Orientation) * 80;
+
+            if (dock.Ship.TryGetComponent<ShipSteeringComponent>(out var steering))
+            {
+                steering.InThrottle = 1;
+                steering.Cruise = false;
+            }
+
+            dock.RingDocking = true;
+            dock.RingDockTimeLeft = 3.0;
+            FLLog.Debug("Docking", $"{dock.Ship} entering docking ring {DockPoints[dock.Dock].DockSphere.Hardpoint}");
         }
 
         private void StartTradelane(GameObject ship, string tlHardpoint)
@@ -352,17 +487,25 @@ namespace LibreLancer.Server.Components
             return true;
         }
 
-        private List<(GameObject Ship, int Index)> undockers = [];
+        private readonly List<(GameObject Ship, int Index)> undockers = [];
+        private readonly HashSet<int> reservedUndockIndices = [];
 
         public void UndockShip(GameObject ship, GameWorld world, int index)
         {
+            reservedUndockIndices.Remove(index);
             TriggerAnimation(index, world);
             undockers.Add((ship, index));
         }
 
+        public void ReleaseUndockIndex(int index)
+        {
+            reservedUndockIndices.Remove(index);
+        }
+
         private bool IsUndockIndexBusy(int index)
         {
-            return undockers.Any(x =>
+            return reservedUndockIndices.Contains(index) ||
+                   undockers.Any(x =>
                        x.Index == index &&
                        x.Ship.Flags.HasFlag(GameObjectFlags.Exists)) ||
                    activeDockings.Any(x =>
@@ -401,30 +544,26 @@ namespace LibreLancer.Server.Components
             return false;
         }
 
-        public int GetUndockIndex()
+        public bool TryReserveUndockIndex(out int index)
         {
-            if (TryGetUndockIndex(out var index))
-                return index;
-
-            if (DockPoints.Length > 1 &&
-                DockPoints[0].DockSphere.Type == Data.Schema.Solar.DockSphereType.ring)
+            if (!TryGetUndockIndex(out index))
             {
-                return 0; // Must undock from 0
+                return false;
             }
-            else
-            {
-                // First free point (?)
-                for (int i = 0; i < DockPoints.Length; i++)
-                {
-                    if (!DockPoints[i].Open)
-                    {
-                        return i;
-                    }
-                }
 
-                // Random
-                return r.Next(0, DockPoints.Length);
+            reservedUndockIndices.Add(index);
+            return true;
+        }
+
+        public bool TryReserveUndockIndex(int index)
+        {
+            if (!IsUndockIndexAvailable(index))
+            {
+                return false;
             }
+
+            reservedUndockIndices.Add(index);
+            return true;
         }
 
         public override void Update(double time, GameWorld world)
@@ -474,19 +613,74 @@ namespace LibreLancer.Server.Components
                     continue;
                 }
 
+                if (dock.Moored)
+                {
+                    dock.MoorTimeLeft -= time;
+                    if (dock.MoorTimeLeft > 0)
+                    {
+                        continue;
+                    }
+
+                    FLLog.Debug("Docking", $"{dock.Ship} leaving moor {DockPoints[dock.Dock].DockSphere.Hardpoint}");
+                    activeDockings.RemoveAt(i);
+                    UndockShip(dock.Ship, world, dock.Dock);
+                    dock.Ship.GetComponent<AutopilotComponent>()?.Undock(Parent, dock.Dock);
+                    continue;
+                }
+
+                if (dock.RingDocking)
+                {
+                    dock.RingDockTimeLeft -= time;
+                    if (dock.RingDockTimeLeft > 0)
+                    {
+                        continue;
+                    }
+
+                    FLLog.Debug("Docking", $"{dock.Ship} docking ring fly-through complete");
+                    if (dock.Ship.TryGetComponent<SPlayerComponent>(out var ringPlayer))
+                    {
+                        ringPlayer.Player.ForceLand(Action.Target);
+                    }
+                    else if (dock.Ship.TryGetComponent<SNPCComponent>(out var ringNpc))
+                    {
+                        ringNpc.Docked();
+                    }
+
+                    activeDockings.RemoveAt(i);
+                    continue;
+                }
+
                 if (Action.Kind == DockKinds.Tradelane)
                 {
-                    if (dock.TLHardpoint.Equals("hpleftlane", StringComparison.OrdinalIgnoreCase))
+                    var tlHardpoint = dock.TLHardpoint;
+                    if (tlHardpoint == null)
+                    {
+                        activeDockings.RemoveAt(i);
+                        continue;
+                    }
+
+                    if (tlHardpoint.Equals("hpleftlane", StringComparison.OrdinalIgnoreCase))
                     {
                         leftThisTick = true;
                     }
-                    else if (dock.TLHardpoint.Equals("hprightlane", StringComparison.OrdinalIgnoreCase))
+                    else if (tlHardpoint.Equals("hprightlane", StringComparison.OrdinalIgnoreCase))
                     {
                         rightThisTick = true;
                     }
                 }
 
                 TryTriggerAnimation(dock.Dock, dock.Ship, world);
+                if (IsDockingRingIndex(dock.Dock) &&
+                    !dock.RingDocking &&
+                    DistanceToDockMount(dock.Dock, dock.Ship) <= GetRingFlyThroughRange(dock.Dock, dock.Ship))
+                {
+                    foreach (var ship in BreakDockingFormation(dock.Ship))
+                        QueueDock(ship, dock.Dock, GotoKind.Goto);
+
+                    StartDockingRingFlyThrough(dock);
+                    continue;
+                }
+
                 if (!CanDock(dock.Dock, dock.Ship, dock.TLHardpoint))
                 {
                     continue;
@@ -494,12 +688,38 @@ namespace LibreLancer.Server.Components
 
                 if (Action.Kind == DockKinds.Base)
                 {
+                    var dockType = DockPoints[dock.Dock].DockSphere.Type;
                     foreach (var ship in BreakDockingFormation(dock.Ship))
                         QueueDock(ship, dock.Dock, GotoKind.Goto);
+
+                    if (IsDockingRingIndex(dock.Dock) &&
+                        !dock.RingDocking)
+                    {
+                        StartDockingRingFlyThrough(dock);
+                        continue;
+                    }
 
                     if (dock.Ship.TryGetComponent<SPlayerComponent>(out var player))
                     {
                         player.Player.ForceLand(Action.Target);
+                    }
+                    else if (IsMoor(dockType) &&
+                             dock.Ship.TryGetComponent<SNPCComponent>(out _))
+                    {
+                        if (dock.Ship.TryGetComponent<AutopilotComponent>(out var ap))
+                        {
+                            ap.Cancel();
+                        }
+
+                        if (dock.Ship.TryGetComponent<ShipSteeringComponent>(out var steering))
+                        {
+                            steering.InThrottle = 0;
+                            steering.Cruise = false;
+                        }
+
+                        dock.Moored = true;
+                        dock.MoorTimeLeft = NPC_MOOR_TIME;
+                        FLLog.Debug("Docking", $"{dock.Ship} moored at {DockPoints[dock.Dock].DockSphere.Hardpoint}");
                     }
                     else if (dock.Ship.TryGetComponent<SNPCComponent>(out var npc))
                     {
@@ -519,13 +739,14 @@ namespace LibreLancer.Server.Components
                 }
                 else if (Action.Kind == DockKinds.Tradelane)
                 {
-                    StartTradelane(dock.Ship, dock.TLHardpoint);
+                    var tlHardpoint = dock.TLHardpoint!;
+                    StartTradelane(dock.Ship, tlHardpoint);
 
                     if (dock.Ship.Formation != null &&
                         dock.Ship.Formation.LeadShip == dock.Ship)
                     {
                         foreach (var ship in dock.Ship.Formation.Followers)
-                            StartTradelane(ship, dock.TLHardpoint);
+                            StartTradelane(ship, tlHardpoint);
                     }
                 }
 
@@ -535,7 +756,7 @@ namespace LibreLancer.Server.Components
             foreach (var dp in DockPoints)
                 dp.Update(Parent, world, (float) time);
 
-            ProcessDockQueue();
+            ProcessDockQueue(world);
 
             if (inactiveTicksLeft > 0 && !leftThisTick)
             {
@@ -543,7 +764,6 @@ namespace LibreLancer.Server.Components
 
                 if (inactiveTicksLeft == 0)
                 {
-                    leftActive = false;
                     world.Server!.DeactivateLane(Parent, true);
                 }
             }
@@ -554,7 +774,6 @@ namespace LibreLancer.Server.Components
 
                 if (inactiveTicksRight == 0)
                 {
-                    rightActive = false;
                     world.Server!.DeactivateLane(Parent, false);
                 }
             }

--- a/src/LibreLancer/Server/NPCManager.cs
+++ b/src/LibreLancer/Server/NPCManager.cs
@@ -126,7 +126,8 @@ namespace LibreLancer.Server
             string? arrivalObj,
             int arrivalIndex,
             MissionRuntime? msn = null,
-            bool registerNpc = true
+            bool registerNpc = true,
+            bool arrivalIndexReserved = false
             )
         {
             var ship = World.Server.GameData.Items.Ships.Get(loadout.Archetype);
@@ -134,18 +135,32 @@ namespace LibreLancer.Server
             SDockableComponent? sdock = null;
             if (spawnPoint?.TryGetComponent<SDockableComponent>(out sdock) ?? false)
             {
-                if (arrivalIndex == 0)
+                var reservedHere = arrivalIndexReserved;
+                if (!reservedHere)
                 {
-                    arrivalIndex = sdock.GetUndockIndex();
+                    var reserved = arrivalIndex == 0
+                        ? sdock.TryReserveUndockIndex(out arrivalIndex)
+                        : sdock.TryReserveUndockIndex(arrivalIndex);
+                    if (!reserved)
+                    {
+                        FLLog.Warning("NPC", $"Could not reserve spawn point for {arrivalObj}");
+                        sdock = null;
+                    }
+                    else
+                    {
+                        reservedHere = true;
+                    }
                 }
 
-                if (sdock.TryGetSpawnPoint(arrivalIndex, out var p))
+                if (sdock != null && sdock.TryGetSpawnPoint(arrivalIndex, out var p))
                 {
                     position = p.Position;
                     orient = p.Orientation;
                 }
-                else
+                else if (sdock != null)
                 {
+                    if (reservedHere)
+                        sdock.ReleaseUndockIndex(arrivalIndex);
                     FLLog.Warning("NPC", $"Could not get spawn point {arrivalIndex} for {arrivalObj}");
                     sdock = null;
                 }

--- a/src/LibreLancer/Server/Player.cs
+++ b/src/LibreLancer/Server/Player.cs
@@ -1282,9 +1282,15 @@ namespace LibreLancer.Server
 
                     if (undockFrom?.TryGetComponent(out sd) ?? false)
                     {
-                        undockIndex = sd!.GetUndockIndex();
+                        if (!sd!.TryReserveUndockIndex(out undockIndex))
+                        {
+                            FLLog.Warning("Server", $"Could not reserve spawn point for {undockFrom}");
+                            return;
+                        }
+
                         if (!sd.TryGetSpawnPoint(undockIndex, out var tr))
                         {
+                            sd.ReleaseUndockIndex(undockIndex);
                             FLLog.Warning("Server", $"Could not get spawn point {undockIndex} for {undockFrom}");
                             return;
                         }
@@ -1303,8 +1309,8 @@ namespace LibreLancer.Server
 
                     if (undockFrom != null)
                     {
-                        rpcClient.UndockFrom(undockFrom, undockIndex);
                         sd!.UndockShip(pship, world.GameWorld, undockIndex);
+                        rpcClient.UndockFrom(undockFrom, undockIndex);
 
                     }
 

--- a/src/LibreLancer/Server/ServerWorld.cs
+++ b/src/LibreLancer/Server/ServerWorld.cs
@@ -531,7 +531,7 @@ namespace LibreLancer.Server
                     }
                     else
                     {
-                        component.StartDock(obj, 0);
+                        component.StartDock(obj, 0, world: GameWorld);
                     }
                 }
             });

--- a/src/LibreLancer/Server/SpacePopulationArrivals.cs
+++ b/src/LibreLancer/Server/SpacePopulationArrivals.cs
@@ -72,6 +72,14 @@ public partial class SpacePopulationManager
     {
         spawn = default;
         var arrivalTargets = TranslateArrival(info.FormationDefinition?.Arrival);
+        if (IsPatrolEncounter(state, info) &&
+            (info.FormationDefinition?.Arrival == null ||
+             (arrivalTargets & (ArrivalTargets.Cruise | ArrivalTargets.Buzz)) != 0) &&
+            TryFindPatrolPathSpawnLocation(state, players, zoneCreationDistance, out spawn))
+        {
+            return true;
+        }
+
         var preferObjectArrival = info.FormationDefinition?.Behavior == EncounterBehavior.trade;
         if (!preferObjectArrival &&
             TryFindFreeSpaceSpawnLocation(state.Zone, arrivalTargets, players, zoneCreationDistance, allowCloseSpawn, out spawn))
@@ -103,6 +111,12 @@ public partial class SpacePopulationManager
         }
 
         return false;
+    }
+
+    private static bool IsPatrolEncounter(ZoneState state, EncounterInfo info)
+    {
+        var behavior = info.FormationDefinition?.Behavior ?? EncounterBehavior.wander;
+        return behavior == EncounterBehavior.patrol_path || IsPatrol(state.Zone);
     }
 
     private bool TryFindFreeSpaceSpawnLocation(

--- a/src/LibreLancer/Server/SpacePopulationBattle.cs
+++ b/src/LibreLancer/Server/SpacePopulationBattle.cs
@@ -20,6 +20,123 @@ public partial class SpacePopulationManager
         state.BattleCooldown = Math.Max(0, state.BattleCooldown - delta);
     }
 
+    private void UpdateGroupCombat(ZoneState state)
+    {
+        foreach (var group in state.Groups)
+        {
+            var leader = group.Ships.FirstOrDefault(Alive);
+            if (leader == null)
+                continue;
+
+            var hostile = FindGroupHostile(group, group.InCombat ? BattleDistance : CombatEngageDistance);
+            if (hostile != null)
+            {
+                if (!group.InCombat)
+                {
+                    group.ResumeDutyTarget = GetDutyResumeTarget(group, leader.WorldTransform.Position);
+                    SuspendGroupDirectives(group);
+                }
+                group.InCombat = true;
+                state.BattleCooldown = BattleCooldownSeconds;
+                continue;
+            }
+
+            if (!group.InCombat)
+                continue;
+
+            group.InCombat = false;
+            group.InitialPathTarget = group.ResumeDutyTarget;
+            group.ResumeDutyTarget = null;
+            ClearCombatTargets(group);
+            AssignDirectives(group);
+        }
+    }
+
+    private GameObject? FindGroupHostile(PopGroup group, float range)
+    {
+        foreach (var ship in group.Ships)
+        {
+            if (!Alive(ship))
+                continue;
+
+            var hostile = FindNearbyHostile(ship, range);
+            if (hostile != null)
+                return hostile;
+        }
+
+        return null;
+    }
+
+    private GameObject? FindNearbyHostile(GameObject ship, float range)
+    {
+        if (!ship.TryGetComponent<SRepComponent>(out var rep))
+            return null;
+
+        var rangeSquared = range * range;
+        var position = ship.WorldTransform.Position;
+        GameObject? selected = null;
+        var selectedDistance = float.MaxValue;
+
+        foreach (var other in world.GameWorld.SpatialLookup.GetNearbyObjects(ship, position, range))
+        {
+            if (!Alive(other) ||
+                ReferenceEquals(other, ship) ||
+                (other.Flags & GameObjectFlags.Cloaked) == GameObjectFlags.Cloaked ||
+                other.TryGetComponent<STradelaneMoveComponent>(out _) ||
+                !rep.IsHostileTo(other))
+            {
+                continue;
+            }
+
+            var distance = Vector3.DistanceSquared(position, other.WorldTransform.Position);
+            if (distance > rangeSquared || distance >= selectedDistance)
+                continue;
+
+            selected = other;
+            selectedDistance = distance;
+        }
+
+        return selected;
+    }
+
+    private Vector3? GetDutyResumeTarget(PopGroup group, Vector3 position)
+    {
+        var path = group.State.Path;
+        if (path == null || group.PathIndex < 0)
+            return null;
+
+        var index = Math.Clamp(group.PathIndex, 0, path.Count - 1);
+        if (!TryGetPatrolPathLine(path, index, out var start, out var end))
+            return path[index].Zone.Position;
+
+        return ClosestPointOnSegment(start, end, position);
+    }
+
+    private static void SuspendGroupDirectives(PopGroup group)
+    {
+        foreach (var ship in group.Ships)
+        {
+            if (!Alive(ship))
+                continue;
+
+            ship.GetComponent<DirectiveRunnerComponent>()?.Cancel();
+        }
+    }
+
+    private static void ClearCombatTargets(PopGroup group)
+    {
+        foreach (var ship in group.Ships)
+        {
+            if (!Alive(ship))
+                continue;
+
+            if (ship.TryGetComponent<SNPCComponent>(out var npc))
+                npc.CurrentDirective = null;
+            if (ship.TryGetComponent<SelectedTargetComponent>(out var selected))
+                selected.Selected = null;
+        }
+    }
+
     private bool GroupInCombat(PopGroup group, GameObject[] players)
     {
         foreach (var ship in group.Ships)
@@ -82,9 +199,12 @@ public partial class SpacePopulationManager
                     continue;
                 }
 
-                var persistDistance = state.InBattle || GroupInCombat(group, players)
-                    ? BattlePersistDistance
+                var basePersistDistance = group.PersistDistance > 0
+                    ? group.PersistDistance
                     : DefaultPersistDistance;
+                var persistDistance = state.InBattle || GroupInCombat(group, players)
+                    ? Math.Max(basePersistDistance, BattlePersistDistance)
+                    : basePersistDistance;
                 if (players.Length == 0 || group.Ships.All(x => DistanceToNearestPlayer(x.WorldTransform.Position, players) > persistDistance))
                 {
                     foreach (var ship in group.Ships)

--- a/src/LibreLancer/Server/SpacePopulationBehavior.cs
+++ b/src/LibreLancer/Server/SpacePopulationBehavior.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using LibreLancer.Data.GameData.World;
 using LibreLancer.Data.Schema.Missions;
 using LibreLancer.Missions;
 using LibreLancer.Missions.Directives;
@@ -14,6 +15,9 @@ namespace LibreLancer.Server;
 
 public partial class SpacePopulationManager
 {
+    private const float PatrolPathWaypointRange = 250f;
+    private const int MaxPatrolPathTargets = 4;
+
     private void AssignDirectives(PopGroup group)
     {
         var leader = group.Ships.FirstOrDefault(Alive);
@@ -38,48 +42,58 @@ public partial class SpacePopulationManager
 
     private MissionDirective[] BuildDirectives(PopGroup group, Vector3 currentPosition)
     {
-        if (ShouldRetire(group))
-            return BuildRetirementDirectives(group, currentPosition);
+        var retirementDockable = GetRetirementDockable(group, currentPosition);
+        if (retirementDockable != null)
+            return BuildRetirementDirectives(retirementDockable);
 
         var behavior = group.Encounter.FormationDefinition?.Behavior ?? EncounterBehavior.wander;
         return behavior switch
         {
-            EncounterBehavior.patrol_path => BuildPathDirectives(group, currentPosition, GotoKind.GotoCruise, 100),
-            EncounterBehavior.trade when IsPatrol(group.State.Zone) => BuildPathDirectives(group, currentPosition, GotoKind.GotoCruise, 100),
+            EncounterBehavior.patrol_path => BuildPathDirectives(group, GotoKind.GotoCruise, 100, PatrolPathWaypointRange),
+            EncounterBehavior.trade when IsPatrol(group.State.Zone) => BuildPathDirectives(group, GotoKind.GotoCruise, 100, PatrolPathWaypointRange),
             EncounterBehavior.trade => BuildTradeDirectives(group.State, currentPosition, group.ArrivalObject),
             _ => BuildWanderDirectives(group.State.Zone)
         };
     }
 
-    private static bool ShouldRetire(PopGroup group)
+    private GameObject? GetRetirementDockable(PopGroup group, Vector3 currentPosition)
     {
         var reliefTime = group.State.Zone.ReliefTime;
         if (reliefTime <= 0 || group.AgeSeconds < reliefTime)
-            return false;
+            return null;
 
         var behavior = group.Encounter.FormationDefinition?.Behavior ?? EncounterBehavior.wander;
-        return behavior == EncounterBehavior.patrol_path || IsPatrol(group.State.Zone);
+        if (behavior != EncounterBehavior.patrol_path && !IsPatrol(group.State.Zone))
+            return null;
+
+        if (HasNextPatrolPathSegment(group))
+            return null;
+
+        return FindRetirementDockable(group, currentPosition);
     }
 
-    private MissionDirective[] BuildRetirementDirectives(PopGroup group, Vector3 currentPosition)
+    private static bool HasNextPatrolPathSegment(PopGroup group)
     {
-        var dockable = FindDockable(currentPosition);
-        if (!string.IsNullOrWhiteSpace(dockable?.Nickname))
-        {
-            return
-            [
-                new GotoShipDirective
-                {
-                    Target = dockable.Nickname!,
-                    CruiseKind = GotoKind.GotoCruise,
-                    Range = 750,
-                    MaxThrottle = 100
-                },
-                new DockDirective { Target = dockable.Nickname! }
-            ];
-        }
+        var path = group.State.Path;
+        if (path == null || path.Count < 2 || group.PathIndex < 0)
+            return false;
 
-        return BuildPathDirectives(group, currentPosition, GotoKind.GotoCruise, 100);
+        return IsClosedPath(path) || group.PathIndex + 1 < path.Count;
+    }
+
+    private static MissionDirective[] BuildRetirementDirectives(GameObject dockable)
+    {
+        return
+        [
+            new GotoShipDirective
+            {
+                Target = dockable.Nickname!,
+                CruiseKind = GotoKind.GotoCruise,
+                Range = 750,
+                MaxThrottle = 100
+            },
+            new DockDirective { Target = dockable.Nickname! }
+        ];
     }
 
     private MissionDirective[] BuildWanderDirectives(Zone zone)
@@ -117,129 +131,175 @@ public partial class SpacePopulationManager
             ];
         }
 
-        return BuildPathDirectives(state, currentPosition, GotoKind.GotoCruise, 100);
+        return BuildPathDirectives(state, GotoKind.GotoCruise, 100);
     }
 
     private MissionDirective[] BuildPathDirectives(
         ZoneState state,
-        Vector3 currentPosition,
         GotoKind kind,
-        float throttle)
+        float throttle,
+        float range = 750)
     {
-        var targets = GetPathTargets(state, currentPosition);
+        var targets = GetPathTargets(state);
         if (targets.Count == 0)
             targets.Add(SampleZonePoint(state.Zone));
 
-        return targets.Select(x => (MissionDirective)new GotoVecDirective
-        {
-            Target = x,
-            CruiseKind = kind,
-            Range = 750,
-            MaxThrottle = throttle
-        }).ToArray();
+        return BuildGotoDirectives(targets, kind, throttle, range);
     }
 
     private MissionDirective[] BuildPathDirectives(
         PopGroup group,
-        Vector3 currentPosition,
         GotoKind kind,
-        float throttle)
+        float throttle,
+        float range = 750)
     {
-        var targets = GetPathTargets(group, currentPosition);
+        var targets = GetPathTargets(group);
         if (targets.Count == 0)
             targets.Add(SampleZonePoint(group.State.Zone));
 
+        return BuildGotoDirectives(targets, kind, throttle, range);
+    }
+
+    private static MissionDirective[] BuildGotoDirectives(
+        List<Vector3> targets,
+        GotoKind kind,
+        float throttle,
+        float range)
+    {
         return targets.Select(x => (MissionDirective)new GotoVecDirective
         {
             Target = x,
             CruiseKind = kind,
-            Range = 750,
+            Range = range,
             MaxThrottle = throttle
         }).ToArray();
     }
 
-    private List<Vector3> GetPathTargets(ZoneState state, Vector3 currentPosition)
+    private List<Vector3> GetPathTargets(ZoneState state)
     {
         var result = new List<Vector3>();
         if (state.Path == null || state.PathIndex < 0)
             return result;
 
-        var direction = 1;
-        if (state.PathIndex + direction >= state.Path.Count)
-            direction = -1;
-
-        for (int i = state.PathIndex + direction; i >= 0 && i < state.Path.Count && result.Count < 4; i += direction)
-        {
-            result.Add(state.Path[i].Position);
-        }
-
-        if (result.Count == 0)
-        {
-            var zone = state.Path
-                .OrderBy(x => Vector3.DistanceSquared(x.Position, currentPosition))
-                .FirstOrDefault(x => x != state.Zone);
-            if (zone != null)
-                result.Add(zone.Position);
-        }
+        for (int i = state.PathIndex; i < state.Path.Count && result.Count < MaxPatrolPathTargets; i++)
+            AddPatrolSegmentTargets(result, state.Path, i, i != state.PathIndex);
 
         return result;
     }
 
-    private List<Vector3> GetPathTargets(PopGroup group, Vector3 currentPosition)
+    private List<Vector3> GetPathTargets(PopGroup group)
     {
         var result = new List<Vector3>();
         var path = group.State.Path;
         if (path == null || path.Count == 0 || group.PathIndex < 0)
             return result;
 
+        if (group.InitialPathTarget is { } initialTarget)
+        {
+            result.Add(initialTarget);
+            group.InitialPathTarget = null;
+        }
+
         var index = Math.Clamp(group.PathIndex, 0, path.Count - 1);
-        var direction = group.PathDirection == 0 ? 1 : Math.Sign(group.PathDirection);
+        var includeCurrent = result.Count > 0 &&
+                             TryGetPatrolPathLine(path, index, out _, out _);
         var closedLoop = IsClosedPath(path);
 
-        for (int count = 0; count < 4 && path.Count > 1; count++)
+        for (int count = 0; count < MaxPatrolPathTargets && result.Count < MaxPatrolPathTargets && path.Count > 1; count++)
         {
-            var next = index + direction;
-            if (closedLoop)
+            if (!includeCurrent)
             {
-                next = (next + path.Count) % path.Count;
-            }
-            else if (next < 0 || next >= path.Count)
-            {
-                direction *= -1;
-                next = index + direction;
-                if (next < 0 || next >= path.Count)
+                index++;
+                if (closedLoop)
+                    index %= path.Count;
+                else if (index >= path.Count)
                     break;
             }
 
-            index = next;
-            result.Add(path[index].Position);
+            AddPatrolSegmentTargets(result, path, index, index != group.PathIndex);
+            includeCurrent = false;
         }
 
         if (result.Count == 0)
         {
-            var zone = path
-                .OrderBy(x => Vector3.DistanceSquared(x.Position, currentPosition))
-                .FirstOrDefault(x => x != group.State.Zone);
-            if (zone != null)
-            {
-                index = path.IndexOf(zone);
-                result.Add(zone.Position);
-            }
+            result.Add(SampleZonePoint(group.State.Zone));
         }
 
         group.PathIndex = index;
-        group.PathDirection = direction;
         return result;
     }
 
-    private static bool IsClosedPath(List<Zone> path)
+    private static void AddPatrolSegmentTargets(
+        List<Vector3> result,
+        List<PatrolPathSegment> path,
+        int pathIndex,
+        bool includeStart)
+    {
+        if (!TryGetPatrolPathLine(path, pathIndex, out var start, out var end))
+        {
+            AddPatrolTarget(result, path[pathIndex].Zone.Position);
+            return;
+        }
+
+        if (includeStart && result.Count + 1 < MaxPatrolPathTargets)
+            AddPatrolTarget(result, start);
+        AddPatrolTarget(result, end);
+    }
+
+    private static void AddPatrolTarget(List<Vector3> result, Vector3 target)
+    {
+        if (result.Count >= MaxPatrolPathTargets)
+            return;
+        if (result.Count > 0 &&
+            Vector3.DistanceSquared(result[^1], target) < PatrolPathWaypointRange * PatrolPathWaypointRange)
+        {
+            return;
+        }
+        result.Add(target);
+    }
+
+    private static bool IsClosedPath(List<PatrolPathSegment> path)
     {
         if (path.Count < 3)
             return false;
 
-        var first = path[0].Position;
-        var last = path[^1].Position;
+        if (ReferenceEquals(path[0].Zone, path[^1].Zone))
+            return true;
+
+        var first = path[0].Zone.Position;
+        var last = path[^1].Zone.Position;
         return Vector3.DistanceSquared(first, last) < 1;
+    }
+
+    private GameObject? FindRetirementDockable(PopGroup group, Vector3 currentPosition)
+    {
+        var maxDistance = group.PersistDistance > 0
+            ? group.PersistDistance
+            : DefaultPersistDistance;
+        var maxDistanceSquared = maxDistance * maxDistance;
+
+        GameObject? nearest = null;
+        var nearestDistance = float.MaxValue;
+        foreach (var obj in world.GameWorld.Objects)
+        {
+            if (string.IsNullOrWhiteSpace(obj.Nickname) ||
+                obj.SystemObject == null ||
+                !Alive(obj) ||
+                !obj.TryGetComponent<SDockableComponent>(out var dockable) ||
+                dockable.Action.Kind != DockKinds.Base ||
+                dockable.DockPoints.Length == 0)
+            {
+                continue;
+            }
+
+            var distance = Vector3.DistanceSquared(currentPosition, obj.WorldTransform.Position);
+            if (distance > maxDistanceSquared || distance >= nearestDistance)
+                continue;
+
+            nearestDistance = distance;
+            nearest = obj;
+        }
+        return nearest;
     }
 
     private GameObject? FindDockable(Vector3 currentPosition, string? excludeNickname = null)
@@ -270,12 +330,12 @@ public partial class SpacePopulationManager
         return nearest;
     }
 
-    private Vector3 GetFirstDirectiveTarget(ZoneState state, EncounterInfo info, Vector3 position)
+    private Vector3 GetFirstDirectiveTarget(ZoneState state, EncounterInfo info)
     {
         var behavior = info.FormationDefinition?.Behavior ?? EncounterBehavior.wander;
         if (behavior == EncounterBehavior.patrol_path || IsPatrol(state.Zone))
         {
-            var targets = GetPathTargets(state, position);
+            var targets = GetPathTargets(state);
             if (targets.Count > 0)
                 return targets[0];
         }
@@ -286,6 +346,9 @@ public partial class SpacePopulationManager
     {
         foreach (var group in state.Groups)
         {
+            if (group.InCombat)
+                continue;
+
             var leader = group.Ships.FirstOrDefault(Alive);
             if (leader == null)
                 continue;

--- a/src/LibreLancer/Server/SpacePopulationGeometry.cs
+++ b/src/LibreLancer/Server/SpacePopulationGeometry.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Numerics;
 using LibreLancer.Data.GameData.World;
 using LibreLancer.World;
@@ -9,6 +10,291 @@ namespace LibreLancer.Server;
 public partial class SpacePopulationManager
 {
     private const float SpawnVerticalBand = 200f;
+    private const float PatrolPathSpawnMinDistance = 2500f;
+    private const float PatrolPathSpawnMaxDistance = 10000f;
+    private const float PatrolPathSpawnDistanceScale = 14f;
+    private const float PatrolPathPersistBuffer = 500f;
+    private const float PatrolPathLineDistanceTolerance = 500f;
+
+    private readonly record struct PatrolPathSpawnCandidate(
+        Vector3 Start,
+        Vector3 End,
+        int PathIndex,
+        Vector3 PlayerPosition,
+        float StartT,
+        float EndT,
+        float Length,
+        float LineDistance);
+
+    private bool TryFindPatrolPathSpawnLocation(
+        ZoneState state,
+        GameObject[] players,
+        float zoneCreationDistance,
+        out SpawnLocation spawn)
+    {
+        spawn = default;
+        var path = state.Path;
+        if (path == null || path.Count < 2 || players.Length == 0)
+            return false;
+
+        var maxDistance = zoneCreationDistance > 0
+            ? zoneCreationDistance * PatrolPathSpawnDistanceScale
+            : PatrolPathSpawnMaxDistance;
+        if (maxDistance <= PatrolPathSpawnMinDistance)
+            maxDistance = PatrolPathSpawnMaxDistance;
+
+        var candidates = new List<PatrolPathSpawnCandidate>();
+        AddPatrolPathSpawnCandidates(state, players, maxDistance, candidates);
+
+        if (!ChoosePatrolPathSpawnCandidate(candidates, out var candidateInfo))
+        {
+            spawn = default;
+            return false;
+        }
+
+        var candidate = SamplePatrolPathSpawnPoint(candidateInfo, players, maxDistance);
+        var approachTarget = ClosestPointOnSegment(
+            candidateInfo.Start,
+            candidateInfo.End,
+            candidateInfo.PlayerPosition);
+        spawn = new SpawnLocation(
+            candidate,
+            Quaternion.Identity,
+            null,
+            0,
+            candidateInfo.PathIndex,
+            approachTarget,
+            maxDistance + PatrolPathPersistBuffer);
+        return true;
+    }
+
+    private void AddPatrolPathSpawnCandidates(
+        ZoneState state,
+        GameObject[] players,
+        float maxDistance,
+        List<PatrolPathSpawnCandidate> candidates)
+    {
+        var path = state.Path;
+        if (path is { Count: > 0 })
+        {
+            var count = candidates.Count;
+            for (int i = 0; i < path.Count; i++)
+                AddPatrolZoneSpawnCandidates(players, candidates, path, i, maxDistance);
+
+            if (candidates.Count > count)
+                return;
+
+            for (int i = 0; i + 1 < path.Count; i++)
+                AddPatrolPathSpawnCandidates(players, candidates, path[i].Zone.Position, path[i + 1].Zone.Position, i, maxDistance);
+            return;
+        }
+
+        AddPatrolZoneSpawnCandidates(players, candidates, state.Zone, state.PathIndex, maxDistance);
+    }
+
+    private void AddPatrolZoneSpawnCandidates(
+        GameObject[] players,
+        List<PatrolPathSpawnCandidate> candidates,
+        List<PatrolPathSegment> path,
+        int pathIndex,
+        float maxDistance)
+    {
+        if (!TryGetPatrolPathLine(path, pathIndex, out var start, out var end))
+            return;
+
+        AddPatrolPathSpawnCandidates(players, candidates, start, end, pathIndex, maxDistance);
+    }
+
+    private void AddPatrolZoneSpawnCandidates(
+        GameObject[] players,
+        List<PatrolPathSpawnCandidate> candidates,
+        Zone zone,
+        int pathIndex,
+        float maxDistance)
+    {
+        if (!TryGetPatrolZoneLine(zone, out var start, out var end))
+            return;
+
+        AddPatrolPathSpawnCandidates(players, candidates, start, end, pathIndex, maxDistance);
+    }
+
+    private void AddPatrolPathSpawnCandidates(
+        GameObject[] players,
+        List<PatrolPathSpawnCandidate> candidates,
+        Vector3 start,
+        Vector3 end,
+        int pathIndex,
+        float maxDistance)
+    {
+        foreach (var player in players)
+        {
+            AddPatrolPathSpawnCandidates(
+                candidates,
+                start,
+                end,
+                pathIndex,
+                player.WorldTransform.Position,
+                PatrolPathSpawnMinDistance,
+                maxDistance);
+        }
+    }
+
+    private void AddPatrolPathSpawnCandidates(
+        List<PatrolPathSpawnCandidate> candidates,
+        Vector3 a,
+        Vector3 b,
+        int pathIndex,
+        Vector3 playerPosition,
+        float minDistance,
+        float maxDistance)
+    {
+        var segment = b - a;
+        var lengthSquared = segment.LengthSquared();
+        if (lengthSquared < 1)
+            return;
+
+        var length = MathF.Sqrt(lengthSquared);
+        var closestT = Math.Clamp(Vector3.Dot(playerPosition - a, segment) / lengthSquared, 0, 1);
+        var closestPoint = a + segment * closestT;
+        var perpendicular = Vector3.Distance(playerPosition, closestPoint);
+        if (perpendicular > maxDistance)
+            return;
+
+        var minAlong = MathF.Sqrt(MathF.Max(0, minDistance * minDistance - perpendicular * perpendicular)) / length;
+        var maxAlong = MathF.Sqrt(MathF.Max(0, maxDistance * maxDistance - perpendicular * perpendicular)) / length;
+        if (maxAlong <= 0)
+            return;
+
+        AddPatrolPathSpawnCandidate(candidates, a, b, pathIndex, playerPosition, closestT - maxAlong, closestT - minAlong, length, perpendicular);
+    }
+
+    private static void AddPatrolPathSpawnCandidate(
+        List<PatrolPathSpawnCandidate> candidates,
+        Vector3 start,
+        Vector3 end,
+        int pathIndex,
+        Vector3 playerPosition,
+        float startT,
+        float endT,
+        float segmentLength,
+        float lineDistance)
+    {
+        startT = Math.Clamp(startT, 0, 1);
+        endT = Math.Clamp(endT, 0, 1);
+        if (endT <= startT)
+            return;
+
+        candidates.Add(new PatrolPathSpawnCandidate(
+            start,
+            end,
+            pathIndex,
+            playerPosition,
+            startT,
+            endT,
+            (endT - startT) * segmentLength,
+            lineDistance));
+    }
+
+    private bool ChoosePatrolPathSpawnCandidate(
+        List<PatrolPathSpawnCandidate> candidates,
+        out PatrolPathSpawnCandidate selected)
+    {
+        selected = default;
+        var closestLine = float.MaxValue;
+        foreach (var candidate in candidates)
+            closestLine = MathF.Min(closestLine, candidate.LineDistance);
+        if (closestLine == float.MaxValue)
+            return false;
+
+        var maxLineDistance = closestLine + PatrolPathLineDistanceTolerance;
+
+        var totalLength = 0f;
+        foreach (var candidate in candidates)
+        {
+            if (candidate.LineDistance <= maxLineDistance &&
+                candidate.Length > 0)
+            {
+                totalLength += candidate.Length;
+            }
+        }
+        if (totalLength <= 0)
+            return false;
+
+        PatrolPathSpawnCandidate? fallback = null;
+        var roll = random.NextSingle() * totalLength;
+        foreach (var candidate in candidates)
+        {
+            if (candidate.LineDistance > maxLineDistance ||
+                candidate.Length <= 0)
+            {
+                continue;
+            }
+
+            fallback ??= candidate;
+            roll -= candidate.Length;
+            if (roll <= 0)
+            {
+                selected = candidate;
+                return true;
+            }
+        }
+
+        selected = fallback.GetValueOrDefault();
+        return fallback.HasValue;
+    }
+
+    private Vector3 SamplePatrolPathSpawnPoint(
+        PatrolPathSpawnCandidate candidate,
+        GameObject[] players,
+        float maxDistance)
+    {
+        var t = Lerp(candidate.StartT, candidate.EndT, random.NextSingle());
+        var point = Vector3.Lerp(candidate.Start, candidate.End, t);
+        for (int i = 0; i < 4; i++)
+        {
+            var playerPosition = GetNearestPlayer(point, players).WorldTransform.Position;
+            var distance = Vector3.Distance(point, playerPosition);
+            if (distance + 1 >= PatrolPathSpawnMinDistance && distance <= maxDistance)
+                return point;
+
+            point = MovePatrolSpawnIntoRange(
+                candidate,
+                point,
+                playerPosition,
+                distance < PatrolPathSpawnMinDistance ? PatrolPathSpawnMinDistance : maxDistance);
+        }
+        return point;
+    }
+
+    private Vector3 MovePatrolSpawnIntoRange(
+        PatrolPathSpawnCandidate candidate,
+        Vector3 point,
+        Vector3 playerPosition,
+        float targetDistance)
+    {
+        var segment = candidate.End - candidate.Start;
+        var lengthSquared = segment.LengthSquared();
+        if (lengthSquared < 1)
+            return candidate.Start;
+
+        var length = MathF.Sqrt(lengthSquared);
+        var closestT = Math.Clamp(Vector3.Dot(playerPosition - candidate.Start, segment) / lengthSquared, 0, 1);
+        var currentT = Math.Clamp(Vector3.Dot(point - candidate.Start, segment) / lengthSquared, 0, 1);
+        var closestPoint = candidate.Start + segment * closestT;
+        var perpendicular = Vector3.Distance(playerPosition, closestPoint);
+        if (perpendicular >= targetDistance)
+            return closestPoint;
+
+        var offset = MathF.Sqrt(MathF.Max(0, targetDistance * targetDistance - perpendicular * perpendicular)) / length;
+        var sign = currentT >= closestT ? 1 : -1;
+        if (MathF.Abs(currentT - closestT) < 0.0001f)
+            sign = -1;
+
+        var targetT = closestT + sign * offset;
+        targetT = Math.Clamp(targetT, candidate.StartT, candidate.EndT);
+
+        return Vector3.Lerp(candidate.Start, candidate.End, Math.Clamp(targetT, 0, 1));
+    }
 
     private bool TryFindSpawnPoint(
         Zone zone,
@@ -54,6 +340,17 @@ public partial class SpacePopulationManager
         }
 
         return false;
+    }
+
+    private static Vector3 ClosestPointOnSegment(Vector3 a, Vector3 b, Vector3 point)
+    {
+        var segment = b - a;
+        var lengthSquared = segment.LengthSquared();
+        if (lengthSquared < 1)
+            return a;
+
+        var t = Math.Clamp(Vector3.Dot(point - a, segment) / lengthSquared, 0, 1);
+        return a + segment * t;
     }
 
     private float DistanceToNearestPlayer(Vector3 point, GameObject[] players)
@@ -131,6 +428,121 @@ public partial class SpacePopulationManager
     private static Vector3 TransformZoneLocal(Zone zone, Vector3 local) =>
         zone.Position + Vector3.Transform(local, zone.RotationMatrix);
 
+    private static bool TryGetPatrolZoneLine(Zone zone, out Vector3 start, out Vector3 end)
+    {
+        if (zone.Shape is ShapeKind.Cylinder or ShapeKind.Ring)
+        {
+            start = TransformZoneLocal(zone, new Vector3(0, zone.Size.Y * -0.5f, 0));
+            end = TransformZoneLocal(zone, new Vector3(0, zone.Size.Y * 0.5f, 0));
+            return true;
+        }
+
+        start = Vector3.Zero;
+        end = Vector3.Zero;
+        return false;
+    }
+
+    private static bool TryGetPatrolPathLine(List<PatrolPathSegment> path, int index, out Vector3 start, out Vector3 end)
+    {
+        start = Vector3.Zero;
+        end = Vector3.Zero;
+        if (index < 0 || index >= path.Count)
+            return false;
+
+        if (!TryGetPatrolZoneLine(path[index].Zone, out start, out end))
+        {
+            if (index + 1 < path.Count)
+            {
+                start = path[index].Zone.Position;
+                end = path[index + 1].Zone.Position;
+                return true;
+            }
+            if (index > 0)
+            {
+                start = path[index - 1].Zone.Position;
+                end = path[index].Zone.Position;
+                return true;
+            }
+            return false;
+        }
+
+        OrientPatrolPathLine(path, index, ref start, ref end);
+        return true;
+    }
+
+    private static void OrientPatrolPathLine(List<PatrolPathSegment> path, int index, ref Vector3 start, ref Vector3 end)
+    {
+        if (!TryGetPatrolConnectionScore(path, index, start, end, out var forwardScore) ||
+            !TryGetPatrolConnectionScore(path, index, end, start, out var reverseScore) ||
+            forwardScore <= reverseScore)
+        {
+            return;
+        }
+
+        (start, end) = (end, start);
+    }
+
+    private static bool TryGetPatrolConnectionScore(
+        List<PatrolPathSegment> path,
+        int index,
+        Vector3 start,
+        Vector3 end,
+        out float score)
+    {
+        score = 0;
+        var scored = false;
+
+        if (TryGetPatrolPrevious(path, index, out var previous))
+        {
+            score += DistanceToPatrolConnection(start, path[previous].Zone);
+            scored = true;
+        }
+
+        if (TryGetPatrolNext(path, index, out var next))
+        {
+            score += DistanceToPatrolConnection(end, path[next].Zone);
+            scored = true;
+        }
+
+        return scored;
+    }
+
+    private static bool TryGetPatrolPrevious(List<PatrolPathSegment> path, int index, out int previous)
+    {
+        previous = index - 1;
+        if (previous >= 0)
+            return true;
+
+        if (!IsClosedPath(path))
+            return false;
+
+        previous = path.Count - 1;
+        return previous != index;
+    }
+
+    private static bool TryGetPatrolNext(List<PatrolPathSegment> path, int index, out int next)
+    {
+        next = index + 1;
+        if (next < path.Count)
+            return true;
+
+        if (!IsClosedPath(path))
+            return false;
+
+        next = 0;
+        return next != index;
+    }
+
+    private static float DistanceToPatrolConnection(Vector3 point, Zone zone)
+    {
+        if (!TryGetPatrolZoneLine(zone, out var start, out var end))
+            return Vector3.DistanceSquared(point, zone.Position);
+
+        return MathF.Min(
+            Vector3.DistanceSquared(point, start),
+            Vector3.DistanceSquared(point, end));
+    }
+
     private Vector3 RandomUnitVector()
     {
         var z = random.NextSingle() * 2f - 1f;
@@ -149,6 +561,6 @@ public partial class SpacePopulationManager
             ? Vector3.UnitZ
             : Vector3.UnitY;
         return Quaternion.Normalize(Quaternion.CreateFromRotationMatrix(
-            Matrix4x4.CreateWorld(Vector3.Zero, -direction, up)));
+            Matrix4x4.CreateWorld(Vector3.Zero, direction, up)));
     }
 }

--- a/src/LibreLancer/Server/SpacePopulationManager.cs
+++ b/src/LibreLancer/Server/SpacePopulationManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using LibreLancer.Data.GameData.World;
 using LibreLancer.Data.Schema.Missions;
 using LibreLancer.Server.Components;
 using LibreLancer.World;
@@ -16,7 +17,9 @@ public partial class SpacePopulationManager
     private const float DefaultSpawnMinDistance = 100f;
     private const float DefaultPersistDistance = 2500f;
     private const float BattleDistance = 5000f;
+    private const float CombatEngageDistance = 2500f;
     private const float BattlePersistDistance = 7500f;
+    private const float ZoneSpawnEdgeDistance = 2000f;
     private const double BattleCooldownSeconds = 10.0;
 
     private readonly ServerWorld world;
@@ -59,6 +62,7 @@ public partial class SpacePopulationManager
             foreach (var group in state.Groups)
                 group.AgeSeconds += delta;
 
+            UpdateGroupCombat(state);
             UpdateIdleGroupDirectives(state);
             state.TimeUntilHeartbeat -= delta;
             if (state.TimeUntilHeartbeat > 0)
@@ -71,20 +75,38 @@ public partial class SpacePopulationManager
 
     private void InitializePaths()
     {
-        var paths = zones
-            .Where(x => x.Zone.PathLabel is { Length: >= 2 })
-            .GroupBy(x => x.Zone.PathLabel![0], StringComparer.OrdinalIgnoreCase);
-        foreach (var path in paths)
+        var paths = world.System.Zones
+            .Where(x => x.PathLabel is { Length: >= 2 })
+            .SelectMany(PatrolPathSegments)
+            .GroupBy(x => x.Zone.PathLabel![0], StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                x => x.Key,
+                x => x.OrderBy(y => y.Label).ToList(),
+                StringComparer.OrdinalIgnoreCase);
+
+        foreach (var state in zones)
         {
-            var ordered = path
-                .Select(x => x.Zone)
-                .OrderBy(PathIndex)
-                .ToList();
-            foreach (var state in path)
-            {
-                state.Path = ordered;
-                state.PathIndex = ordered.IndexOf(state.Zone);
-            }
+            if (state.Zone.PathLabel is not { Length: >= 2 } ||
+                !paths.TryGetValue(state.Zone.PathLabel[0], out var path))
+                continue;
+
+            state.Path = path;
+            var zoneLabel = PathIndex(state.Zone);
+            state.PathIndex = path.FindIndex(x =>
+                ReferenceEquals(x.Zone, state.Zone) &&
+                x.Label == zoneLabel);
+        }
+    }
+
+    private static IEnumerable<PatrolPathSegment> PatrolPathSegments(Zone zone)
+    {
+        if (zone.PathLabel is not { Length: >= 2 })
+            yield break;
+
+        for (int i = 1; i < zone.PathLabel.Length; i++)
+        {
+            if (int.TryParse(zone.PathLabel[i], out var label))
+                yield return new PatrolPathSegment(zone, label);
         }
     }
 
@@ -106,17 +128,74 @@ public partial class SpacePopulationManager
         foreach (var player in players)
         {
             var position = player.WorldTransform.Position;
-            if (!state.Zone.ContainsPoint(position) ||
+            if (!IsPopulationZoneActive(state, position) ||
                 !AllowsPopulationSpawn(state.Zone, position))
             {
                 continue;
             }
 
             activePlayers.Add(player);
-            effectiveDensity = Math.Max(effectiveDensity, EffectivePopulationDensity(state.Zone, position));
+            effectiveDensity = Math.Max(effectiveDensity, state.Zone.Density);
         }
 
         return new PopulationContext(activePlayers.ToArray(), effectiveDensity);
+    }
+
+    private bool IsPopulationZoneActive(ZoneState state, Vector3 position)
+    {
+        if (!state.Zone.ContainsPoint(position) &&
+            DistanceToZoneEdge(state.Zone, position) > ZoneSpawnEdgeDistance)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static float DistanceToZoneEdge(Zone zone, Vector3 position)
+    {
+        if (zone.ContainsPoint(position))
+            return 0;
+
+        var offset = position - zone.Position;
+        return zone.Shape switch
+        {
+            ShapeKind.Sphere => MathF.Max(0, offset.Length() - zone.Size.X),
+            ShapeKind.Box => DistanceToBoxEdge(zone, position),
+            ShapeKind.Ellipsoid => DistanceToEllipsoidEdge(zone, position),
+            ShapeKind.Cylinder or ShapeKind.Ring => DistanceToCylinderEdge(zone, position),
+            _ => float.MaxValue
+        };
+    }
+
+    private static float DistanceToBoxEdge(Zone zone, Vector3 position)
+    {
+        var local = Vector3.Transform(position - zone.Position, Matrix4x4.Transpose(zone.RotationMatrix));
+        var outside = Vector3.Max(Vector3.Abs(local) - zone.Size * 0.5f, Vector3.Zero);
+        return outside.Length();
+    }
+
+    private static float DistanceToEllipsoidEdge(Zone zone, Vector3 position)
+    {
+        var local = Vector3.Transform(position - zone.Position, Matrix4x4.Transpose(zone.RotationMatrix));
+        var length = local.Length();
+        if (length < 1)
+            return 0;
+
+        var direction = local / length;
+        var denominator = MathF.Sqrt(
+            (direction.X * direction.X) / (zone.Size.X * zone.Size.X) +
+            (direction.Y * direction.Y) / (zone.Size.Y * zone.Size.Y) +
+            (direction.Z * direction.Z) / (zone.Size.Z * zone.Size.Z));
+        return denominator <= 0 ? 0 : MathF.Max(0, length - (1 / denominator));
+    }
+
+    private static float DistanceToCylinderEdge(Zone zone, Vector3 position)
+    {
+        var local = Vector3.Transform(position - zone.Position, Matrix4x4.Transpose(zone.RotationMatrix));
+        var radial = MathF.Max(0, MathF.Sqrt(local.X * local.X + local.Z * local.Z) - zone.Size.X);
+        var vertical = MathF.Max(0, MathF.Abs(local.Y) - zone.Size.Y * 0.5f);
+        return MathF.Sqrt(radial * radial + vertical * vertical);
     }
 
     private bool AllowsPopulationSpawn(Zone zone, Vector3 position)
@@ -133,21 +212,6 @@ public partial class SpacePopulationManager
         }
 
         return true;
-    }
-
-    private int EffectivePopulationDensity(Zone zone, Vector3 position)
-    {
-        var density = zone.Density;
-        foreach (var other in world.System.Zones)
-        {
-            if (ReferenceEquals(other, zone))
-                return density;
-
-            if (other.PopulationAdditive == false && other.ContainsPoint(position))
-                density = other.Density;
-        }
-
-        return density;
     }
 
     private static bool Alive(GameObject obj) =>

--- a/src/LibreLancer/Server/SpacePopulationSpawner.cs
+++ b/src/LibreLancer/Server/SpacePopulationSpawner.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using LibreLancer.Data.GameData;
@@ -56,13 +57,16 @@ public partial class SpacePopulationManager
         {
             return;
         }
+        var populationClasses = BuildPopulationClasses(state.Zone, info, faction);
+        if (!CanSpawnRestrictedPopulation(state, populationClasses))
+            return;
         if (!CanCreateFormation(state, info))
             return;
         var creationDistance = info.FormationDefinition?.ZoneCreationDistance ?? 0;
         if (!TryFindSpawnLocation(state, info, context.Players, creationDistance, false, out var spawn))
             return;
 
-        SpawnGroup(state, info, faction, spawn);
+        SpawnGroup(state, info, faction, spawn, populationClasses);
     }
 
     public void PopulateInitialAroundPlayer(GameObject player)
@@ -119,13 +123,16 @@ public partial class SpacePopulationManager
         {
             return;
         }
+        var populationClasses = BuildPopulationClasses(state.Zone, info, faction);
+        if (!CanSpawnRestrictedPopulation(state, populationClasses))
+            return;
         if (!CanCreateFormation(state, info))
             return;
         var creationDistance = info.FormationDefinition?.ZoneCreationDistance ?? 0;
         if (!TryFindSpawnLocation(state, info, context.Players, creationDistance, true, out var spawn))
             return;
 
-        SpawnGroup(state, info, faction, spawn);
+        SpawnGroup(state, info, faction, spawn, populationClasses);
     }
 
     private int CountShips(ZoneState state) =>
@@ -226,18 +233,30 @@ public partial class SpacePopulationManager
         }
     }
 
-    private void SpawnGroup(ZoneState state, EncounterInfo info, Faction faction, SpawnLocation spawn)
+    private void SpawnGroup(
+        ZoneState state,
+        EncounterInfo info,
+        Faction faction,
+        SpawnLocation spawn,
+        HashSet<string> populationClasses)
     {
         var items = world.Server.GameData.Items;
         var position = spawn.Position;
-        var firstTarget = GetFirstDirectiveTarget(state, info, position);
+        var firstTarget = spawn.InitialPathTarget ?? GetFirstDirectiveTarget(state, info);
         var orientation = spawn.ArrivalObject != null
             ? spawn.Orientation
             : LookRotation(firstTarget - position);
         var group = new PopGroup(state, info)
         {
-            ArrivalObject = spawn.ArrivalObject
+            ArrivalObject = spawn.ArrivalObject,
+            PersistDistance = spawn.PersistDistance
         };
+        foreach (var populationClass in populationClasses)
+            group.PopulationClasses.Add(populationClass);
+        if (spawn.PathIndex >= 0)
+            group.PathIndex = spawn.PathIndex;
+        group.InitialPathTarget = spawn.InitialPathTarget;
+
         SDockableComponent? arrivalDockable = null;
         if (spawn.ArrivalObject != null &&
             world.GameWorld.GetObject(spawn.ArrivalObject)?.TryGetComponent<SDockableComponent>(out var dockable) == true)
@@ -248,13 +267,23 @@ public partial class SpacePopulationManager
         for (int i = 0; i < info.Ships.Count; i++)
         {
             var arrivalIndex = spawn.ArrivalIndex;
-            if (arrivalDockable != null && !arrivalDockable.TryGetUndockIndex(out arrivalIndex))
-                break;
+            var reservedArrival = false;
+            if (arrivalDockable != null)
+            {
+                reservedArrival = spawn.ArrivalIndex == 0
+                    ? arrivalDockable.TryReserveUndockIndex(out arrivalIndex)
+                    : arrivalDockable.TryReserveUndockIndex(arrivalIndex);
+
+                if (!reservedArrival)
+                    break;
+            }
 
             var entry = info.Ships[i];
             if (string.IsNullOrWhiteSpace(entry.Ship.Loadout) ||
                 !items.TryGetLoadout(entry.Ship.Loadout, out var loadout))
             {
+                if (reservedArrival)
+                    arrivalDockable!.ReleaseUndockIndex(arrivalIndex);
                 FLLog.Warning("SpacePop", $"NPC ship {entry.Ship.Nickname} has no valid loadout");
                 continue;
             }
@@ -281,18 +310,13 @@ public partial class SpacePopulationManager
                 spawn.ArrivalObject,
                 arrivalIndex,
                 null,
-                false);
+                false,
+                reservedArrival);
             group.Ships.Add(obj);
         }
 
         if (group.Ships.Count == 0)
             return;
-
-        var factionName = string.IsNullOrWhiteSpace(faction.Nickname) ? "unknown" : faction.Nickname;
-        var arrival = spawn.ArrivalObject == null
-            ? "free space"
-            : $"{spawn.ArrivalObject}:{spawn.ArrivalIndex}";
-        FLLog.Debug("SpacePop", $"Spawned {group.Ships.Count} NPC(s) from zone {state.Zone.Nickname} for faction {factionName} via {arrival}");
 
         state.Groups.Add(group);
         RecordFormationCreation(state, info);
@@ -305,6 +329,88 @@ public partial class SpacePopulationManager
                 group.Ships.Skip(1).Select(x => x.Nickname).ToList());
         }
         AssignDirectives(group);
+    }
+
+    private bool CanSpawnRestrictedPopulation(ZoneState state, HashSet<string> populationClasses)
+    {
+        if (state.Zone.DensityRestrictions is not { Length: > 0 })
+            return true;
+
+        foreach (var restriction in state.Zone.DensityRestrictions)
+        {
+            var type = NormalizePopulationClass(restriction.Type);
+            if (!populationClasses.Contains(type))
+                continue;
+
+            if (restriction.Count <= 0)
+                return false;
+
+            if (CountPopulationClass(type) >= restriction.Count)
+                return false;
+        }
+        return true;
+    }
+
+    private int CountPopulationClass(string populationClass)
+    {
+        var count = 0;
+        foreach (var state in zones)
+        {
+            foreach (var group in state.Groups)
+            {
+                if (group.PopulationClasses.Contains(populationClass) &&
+                    group.Ships.Any(Alive))
+                {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    private static HashSet<string> BuildPopulationClasses(Zone zone, EncounterInfo info, Faction faction)
+    {
+        var classes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        AddPopulationClasses(classes, zone.PopType);
+        foreach (var entry in info.Ships)
+            AddPopulationClass(classes, entry.MakeClass);
+
+        if (faction.Properties?.Legality == Legality.Unlawful)
+            classes.Add("unlawfuls");
+        else
+            classes.Add("lawfuls");
+        return classes;
+    }
+
+    private static void AddPopulationClasses(HashSet<string> classes, string[]? values)
+    {
+        if (values == null)
+            return;
+
+        foreach (var value in values)
+            AddPopulationClass(classes, value);
+    }
+
+    private static void AddPopulationClass(HashSet<string> classes, string? value)
+    {
+        var normalized = NormalizePopulationClass(value);
+        if (normalized.Length == 0)
+            return;
+
+        classes.Add(normalized);
+        if (normalized.EndsWith("_patroller", StringComparison.OrdinalIgnoreCase))
+            classes.Add("patroller");
+    }
+
+    private static string NormalizePopulationClass(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return string.Empty;
+
+        value = value.Trim();
+        return value.StartsWith("class_", StringComparison.OrdinalIgnoreCase)
+            ? value["class_".Length..]
+            : value;
     }
 
     private bool CanCreateFormation(ZoneState state, EncounterInfo info)

--- a/src/LibreLancer/Server/SpacePopulationState.cs
+++ b/src/LibreLancer/Server/SpacePopulationState.cs
@@ -16,26 +16,35 @@ public partial class SpacePopulationManager
         public double TimeUntilHeartbeat;
         public double BattleCooldown;
         public bool InBattle => BattleCooldown > 0;
-        public List<Zone>? Path;
+        public List<PatrolPathSegment>? Path;
         public int PathIndex = -1;
     }
+
+    private readonly record struct PatrolPathSegment(Zone Zone, int Label);
 
     private sealed class PopGroup(ZoneState state, EncounterInfo encounter)
     {
         public readonly ZoneState State = state;
         public readonly EncounterInfo Encounter = encounter;
         public readonly List<GameObject> Ships = [];
+        public readonly HashSet<string> PopulationClasses = new(System.StringComparer.OrdinalIgnoreCase);
         public double AgeSeconds;
         public string? ArrivalObject;
+        public float PersistDistance;
         public int PathIndex = state.PathIndex;
-        public int PathDirection = 1;
+        public Vector3? InitialPathTarget;
+        public bool InCombat;
+        public Vector3? ResumeDutyTarget;
     }
 
     private readonly record struct SpawnLocation(
         Vector3 Position,
         Quaternion Orientation,
         string? ArrivalObject,
-        int ArrivalIndex);
+        int ArrivalIndex,
+        int PathIndex = -1,
+        Vector3? InitialPathTarget = null,
+        float PersistDistance = 0);
 
     private readonly record struct PopulationContext(GameObject[] Players, int Density);
 }

--- a/src/LibreLancer/World/Components/AnimationComponent.cs
+++ b/src/LibreLancer/World/Components/AnimationComponent.cs
@@ -240,6 +240,23 @@ namespace LibreLancer.World.Components
             return anm.Scripts.ContainsKey(animationName);
         }
 
+        public float GetAnimationDuration(string? animationName)
+        {
+            if (animationName == null ||
+                !anm.Scripts.TryGetValue(animationName, out var script))
+            {
+                return 0;
+            }
+
+            var duration = 0f;
+            foreach (var jm in script.JointMaps)
+            {
+                duration = Math.Max(duration, jm.Channel.Duration);
+            }
+
+            return duration;
+        }
+
         public override void Update(double time, GameWorld world)
         {
             if ((GameObject?)Parent != null && Parent.RenderComponent is CharacterRenderer characterRenderer)

--- a/src/LibreLancer/World/Components/AutopilotComponent.cs
+++ b/src/LibreLancer/World/Components/AutopilotComponent.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Numerics;
 using ImGuiNET;
 using LibreLancer.Client.Components;
+using LibreLancer.Data.GameData.World;
 using LibreLancer.Net.Protocol;
 
 namespace LibreLancer.World.Components
@@ -25,6 +26,8 @@ namespace LibreLancer.World.Components
         private bool hasTriggeredCruise = false;
 
         public abstract AutopilotBehaviors Behavior { get; }
+
+        public virtual bool DockCameraActive => false;
 
         protected AutopilotBehavior(AutopilotComponent component)
         {
@@ -51,19 +54,23 @@ namespace LibreLancer.World.Components
         public void Start(GotoKind kind,
             GameObject targetObject,
             float maxThrottle,
-            float gotoRadius)
+            float gotoRadius,
+            bool shouldStopAtTarget = true)
         {
             TargetObject = targetObject;
+            ShouldStopAtTarget = shouldStopAtTarget;
             Start(kind, maxThrottle, gotoRadius);
         }
 
         public void Start(GotoKind kind,
             Vector3 targetPosition,
             float maxThrottle,
-            float gotoRadius)
+            float gotoRadius,
+            bool shouldStopAtTarget = true)
         {
             _targetPosition = targetPosition;
             _targetRadius = 5;
+            ShouldStopAtTarget = shouldStopAtTarget;
             Start(kind, maxThrottle, gotoRadius);
         }
 
@@ -75,6 +82,7 @@ namespace LibreLancer.World.Components
 
         protected float MaxThrottle;
         protected float GotoRadius;
+        protected bool ShouldStopAtTarget = true;
 
         protected void SetThrottle(float throttle, ShipSteeringComponent control, ShipInputComponent? input)
         {
@@ -123,9 +131,9 @@ namespace LibreLancer.World.Components
             return TargetObject.PhysicsComponent!.Body!.Collider.Radius;
         }
 
-        protected Hardpoint? GetTargetHardpoint(DockInfoComponent docking, bool reverse, int index)
+        protected Hardpoint? GetTargetHardpoint(DockInfoComponent docking, bool reverse, int index, int dockIndex = 0)
         {
-            var hps = docking.GetDockHardpoints(Parent.PhysicsComponent!.Body!.Position);
+            var hps = docking.GetDockHardpoints(Parent.PhysicsComponent!.Body!.Position, dockIndex);
 
             if (reverse)
             {
@@ -165,17 +173,18 @@ namespace LibreLancer.World.Components
             float maxSpeed,
             bool shouldStop,
             ShipSteeringComponent control,
-            ShipInputComponent? input)
+            ShipInputComponent? input,
+            bool includeTargetRadius = true)
         {
             float targetPower = 0;
             // Bring ship to within GotoRange metres of target
-            var targetRadius = GetTargetRadius();
+            var targetRadius = includeTargetRadius ? GetTargetRadius() : 0;
             var myRadius = Parent.PhysicsComponent!.Body!.Collider.Radius;
             var distance = (point - Parent.PhysicsComponent.Body.Position).Length();
 
             TriggerCruise(control, (distance - range) > 2000);
 
-            if ((distance - range) < 500)
+            if (shouldStop && (distance - range) < 500)
             {
                 control.Cruise = false; // Disable cruise at small distance
             }
@@ -210,18 +219,43 @@ namespace LibreLancer.World.Components
         }
     }
 
-    internal sealed class DockBehavior(AutopilotComponent c) : AutopilotBehavior(c)
+    internal sealed class DockBehavior(AutopilotComponent c, int dockIndex) : AutopilotBehavior(c)
     {
         public override AutopilotBehaviors Behavior => AutopilotBehaviors.Dock;
+        public override bool DockCameraActive => ringDocking;
 
         private int lastTargetHp = 0;
+        private bool ringDocking = false;
+        private double ringDockTime = 0;
+
+        private static bool IsDockingRingIndex(DockInfoComponent docking, int index) =>
+            docking.Action.Kind == DockKinds.Base &&
+            index == 0 &&
+            index < docking.Spheres.Length &&
+            docking.Spheres[index].Type == Data.Schema.Solar.DockSphereType.ring;
+
+        private void StartRingFlyThrough(ShipSteeringComponent control, ShipInputComponent? input)
+        {
+            if (Parent.TryGetComponent<ShipPhysicsComponent>(out var physics))
+            {
+                physics.Active = false;
+            }
+
+            Parent.PhysicsComponent!.Collidable = false;
+            Parent.PhysicsComponent.Body.Collidable = false;
+            Parent.PhysicsComponent.Body.LinearVelocity =
+                Vector3.Transform(-Vector3.UnitZ, Parent.PhysicsComponent.Body.Orientation) * 80;
+            ringDocking = true;
+            ringDockTime = 3.0;
+            SetThrottle(1, control, input);
+        }
 
         public override void ImGuiDebug()
         {
             if (Dockable(out var docking))
             {
                 ImGui.Text($"Docking with: {docking?.Parent}");
-                var hp = GetTargetHardpoint(docking!, false, lastTargetHp);
+                var hp = GetTargetHardpoint(docking!, false, lastTargetHp, dockIndex);
                 ImGui.Text($"Target hardpoint: {hp?.Name}");
             }
         }
@@ -233,44 +267,56 @@ namespace LibreLancer.World.Components
                 return true; // finished
             }
 
-            var hp = GetTargetHardpoint(docking!, false, lastTargetHp);
+            if (ringDocking)
+            {
+                SetThrottle(1, control, input);
+                ringDockTime -= time;
+                return ringDockTime <= 0;
+            }
+
+            var dock = docking!;
+            var hp = GetTargetHardpoint(dock, false, lastTargetHp, dockIndex);
 
             if (hp == null)
             {
                 // No dock hardpoints available, cancel docking
-                FLLog.Error("Autopilot", $"No dock hardpoints available for {Parent.Nickname} docking");
+                FLLog.Error("Autopilot", "No dock hardpoints available for docking");
                 return true; // finished
             }
 
-            float radius = 5;
-            var maxSpeed = 1f;
+            var isTradelane = dock.Action.Kind == DockKinds.Tradelane;
+            var radius = isTradelane || lastTargetHp == 2 ? dock.GetTriggerRadius(dockIndex) : 5;
             var targetPoint = (hp.Transform * TargetObject!.WorldTransform).Position;
-
-            if (lastTargetHp > 0)
-            {
-                maxSpeed = 0.3f;
-            }
-
-            if (lastTargetHp == 2)
-            {
-                radius = docking!.GetTriggerRadius();
-            }
+            var isDockingRing = IsDockingRingIndex(dock, dockIndex);
 
             var d2 = (targetPoint - Parent.PhysicsComponent!.Body!.Position).Length();
 
-            if (d2 < 80)
+            if (isDockingRing &&
+                hp.Name.Equals(dock.Spheres[dockIndex].Hardpoint, StringComparison.OrdinalIgnoreCase) &&
+                d2 <= Math.Max(250, dock.GetTriggerRadius(dockIndex) + Parent.PhysicsComponent.Body.Collider.Radius))
             {
-                maxSpeed = 0.3f;
+                StartRingFlyThrough(control, input);
+                return false;
             }
 
-            if (!MoveToPoint(time, targetPoint, radius, GotoRadius, maxSpeed, true, control, input))
+            var maxSpeed = lastTargetHp > 0 || d2 < 80 ? 0.3f : 1f;
+            if (!MoveToPoint(time, targetPoint, radius, 0, maxSpeed, true, control, input, false))
             {
                 return false; // not finished
+            }
+
+            if (isTradelane)
+            {
+                return false; // wait for the server to start the tradelane
             }
 
             if (lastTargetHp < 2)
             {
                 lastTargetHp++;
+            }
+            else if (isDockingRing)
+            {
+                StartRingFlyThrough(control, input);
             }
             else
             {
@@ -281,14 +327,15 @@ namespace LibreLancer.World.Components
         }
     }
 
-    internal sealed class UndockBehavior(AutopilotComponent c, int index) : AutopilotBehavior(c)
+    internal sealed class UndockBehavior(AutopilotComponent c, int index, double initialDelay) : AutopilotBehavior(c)
     {
         public override AutopilotBehaviors Behavior => AutopilotBehaviors.Undock;
 
-        private const double MAX_TIME_UNDOCK = 8.0;
+        private const double MAX_TIME_UNDOCK = 30.0;
 
         private double totalTime = 0.0;
-        private double delay = 1.2;
+        private double delay = initialDelay;
+        private int targetHp = 1;
 
         public override void ImGuiDebug()
         {
@@ -322,12 +369,32 @@ namespace LibreLancer.World.Components
                 return true; // finished
             }
 
-            var info = docking!.GetUndockInfo(index);
-            var targetPoint = (info.End!.Transform * TargetObject!.WorldTransform).Position;
-            var startPoint = (info.Start!.Transform * TargetObject.WorldTransform).Position;
-            return MoveToPoint(time, targetPoint, 25, 10, 1f, false, control, input) ||
-                   Vector3.Distance(startPoint, targetPoint) - 20 <
-                   Vector3.Distance(Parent.LocalTransform.Position, startPoint);
+            var hps = docking!.GetDockHardpoints(Parent.PhysicsComponent!.Body!.Position, index).Reverse().ToArray();
+            if (hps.Length < 2)
+            {
+                var info = docking.GetUndockInfo(index);
+                var fallbackPoint = (info.End!.Transform * TargetObject!.WorldTransform).Position;
+                return MoveToPoint(time, fallbackPoint, 25, 0, 1f, false, control, input, false);
+            }
+
+            if (targetHp >= hps.Length)
+            {
+                return true;
+            }
+
+            var targetPoint = (hps[targetHp].Transform * TargetObject!.WorldTransform).Position;
+            if (!MoveToPoint(time, targetPoint, 25, 0, 1f, false, control, input, false))
+            {
+                return false;
+            }
+
+            targetHp++;
+            if (targetHp < hps.Length)
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 
@@ -342,7 +409,7 @@ namespace LibreLancer.World.Components
                 return true;
             }
 
-            return MoveToPoint(time, GetTargetPoint(), GetTargetRadius(), GotoRadius, MaxThrottle, true, control,
+            return MoveToPoint(time, GetTargetPoint(), GetTargetRadius(), GotoRadius, MaxThrottle, ShouldStopAtTarget, control,
                 input);
         }
 
@@ -503,6 +570,8 @@ namespace LibreLancer.World.Components
         public AutopilotBehaviors CurrentBehavior
             => instance?.Behavior ?? AutopilotBehaviors.None;
 
+        public bool DockCameraActive => instance?.DockCameraActive ?? false;
+
         public readonly PIDController PitchControl = new();
         public readonly PIDController YawControl = new();
 
@@ -536,16 +605,16 @@ namespace LibreLancer.World.Components
             instance?.ImGuiDebug();
         }
 
-        public void GotoVec(Vector3 vec, GotoKind kind, float maxThrottle = 1, float gotoRange = 40)
+        public void GotoVec(Vector3 vec, GotoKind kind, float maxThrottle = 1, float gotoRange = 40, bool shouldStopAtTarget = true)
         {
             SetInstance(new GotoBehavior(this));
-            instance?.Start(kind, vec, maxThrottle, gotoRange);
+            instance?.Start(kind, vec, maxThrottle, gotoRange, shouldStopAtTarget);
         }
 
-        public void GotoObject(GameObject obj, GotoKind kind, float maxThrottle = 1, float gotoRange = 40)
+        public void GotoObject(GameObject obj, GotoKind kind, float maxThrottle = 1, float gotoRange = 40, bool shouldStopAtTarget = true)
         {
             SetInstance(new GotoBehavior(this));
-            instance?.Start(kind, obj, maxThrottle, gotoRange);
+            instance?.Start(kind, obj, maxThrottle, gotoRange, shouldStopAtTarget);
         }
 
         public void Cancel()
@@ -553,17 +622,31 @@ namespace LibreLancer.World.Components
             SetInstance(null);
         }
 
-        public void StartDock(GameObject target, GotoKind kind)
+        public void StartDock(GameObject target, GotoKind kind, int dockIndex = 0)
         {
-            SetInstance(new DockBehavior(this));
+            SetInstance(new DockBehavior(this, dockIndex));
             instance?.Start(kind, target, 1, 40);
         }
 
         public void Undock(GameObject target, int index)
         {
-            SetInstance(new UndockBehavior(this, index));
+            SetInstance(new UndockBehavior(this, index, GetUndockDelay(target, index)));
             instance?.Start(GotoKind.GotoNoCruise,
                 target, 1, 10);
+        }
+
+        private static double GetUndockDelay(GameObject target, int index)
+        {
+            if (!target.TryGetComponent<DockInfoComponent>(out var docking) ||
+                index < 0 ||
+                index >= docking.Spheres.Length ||
+                docking.Spheres[index].Type != Data.Schema.Solar.DockSphereType.berth)
+            {
+                return 1.2;
+            }
+
+            var duration = target.AnimationComponent?.GetAnimationDuration(docking.Spheres[index].Script) ?? 0;
+            return Math.Max(1.2, duration);
         }
 
         public void StartFormation()

--- a/src/LibreLancer/World/Components/DirectiveRunnerComponent.cs
+++ b/src/LibreLancer/World/Components/DirectiveRunnerComponent.cs
@@ -27,6 +27,17 @@ public class DirectiveRunnerComponent(GameObject parent) : GameComponent(parent)
         }
     }
 
+    public void Cancel(bool cancelAutopilot = true)
+    {
+        currentDirectives = null;
+        index = -1;
+        splineIndex = -1;
+        if (cancelAutopilot && Parent.TryGetComponent<AutopilotComponent>(out var ap))
+        {
+            ap.Cancel();
+        }
+    }
+
     private double currentDelay = 0;
 
     public override void Update(double time, GameWorld world)
@@ -55,7 +66,7 @@ public class DirectiveRunnerComponent(GameObject parent) : GameComponent(parent)
                 {
                     if (tgt.TryGetComponent<SDockableComponent>(out var sd))
                     {
-                        sd.StartDock(Parent, 0);
+                        sd.StartDock(Parent, 0, world: world);
                     }
                     else if (tgt.TryGetComponent<CLocalPlayerComponent>(out var pl))
                     {
@@ -92,7 +103,12 @@ public class DirectiveRunnerComponent(GameObject parent) : GameComponent(parent)
             {
                 if (Parent.TryGetComponent<AutopilotComponent>(out var ap))
                 {
-                    ap.GotoVec(vec.Target, vec.CruiseKind, Throttle(vec.MaxThrottle), vec.Range);
+                    ap.GotoVec(
+                        vec.Target,
+                        vec.CruiseKind,
+                        Throttle(vec.MaxThrottle),
+                        vec.Range,
+                        shouldStopAtTarget: vec.CruiseKind == GotoKind.GotoNoCruise);
                 }
 
                 break;

--- a/src/LibreLancer/World/Components/DockInfoComponent.cs
+++ b/src/LibreLancer/World/Components/DockInfoComponent.cs
@@ -3,7 +3,6 @@
 // LICENSE, which is part of this source code package
 
 using System.Collections.Generic;
-using System.Data;
 using System.Numerics;
 using LibreLancer.Data.GameData.World;
 
@@ -32,7 +31,6 @@ namespace LibreLancer.World.Components
 		public required DockAction Action;
         public required DockSphere[] Spheres;
 
-        private string? tlHP;
 		public DockInfoComponent(GameObject parent) : base(parent)
 		{
 		}
@@ -63,9 +61,15 @@ namespace LibreLancer.World.Components
 			if (Action.Kind != DockKinds.Tradelane)
 			{
 				var hpname = Spheres[index].Hardpoint.Replace("DockMount", "DockPoint");
-				yield return Parent.GetHardpoint(hpname + "02")!;
-				yield return Parent.GetHardpoint(hpname + "01")!;
-				yield return Parent.GetHardpoint(Spheres[index].Hardpoint)!;
+				var hp2 = Parent.GetHardpoint(hpname + "02");
+				var hp1 = Parent.GetHardpoint(hpname + "01");
+				var hp0 = Parent.GetHardpoint(Spheres[index].Hardpoint);
+				if (hp2 != null)
+					yield return hp2;
+				if (hp1 != null)
+					yield return hp1;
+				if (hp0 != null)
+					yield return hp0;
 			}
 			else if (Action.Kind == DockKinds.Tradelane)
 			{
@@ -74,12 +78,10 @@ namespace LibreLancer.World.Components
 				var dot = Vector3.Dot(heading, fwd);
 				if (dot > 0)
 				{
-					tlHP = "HpLeftLane";
 					yield return Parent.GetHardpoint("HpLeftLane")!;
 				}
 				else
 				{
-					tlHP = "HpRightLane";
 					yield return Parent.GetHardpoint("HpRightLane")!;
 				}
 			}

--- a/src/LibreLancer/World/EncounterHandler.cs
+++ b/src/LibreLancer/World/EncounterHandler.cs
@@ -50,7 +50,7 @@ public static class EncounterHandler
                 var arch = possible[random.Next(possible.Count)];
                 var v = faction.NpcVoices.Count > 0 ? faction.NpcVoices[random.Next(faction.NpcVoices.Count)] : null;
                 var name = MakeName(faction, v, random);
-                ei.Ships.Add(new(name, v, arch));
+                ei.Ships.Add(new(name, v, arch, s.MakeClass));
             }
         }
 

--- a/src/LibreLancer/World/EncounterInfo.cs
+++ b/src/LibreLancer/World/EncounterInfo.cs
@@ -11,4 +11,4 @@ public class EncounterInfo
     public List<EncounterEntry> Ships = [];
 }
 
-public record EncounterEntry(ObjectName Name, Voice? Voice, ShipArch Ship);
+public record EncounterEntry(ObjectName Name, Voice? Voice, ShipArch Ship, string? MakeClass);


### PR DESCRIPTION
-Add separate docking reservations for berth/moor/ring dock points and prevent NPC undocks from colliding with player undocks.

-Now ships try to dock at their respective dock types.

-Improve docking and undocking autopilot behavior, including berth door timing, docking ring fly-through, and dock index handling.

-Spawn patrol encounters along patrol path segments using path_label order whose looks towards the player, with better direction/orientation and continuation between segments.

-Add ambient NPC combat engagement near hostile ships, then resume patrol/trade duties after combat resolves.