### PR TITLE
m04 fixes

### DIFF
--- a/src/Editor/LancerEdit/GameContent/MissionEditor/NodeTypes/Actions/ActEnableManeuver.cs
+++ b/src/Editor/LancerEdit/GameContent/MissionEditor/NodeTypes/Actions/ActEnableManeuver.cs
@@ -27,7 +27,7 @@ public sealed class ActEnableManeuver : NodeTriggerEntry
         ref NodeLookups lookups)
     {
         nodePopups.Combo("Maneuver", undoBuffer, () => ref Data.Maneuver);
-        Controls.CheckboxUndo("Lock", undoBuffer, () => ref Data.Lock);
+        Controls.CheckboxUndo("Enabled", undoBuffer, () => ref Data.Enabled);
     }
 
     public override void WriteEntry(IniBuilder.IniSectionBuilder sectionBuilder)

--- a/src/LibreLancer.Physics/PhysicsObject.cs
+++ b/src/LibreLancer.Physics/PhysicsObject.cs
@@ -11,6 +11,7 @@ namespace LibreLancer.Physics
     {
         public object? Tag;
         internal readonly int Id;
+        public bool IsDisposed { get; private set; }
 
         protected PhysicsObject(int id, Collider collider)
         {
@@ -58,6 +59,8 @@ namespace LibreLancer.Physics
         public abstract void PredictionStep(float timestep);
 
         internal abstract void UpdateProperties();
+
+        internal void MarkDisposed() => IsDisposed = true;
 
         public abstract void Dispose();
     }

--- a/src/LibreLancer.Physics/PhysicsWorld.cs
+++ b/src/LibreLancer.Physics/PhysicsWorld.cs
@@ -397,6 +397,7 @@ namespace LibreLancer.Physics
             }
 
             var id = -1;
+            obj.MarkDisposed();
 
             switch (obj)
             {

--- a/src/LibreLancer/Client/CGameSession.Space.cs
+++ b/src/LibreLancer/Client/CGameSession.Space.cs
@@ -859,9 +859,20 @@ public partial class CGameSession
             else
             {
                 FLLog.Debug("Client", "Formation received");
+                var lead = ObjOrPlayer(form.LeadShip);
+                var followers = form.Followers.Select(ObjOrPlayer).ToArray();
+                if (lead == null || followers.Any(x => x == null))
+                {
+                    FLLog.Warning("Client", "Formation update referenced a missing object. Clearing formation.");
+                    spaceGameplay.player.Formation = null;
+                    if (spaceGameplay.pilotComponent.CurrentBehavior == AutopilotBehaviors.Formation)
+                        spaceGameplay.pilotComponent.Cancel();
+                    return;
+                }
+
                 spaceGameplay.player.Formation = new ShipFormation(
-                    ObjOrPlayer(form.LeadShip),
-                    form.Followers.Select(ObjOrPlayer).ToArray()
+                    lead,
+                    followers.Select(x => x!).ToArray()
                 )
                 {
                     PlayerTargetPosition = form.YourPosition
@@ -988,12 +999,12 @@ public partial class CGameSession
         return scannedInventory.Where(x => predicate(x.Equipment!)).ToArray();
     }
 
-    private GameObject ObjOrPlayer(int id)
+    private GameObject? ObjOrPlayer(int id)
     {
         if (id == 0)
             return spaceGameplay!.player;
 
-        return spaceGameplay!.world.GetNetObject(id)!;
+        return spaceGameplay!.world.GetNetObject(id);
     }
 
     public bool DockAllowed(GameObject gameObject)

--- a/src/LibreLancer/Client/CGameSession.cs
+++ b/src/LibreLancer/Client/CGameSession.cs
@@ -55,6 +55,8 @@ public partial class CGameSession : IClientPlayer
     private bool inTradelane;
     public bool InTradelane => inTradelane;
     public List<NetCargo> Items = [];
+    private bool maneuversLocked;
+    private readonly HashSet<ManeuverType> disabledManeuvers = [];
 
     private PlayerInventory lastInventory = new();
     private string? currentBase;
@@ -88,6 +90,19 @@ public partial class CGameSession : IClientPlayer
     private UIInventoryItem[] scannedInventory = [];
     public NetSoldShip[]? Ships;
     public ulong ShipWorth;
+
+    public bool IsManeuverEnabled(string maneuver)
+    {
+        if (maneuversLocked)
+            return false;
+        if (maneuver.Equals("Dock", StringComparison.OrdinalIgnoreCase))
+            return !disabledManeuvers.Contains(ManeuverType.Dock);
+        if (maneuver.Equals("Goto", StringComparison.OrdinalIgnoreCase))
+            return !disabledManeuvers.Contains(ManeuverType.GoTo);
+        if (maneuver.Equals("Formation", StringComparison.OrdinalIgnoreCase))
+            return !disabledManeuvers.Contains(ManeuverType.Formation);
+        return maneuver.Equals("FreeFlight", StringComparison.OrdinalIgnoreCase);
+    }
     private SpaceGameplay? spaceGameplay;
 
     // Use only for Single Player
@@ -186,6 +201,19 @@ public partial class CGameSession : IClientPlayer
 
         if (!history)
             ObjectiveUpdated?.Invoke();
+    }
+
+    void IClientPlayer.SetManeuverLock(bool locked)
+    {
+        maneuversLocked = locked;
+    }
+
+    void IClientPlayer.SetManeuverEnabled(ManeuverType maneuver, bool enabled)
+    {
+        if (enabled)
+            disabledManeuvers.Remove(maneuver);
+        else
+            disabledManeuvers.Add(maneuver);
     }
 
     void IClientPlayer.OnConsoleMessage(string text)

--- a/src/LibreLancer/GameStates/RoomGameplay.cs
+++ b/src/LibreLancer/GameStates/RoomGameplay.cs
@@ -864,12 +864,22 @@ namespace LibreLancer
                         cState == CutsceneState.Accept ||
                         cState == CutsceneState.Reject)
                     {
-                        session.FinishCutscene(currentCutscene);
+                        var finishedCutscene = currentCutscene;
+                        session.FinishCutscene(finishedCutscene);
 
-                        if (currentCutscene.Encounters[0].RelocatePlayer != null)
+                        if (finishedCutscene.Encounters[0].RelocatePlayer != null)
                         {
-                            var rm = currentBase.Rooms.Get(currentCutscene.Encounters[0].RelocatePlayer);
-                            Game.ChangeState(new RoomGameplay(Game, session, baseId, rm));
+                            var relocate = finishedCutscene.Encounters[0].RelocatePlayer!;
+                            currentCutscene = null;
+                            if (relocate.Equals("Spaceflight", StringComparison.OrdinalIgnoreCase))
+                            {
+                                SendLaunch();
+                            }
+                            else
+                            {
+                                var rm = currentBase.Rooms.Get(relocate);
+                                Game.ChangeState(new RoomGameplay(Game, session, baseId, rm));
+                            }
                         }
                         else
                         {

--- a/src/LibreLancer/GameStates/SpaceGameplay.cs
+++ b/src/LibreLancer/GameStates/SpaceGameplay.cs
@@ -1018,11 +1018,13 @@ World Time: {12:F2}
             public LuaCompatibleDictionary GetManeuversEnabled()
             {
                 var dict = new LuaCompatibleDictionary();
-                dict.Set("FreeFlight", true);
-                dict.Set("Goto", g.Selection.Selected != null);
-                dict.Set("Dock", g.Selection.Selected?.GetComponent<DockInfoComponent>() != null &&
+                dict.Set("FreeFlight", g.session.IsManeuverEnabled("FreeFlight"));
+                dict.Set("Goto", g.session.IsManeuverEnabled("Goto") && g.Selection.Selected != null);
+                dict.Set("Dock", g.session.IsManeuverEnabled("Dock") &&
+                                 g.Selection.Selected?.GetComponent<DockInfoComponent>() != null &&
                                  g.session.DockAllowed(g.Selection.Selected));
-                dict.Set("Formation", g.Selection.Selected is { Kind: GameObjectKind.Ship });
+                dict.Set("Formation", g.session.IsManeuverEnabled("Formation") &&
+                                      g.Selection.Selected is { Kind: GameObjectKind.Ship });
                 return dict;
             }
 
@@ -1135,6 +1137,9 @@ World Time: {12:F2}
 
         private bool ManeuverSelect(string e)
         {
+            if (!session.IsManeuverEnabled(e))
+                return false;
+
             switch (e)
             {
                 case "FreeFlight":

--- a/src/LibreLancer/Missions/Actions/ScriptedAction.cs
+++ b/src/LibreLancer/Missions/Actions/ScriptedAction.cs
@@ -216,36 +216,7 @@ namespace LibreLancer.Missions.Actions
 
         public override void Invoke(MissionRuntime runtime, MissionScript script)
         {
-            if (!script.Objectives.TryGetValue(Objective, out var v))
-            {
-                return;
-            }
-
-            switch (v.Type)
-            {
-                case NNObjectiveType.ids:
-                    runtime.Player.SetObjective(new NetObjective(v.NameIds), History);
-                    break;
-                case NNObjectiveType.navmarker:
-                    runtime.Player.SetObjective(
-                        new NetObjective(
-                            v.NameIds,
-                            v.ExplanationIds,
-                            v.System,
-                            v.Position
-                        ), History);
-                    break;
-                case NNObjectiveType.rep_inst:
-                    runtime.Player.SetObjective(
-                        new NetObjective(
-                            v.NameIds,
-                            v.ExplanationIds,
-                            v.System,
-                            v.SolarNickname
-                        ), History);
-                    break;
-            }
-
+            runtime.SetCurrentObjective(Objective, History);
         }
     }
 

--- a/src/LibreLancer/Missions/Actions/ScriptedAction_Comm.cs
+++ b/src/LibreLancer/Missions/Actions/ScriptedAction_Comm.cs
@@ -39,8 +39,7 @@ namespace LibreLancer.Missions.Actions
                 int sourceId = 0;
                 if (!d.Source!.Equals("Player", StringComparison.OrdinalIgnoreCase))
                 {
-                    var src = script.Ships[d.Source];
-                    voice = src.NPC!.Voice!;
+                    voice = Act_SendComm.GetCommVoice(script, d.Source);
                     var o = runtime.Player.Space!.World.GameWorld.GetObject(d.Source);
                     sourceId = o?.NetID ?? 0;
                 }
@@ -82,8 +81,7 @@ namespace LibreLancer.Missions.Actions
         public override void Invoke(MissionRuntime runtime, MissionScript script)
         {
             var netdlg = new NetDlgLine[1];
-            var src = script.Ships[Source];
-            var voice = src.NPC!.Voice;
+            var voice = GetCommVoice(script, Source);
             var hash = FLHash.CreateID(Line);
             runtime.EnqueueLine(hash, Line);
             int sourceId = 0;
@@ -97,6 +95,24 @@ namespace LibreLancer.Missions.Actions
                 Hash = hash
             };
             runtime.Player.RpcClient.RunMissionDialog(netdlg);
+        }
+
+        internal static string GetCommVoice(MissionScript script, string source)
+        {
+            if (script.Ships.TryGetValue(source, out var ship) &&
+                !string.IsNullOrWhiteSpace(ship.NPC?.Voice))
+            {
+                return ship.NPC.Voice;
+            }
+
+            if (script.Solars.TryGetValue(source, out var solar) &&
+                !string.IsNullOrWhiteSpace(solar.Voice))
+            {
+                return solar.Voice;
+            }
+
+            FLLog.Warning("Missions", $"Could not find comm voice for '{source}', using trent_voice");
+            return "trent_voice";
         }
     }
 

--- a/src/LibreLancer/Missions/Actions/ScriptedAction_Movement.cs
+++ b/src/LibreLancer/Missions/Actions/ScriptedAction_Movement.cs
@@ -129,7 +129,7 @@ namespace LibreLancer.Missions.Actions
         }
     }
 
-    public class Act_RelocateShip : ScriptedAction
+    public class Act_RelocateShip : ShipSpawnBase
     {
         public string Ship = string.Empty;
         public Vector3 Position;
@@ -171,14 +171,35 @@ namespace LibreLancer.Missions.Actions
             {
                 runtime.Player.MissionWorldAction(() => runtime.Player.Space!.ForceMove(Position, Orientation));
             }
-            else if (script.Ships.ContainsKey(Ship))
+            else if (script.Ships.TryGetValue(Ship, out var scriptShip))
             {
                 runtime.Player.MissionWorldAction(() =>
                 {
-                    var obj = runtime.Player.Space!.World.GameWorld.GetObject(Ship)!;
+                    var obj = runtime.Player.Space!.World.GameWorld.GetObject(Ship);
+                    if (obj == null)
+                    {
+                        FLLog.Warning("Mission",
+                            $"Act_RelocateShip could not find `{Ship}` in space; spawning mission ship at relocate position");
+                        runtime.ObjectSpawned(scriptShip.Nickname);
+                        var spawnOrientation = Orientation.HasValue
+                            ? (OptionalArgument<Quaternion>)Orientation.Value
+                            : default;
+                        obj = SpawnShipInWorld(scriptShip, Position, spawnOrientation, string.Empty, script, runtime);
+                    }
+
+                    if (obj == null)
+                    {
+                        FLLog.Warning("Mission", $"Act_RelocateShip could not find `{Ship}`");
+                        return;
+                    }
+
                     var quat = Orientation ?? obj.LocalTransform.Orientation;
                     obj.SetLocalTransform(new Transform3D(Position, quat));
                 });
+            }
+            else
+            {
+                FLLog.Warning("Mission", $"Act_RelocateShip could not find mission ship `{Ship}`");
             }
         }
     }

--- a/src/LibreLancer/Missions/Actions/ScriptedAction_Spawn.cs
+++ b/src/LibreLancer/Missions/Actions/ScriptedAction_Spawn.cs
@@ -35,26 +35,9 @@ namespace LibreLancer.Missions.Actions
 
         public override void Invoke(MissionRuntime runtime, MissionScript script)
         {
-            var sol = script.Solars[Solar];
-            var arch = sol.Archetype;
-            runtime.ObjectSpawned(sol.Nickname);
             runtime.Player.MissionWorldAction(() =>
             {
-                var obj = runtime.Player.Space!.World.SpawnSolar(
-                    sol.Nickname,
-                    arch!,
-                    sol.Loadout!,
-                    sol.Faction!,
-                    sol.Position,
-                    sol.Orientation,
-                    sol.IdsName,
-                    sol.Base
-                );
-
-                if (obj.TryGetComponent<SDestroyableComponent>(out var dstComp))
-                {
-                    dstComp.OnKilled = () => { runtime.ObjectDestroyed(Solar); };
-                }
+                runtime.SpawnMissionSolar(Solar, runtime.Player.Space!.World);
             });
         }
     }
@@ -115,12 +98,11 @@ namespace LibreLancer.Missions.Actions
         {
         }
 
-        protected void SpawnShip(ScriptShip ship, OptionalArgument<Vector3> spawnpos,
+        protected GameObject SpawnShipInWorld(ScriptShip ship, OptionalArgument<Vector3> spawnpos,
             OptionalArgument<Quaternion> spawnorient, string objList, MissionScript script, MissionRuntime runtime)
         {
             var npcDef = ship.NPC!;
             script.NpcShips.TryGetValue(npcDef.NpcShipArch!, out var shipArch);
-            runtime.ObjectSpawned(ship.Nickname);
 
             if (shipArch == null)
             {
@@ -143,47 +125,59 @@ namespace LibreLancer.Missions.Actions
                 }
             }
 
+            runtime.Player.Space!.World.Server.GameData.Items.TryGetLoadout(shipArch!.Loadout!, out var ld);
+            var pilot = runtime.Player.Space.World.Server.GameData.Items.GetPilot(shipArch.Pilot!);
+            ObjectName oName;
+
+            if (ship.RandomName)
+            {
+                oName = runtime.Player.Space.World.NPCs.RandomName(npcDef.Affiliation);
+            }
+            else
+            {
+                oName = new ObjectName(npcDef.IndividualName);
+            }
+
+            var pos = archPos;
+            GameObject relObj;
+
+            // Spawn relative to object
+            if (!string.IsNullOrWhiteSpace(ship.RelativePosition.ObjectName) &&
+                (relObj = runtime.Player.Space.World.GameWorld.GetObject(ship.RelativePosition.ObjectName)!) != null)
+            {
+                var dir = new Vector3(runtime.Random.NextFloat(-1, 1),
+                    runtime.Random.NextFloat(-0.1f, 0.1f),
+                    runtime.Random.NextFloat(-1, 1)).Normalized();
+                var range = runtime.Random.NextFloat(ship.RelativePosition.MinRange,
+                    ship.RelativePosition.MaxRange);
+                pos = relObj.WorldTransform.Position + (dir * range);
+            }
+
+            var arrivalObject = string.IsNullOrWhiteSpace(ship.ArrivalObj.Object) || spawnpos.Present
+                ? null
+                : ship.ArrivalObj.Object;
+
+            var obj = runtime.Player.Space.World.NPCs.DoSpawn(
+                oName,
+                ship.Nickname,
+                npcDef.Affiliation,
+                shipArch?.StateGraph ?? "FIGHTER",
+                npcDef.SpaceCostume,
+                ld!, pilot, pos, orient, arrivalObject, ship.ArrivalObj.Index, runtime);
+            var drComp = obj.GetComponent<DirectiveRunnerComponent>();
+            drComp!.SetDirectives(directives, runtime.Player.Space.World.GameWorld);
+            var dstComp = obj.GetComponent<SDestroyableComponent>();
+            dstComp!.OnKilled = () => { runtime.ObjectDestroyed(ship.Nickname); };
+            return obj;
+        }
+
+        protected void SpawnShip(ScriptShip ship, OptionalArgument<Vector3> spawnpos,
+            OptionalArgument<Quaternion> spawnorient, string objList, MissionScript script, MissionRuntime runtime)
+        {
+            runtime.ObjectSpawned(ship.Nickname);
             runtime.Player.MissionWorldAction(() =>
             {
-                runtime.Player.Space!.World.Server.GameData.Items.TryGetLoadout(shipArch!.Loadout!, out var ld);
-                var pilot = runtime.Player.Space.World.Server.GameData.Items.GetPilot(shipArch.Pilot!);
-                ObjectName oName;
-
-                if (ship.RandomName)
-                {
-                    oName = runtime.Player.Space.World.NPCs.RandomName(npcDef.Affiliation);
-                }
-                else
-                {
-                    oName = new ObjectName(npcDef.IndividualName);
-                }
-
-                var pos = archPos;
-                GameObject relObj;
-
-                // Spawn relative to object
-                if (!string.IsNullOrWhiteSpace(ship.RelativePosition.ObjectName) &&
-                    (relObj = runtime.Player.Space.World.GameWorld.GetObject(ship.RelativePosition.ObjectName)!) != null)
-                {
-                    var dir = new Vector3(runtime.Random.NextFloat(-1, 1),
-                        runtime.Random.NextFloat(-0.1f, 0.1f),
-                        runtime.Random.NextFloat(-1, 1)).Normalized();
-                    var range = runtime.Random.NextFloat(ship.RelativePosition.MinRange,
-                        ship.RelativePosition.MaxRange);
-                    pos = relObj.WorldTransform.Position + (dir * range);
-                }
-
-                var obj = runtime.Player.Space.World.NPCs.DoSpawn(
-                    oName,
-                    ship.Nickname,
-                    npcDef.Affiliation,
-                    shipArch?.StateGraph ?? "FIGHTER",
-                    npcDef.SpaceCostume,
-                    ld!, pilot, pos, orient, null, 0, runtime);
-                var drComp = obj.GetComponent<DirectiveRunnerComponent>();
-                drComp!.SetDirectives(directives, runtime.Player.Space.World.GameWorld);
-                var dstComp = obj.GetComponent<SDestroyableComponent>();
-                dstComp!.OnKilled = () => { runtime.ObjectDestroyed(ship.Nickname); };
+                SpawnShipInWorld(ship, spawnpos, spawnorient, objList, script, runtime);
             });
         }
     }
@@ -250,7 +244,24 @@ namespace LibreLancer.Missions.Actions
 
         public override void Invoke(MissionRuntime runtime, MissionScript script)
         {
-            var form = script.Formations[Formation];
+            if (!script.Formations.TryGetValue(Formation, out var form))
+            {
+                if (script.Ships.TryGetValue(Formation, out var ship))
+                {
+                    SpawnShip(ship, Position, Orientation, string.Empty, script, runtime);
+                    return;
+                }
+
+                FLLog.Warning("Mission", $"Act_SpawnFormation could not find formation `{Formation}`");
+                return;
+            }
+
+            if (form.Ships.Count == 0)
+            {
+                FLLog.Warning("Mission", $"Act_SpawnFormation `{Formation}` has no valid ships to spawn");
+                return;
+            }
+
             var fpos = Position.Get(form.Position);
             var forient = Orientation.Get(form.Orientation);
             var mat = Matrix4x4.CreateFromQuaternion(forient) *
@@ -260,7 +271,8 @@ namespace LibreLancer.Missions.Actions
 
             for (int i = 0; i < form.Ships.Count; i++)
             {
-                var pos = Vector3.Transform(positions[i], mat);
+                var offset = i < positions.Count ? positions[i] : positions[^1];
+                var pos = Vector3.Transform(offset, mat);
                 SpawnShip(form.Ships[i], pos, forient, null!, script, runtime);
             }
 
@@ -440,8 +452,14 @@ namespace LibreLancer.Missions.Actions
             runtime.ObjectDestroyed(ship.Nickname);
             runtime.Player.MissionWorldAction(() =>
             {
-                runtime.Player.Space!.World.NPCs.Despawn(runtime.Player.Space.World.GameWorld.GetObject(Target)!,
-                    false);
+                var obj = runtime.Player.Space!.World.GameWorld.GetObject(Target);
+                if (obj == null)
+                {
+                    FLLog.Warning("Mission", $"Act_Destroy could not find `{Target}`");
+                    return;
+                }
+
+                runtime.Player.Space.World.NPCs.Despawn(obj, Kind == DestroyKind.EXPLODE);
             });
         }
 

--- a/src/LibreLancer/Missions/Actions/ScriptedAction_Unknown.cs
+++ b/src/LibreLancer/Missions/Actions/ScriptedAction_Unknown.cs
@@ -356,6 +356,11 @@ public class Act_LockManeuvers : ScriptedAction
     {
         section.Entry("Act_LockManeuvers", Lock ? "true" : "false");
     }
+
+    public override void Invoke(MissionRuntime runtime, MissionScript script)
+    {
+        runtime.Player.SetManeuversLocked(Lock);
+    }
 }
 
 // Act_NagDistLeaving = takeTL34, escort, Li01_Trade_Lane_Ring_34, 21985, 1, NAG_ALWAYS
@@ -774,6 +779,11 @@ public class Act_SetNNState : ScriptedAction
     {
         section.Entry("Act_SetNNState", Objective, Complete ? "COMPLETE" : "ACTIVE");
     }
+
+    public override void Invoke(MissionRuntime runtime, MissionScript script)
+    {
+        runtime.SetNNObjectiveState(Objective, Complete);
+    }
 }
 
 public class Act_SetLifetime : ScriptedAction
@@ -938,12 +948,17 @@ public class Act_GiveNNObjs : ScriptedAction
     {
         section.Entry("Act_GiveNNObjs", "no_params");
     }
+
+    public override void Invoke(MissionRuntime runtime, MissionScript script)
+    {
+        runtime.GiveNNObjectives();
+    }
 }
 
 public class Act_EnableManeuver : ScriptedAction
 {
     public ManeuverType Maneuver = ManeuverType.Dock;
-    public bool Lock;
+    public bool Enabled;
 
     public Act_EnableManeuver()
     {
@@ -952,12 +967,17 @@ public class Act_EnableManeuver : ScriptedAction
     public Act_EnableManeuver(MissionAction act) : base(act)
     {
         GetEnum(nameof(Maneuver), 0, out Maneuver, act.Entry);
-        GetBoolean(nameof(Lock), 1, out Lock, act.Entry);
+        GetBoolean(nameof(Enabled), 1, out Enabled, act.Entry);
     }
 
     public override void Write(IniBuilder.IniSectionBuilder section)
     {
-        section.Entry("Act_EnableManeuver", Maneuver.ToString(), Lock);
+        section.Entry("Act_EnableManeuver", Maneuver.ToString(), Enabled);
+    }
+
+    public override void Invoke(MissionRuntime runtime, MissionScript script)
+    {
+        runtime.Player.SetManeuverEnabled(Maneuver, Enabled);
     }
 }
 

--- a/src/LibreLancer/Missions/Conditions/ScriptedCondition.cs
+++ b/src/LibreLancer/Missions/Conditions/ScriptedCondition.cs
@@ -359,7 +359,7 @@ public class Cnd_TetherBroke : ScriptedCondition
     }
 }
 
-public class Cnd_SystemExit : ScriptedCondition
+public class Cnd_SystemExit : SingleEventListenerCondition<SystemExitedEvent>
 {
     public List<string> Systems = [];
     public bool Any;
@@ -386,6 +386,12 @@ public class Cnd_SystemExit : ScriptedCondition
     public override void Write(IniBuilder.IniSectionBuilder section)
     {
         section.Entry("Cnd_SystemExit", Any ? ["any"] : Systems.Select(x => (ValueBase)x).ToArray());
+    }
+
+    protected override bool EventCheck(SystemExitedEvent ev, MissionRuntime runtime, ActiveCondition self)
+    {
+        return ev.Ship.Equals("Player", StringComparison.OrdinalIgnoreCase) &&
+               (Any || Systems.Any(x => x.Equals(ev.System, StringComparison.OrdinalIgnoreCase)));
     }
 }
 
@@ -650,7 +656,7 @@ public class Cnd_PlayerLaunch : SingleEventListenerCondition<PlayerLaunchedEvent
     }
 }
 
-public class Cnd_NPCSystemExit : ScriptedCondition
+public class Cnd_NPCSystemExit : EventListenerCondition<SystemExitedEvent>
 {
     public string System = string.Empty;
     public List<string> Ships = [];
@@ -666,6 +672,27 @@ public class Cnd_NPCSystemExit : ScriptedCondition
         {
             Ships.Add(value.ToString());
         }
+    }
+
+    public override void Init(MissionRuntime runtime, ActiveCondition self)
+    {
+        var checking = new ConditionHashSet();
+        foreach (var sh in Ships)
+            checking.Values.Add(sh);
+        self.Storage = checking;
+    }
+
+    public override void OnEvent(SystemExitedEvent ev, MissionRuntime runtime, ActiveCondition self)
+    {
+        if (!ev.System.Equals(System, StringComparison.OrdinalIgnoreCase))
+            return;
+        var v = (ConditionHashSet)self.Storage;
+        v.Values.Remove(ev.Ship);
+    }
+
+    public override bool CheckCondition(MissionRuntime runtime, ActiveCondition self, double elapsed)
+    {
+        return ((ConditionHashSet)self.Storage).Values.Count == 0;
     }
 
     public override void Write(IniBuilder.IniSectionBuilder section)
@@ -919,6 +946,28 @@ public class Cnd_InTradelane : ScriptedCondition
         GetString(nameof(Ship), 1, out Ship, entry);
     }
 
+    public override bool CheckCondition(MissionRuntime runtime, ActiveCondition self, double elapsed)
+    {
+        bool inTradelane;
+        if (IdEqual(Ship, "Player"))
+        {
+            inTradelane = runtime.Player.InTradelane;
+        }
+        else
+        {
+            if (!runtime.GetSpace(out var space))
+                return false;
+
+            var obj = space.World.GameWorld.GetObject(Ship);
+            if (obj == null)
+                return !InTL;
+
+            inTradelane = obj.TryGetComponent<STradelaneMoveComponent>(out _);
+        }
+
+        return inTradelane == InTL;
+    }
+
     public override void Write(IniBuilder.IniSectionBuilder section)
     {
         section.Entry("Cnd_InTradelane", InTL, Ship);
@@ -1101,8 +1150,9 @@ public class Cnd_DistVec : ScriptedCondition
         GetVector3(nameof(Position), 2, out Position, entry);
         GetFloat(nameof(Distance), 5, out Distance, entry);
 
-        if (entry.Count >= 8 &&
-            entry[7].ToString().Equals("tick_away", StringComparison.InvariantCultureIgnoreCase))
+        if (entry.Count >= 7 &&
+            (entry.Count == 7 ||
+             entry[7].ToString().Equals("tick_away", StringComparison.InvariantCultureIgnoreCase)))
         {
             TickAway = entry[6].ToSingle();
         }
@@ -1125,12 +1175,16 @@ public class Cnd_DistVec : ScriptedCondition
         if (obj == null)
             return false;
         bool isInside = Vector3.Distance(obj.WorldTransform.Position, Position) <= Distance;
-        if(TickAway.Present)
+        if (TickAway.Present)
         {
             var st = (ConditionDouble)self.Storage;
             if (Inside == isInside)
             {
                 st.Value -= elapsed;
+            }
+            else
+            {
+                st.Value = TickAway.Value;
             }
             return st.Value <= 0;
         }
@@ -1172,8 +1226,9 @@ public class Cnd_DistShip : ScriptedCondition
         GetString(nameof(DestObject), 2, out DestObject, entry);
         GetFloat(nameof(Distance), 3, out Distance, entry);
 
-        if (entry.Count >= 6 &&
-            entry[5].ToString().Equals("tick_away", StringComparison.InvariantCultureIgnoreCase))
+        if (entry.Count >= 5 &&
+            (entry.Count == 5 ||
+             entry[5].ToString().Equals("tick_away", StringComparison.InvariantCultureIgnoreCase)))
         {
             TickAway = entry[4].ToSingle();
         }
@@ -1197,14 +1252,18 @@ public class Cnd_DistShip : ScriptedCondition
         if (obj == null || obj2 == null)
             return false;
         var isInside = Vector3.Distance(obj.WorldTransform.Position, obj2.WorldTransform.Position) <= Distance;
-        if(TickAway.Present)
+        if (TickAway.Present)
         {
             var st = (ConditionDouble)self.Storage;
             if (Inside == isInside)
             {
                 st.Value -= elapsed;
             }
-            if(st.Value <= 0)
+            else
+            {
+                st.Value = TickAway.Value;
+            }
+            if (st.Value <= 0)
             {
                 FLLog.Debug("Mission", $"Cnd_Dist: {elapsed} satisfied TICK_AWAY");
             }
@@ -1316,7 +1375,7 @@ public class Cnd_Destroyed :
             {
                 if (Kind != CndDestroyedKind.ALL && Kind != CndDestroyedKind.ALL_IGNORE_LANDING)
                 {
-                    return !lbl.AnyAlive();  // True if no ships are alive (all dead or not spawned). Used for EXPLODE with Count=-1.
+                    return lbl.IsAllKilled();  // True if at least one label member has spawned, and none of the spawned members are alive.
                 }
                 else
                 {

--- a/src/LibreLancer/Missions/Events/MissionEvents.cs
+++ b/src/LibreLancer/Missions/Events/MissionEvents.cs
@@ -18,6 +18,7 @@ public record struct DestroyedEvent(string Object);
 public record struct MissionResponseEvent(bool Accept);
 
 public record struct SystemEnteredEvent(string System, string Ship);
+public record struct SystemExitedEvent(string System, string Ship);
 
 public record struct CommCompleteEvent(string Comm);
 

--- a/src/LibreLancer/Missions/MissionRuntime.cs
+++ b/src/LibreLancer/Missions/MissionRuntime.cs
@@ -8,9 +8,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using LibreLancer.Data;
 using LibreLancer.Data.Ini;
+using LibreLancer.Data.Schema.Missions;
 using LibreLancer.Data.Schema.Save;
 using LibreLancer.Missions.Conditions;
 using LibreLancer.Missions.Events;
+using LibreLancer.Net;
 using LibreLancer.Server;
 using LibreLancer.Server.Components;
 using LibreLancer.World;
@@ -26,6 +28,7 @@ namespace LibreLancer.Missions
         public Random Random = new();
 
         public Dictionary<string, MissionLabel> Labels = new(StringComparer.OrdinalIgnoreCase);
+        private string? activeNNObjective;
 
         public MissionRuntime(MissionScript script, Player player, uint[] triggerSave)
         {
@@ -72,6 +75,60 @@ namespace LibreLancer.Missions
             }
 
             UpdateUiTriggers();
+        }
+
+        private static NetObjective ToNetObjective(NNObjective objective) => objective.Type switch
+        {
+            NNObjectiveType.ids => new NetObjective(objective.NameIds),
+            NNObjectiveType.navmarker => new NetObjective(
+                objective.NameIds,
+                objective.ExplanationIds,
+                objective.System,
+                objective.Position
+            ),
+            NNObjectiveType.rep_inst => new NetObjective(
+                objective.NameIds,
+                objective.ExplanationIds,
+                objective.System,
+                objective.SolarNickname
+            ),
+            _ => new NetObjective()
+        };
+
+        public void SetNNObjectiveState(string objective, bool complete)
+        {
+            if (!Script.Objectives.ContainsKey(objective))
+            {
+                FLLog.Warning("Mission", $"Act_SetNNState could not find objective `{objective}`");
+                return;
+            }
+
+            if (!complete)
+                activeNNObjective = objective;
+            else if (activeNNObjective != null &&
+                     activeNNObjective.Equals(objective, StringComparison.OrdinalIgnoreCase))
+                activeNNObjective = null;
+        }
+
+        public void SetCurrentObjective(string objective, bool history)
+        {
+            if (!Script.Objectives.TryGetValue(objective, out var value))
+            {
+                FLLog.Warning("Mission", $"Act_SetNNObj could not find objective `{objective}`");
+                return;
+            }
+
+            activeNNObjective = objective;
+            Player.SetObjective(ToNetObjective(value), history);
+        }
+
+        public void GiveNNObjectives()
+        {
+            if (activeNNObjective == null)
+                return;
+            if (!Script.Objectives.TryGetValue(activeNNObjective, out var value))
+                return;
+            Player.SetObjective(ToNetObjective(value), false);
         }
 
         private string lastSaveTrigger = string.Empty;
@@ -141,6 +198,51 @@ namespace LibreLancer.Missions
                     FLLog.Error("Mission", $"Cnd_ProjHit won't register for not spawned {target}");
                 }
             });
+        }
+
+        public GameObject? SpawnMissionSolar(string solarName, ServerWorld world)
+        {
+            if (!Script.Solars.TryGetValue(solarName, out var sol))
+                return null;
+
+            var existing = world.GameWorld.GetObject(sol.Nickname);
+            if (existing != null)
+                return existing;
+
+            ObjectSpawned(sol.Nickname);
+            var obj = world.SpawnSolar(
+                sol.Nickname,
+                sol.Archetype!,
+                sol.Loadout!,
+                sol.Faction!,
+                sol.Position,
+                sol.Orientation,
+                sol.IdsName,
+                sol.Base
+            );
+
+            if (obj.TryGetComponent<SDestroyableComponent>(out var dstComp))
+            {
+                dstComp.OnKilled = () => ObjectDestroyed(sol.Nickname);
+            }
+
+            return obj;
+        }
+
+        public GameObject? SpawnMissionSolarForBase(string baseName, ServerWorld world)
+        {
+            foreach (var sol in Script.Solars.Values)
+            {
+                if (!baseName.Equals(sol.Base, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (sol.System != null && !sol.System.Equals(world.System.Nickname, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                FLLog.Info("Mission", $"Spawning mission solar `{sol.Nickname}` for base `{baseName}`");
+                return SpawnMissionSolar(sol.Nickname, world);
+            }
+
+            return null;
         }
 
         public void ActivateTrigger(string trigger)
@@ -223,6 +325,9 @@ namespace LibreLancer.Missions
 
         public void SystemEnter(string system, string ship) =>
             MsnEvent(new SystemEnteredEvent(system, ship));
+
+        public void SystemExit(string system, string ship) =>
+            MsnEvent(new SystemExitedEvent(system, ship));
 
         public void Update(double elapsed)
         {

--- a/src/LibreLancer/Net/Protocol/IClientPlayer.cs
+++ b/src/LibreLancer/Net/Protocol/IClientPlayer.cs
@@ -31,6 +31,8 @@ public interface IClientPlayer
     void BaseEnter(string _base, NetObjective objective, NetThnInfo thns, NewsArticle[] news, SoldGood[] goods, NetSoldShip[] ships);
     void UpdateThns(NetThnInfo thns);
     void SetObjective(NetObjective objective, bool history);
+    void SetManeuverLock(bool locked);
+    void SetManeuverEnabled(ManeuverType maneuver, bool enabled);
     void Killed();
     void DespawnObject(int id, bool explode);
     void PlaySound(string sound);

--- a/src/LibreLancer/Server/Components/SDestroyableComponent.cs
+++ b/src/LibreLancer/Server/Components/SDestroyableComponent.cs
@@ -15,6 +15,9 @@ public class SDestroyableComponent : GameComponent
 
     public void Destroy(bool exploded)
     {
+        if (Parent.Formation?.Contains(Parent) == true)
+            Parent.Formation.Remove(Parent);
+
         OnKilled?.Invoke();
         if (Parent.TryGetComponent<SPlayerComponent>(out var player))
         {

--- a/src/LibreLancer/Server/FormationTools.cs
+++ b/src/LibreLancer/Server/FormationTools.cs
@@ -10,17 +10,20 @@ public class FormationTools
 {
     public static void EnterFormation(GameObject self, GameObject tgt, Vector3 offset)
     {
+        if (self.Formation != null && self.Formation != tgt.Formation)
+            self.Formation.Remove(self);
+
         if (tgt.Formation == null)
         {
             tgt.Formation = new ShipFormation(tgt, self);
         }
         else
         {
-            if(!tgt.Formation.Contains(self))
+            if (!tgt.Formation.Contains(self))
                 tgt.Formation.Add(self);
         }
         self.Formation = tgt.Formation;
-        if(offset != Vector3.Zero)
+        if (offset != Vector3.Zero)
             tgt.Formation.SetShipOffset(self, offset);
         if (self.TryGetComponent<AutopilotComponent>(out var ap))
         {
@@ -56,7 +59,16 @@ public class FormationTools
         }
 
         obj.Formation?.Remove(obj);
-        var form = new ShipFormation(playerLead ? player! : obj, formDef!);
+        ShipFormation form;
+        if (formDef != null)
+        {
+            form = new ShipFormation(playerLead ? player! : obj, formDef);
+        }
+        else
+        {
+            FLLog.Warning("Mission", $"Formation definition `{formation}` was not found. Falling back to a simple group.");
+            form = new ShipFormation(playerLead ? player! : obj);
+        }
         if (playerLead && player != null)
         {
             form.Add(obj);

--- a/src/LibreLancer/Server/Player.cs
+++ b/src/LibreLancer/Server/Player.cs
@@ -103,6 +103,16 @@ namespace LibreLancer.Server
             rpcClient.SetObjective(objective, history);
         }
 
+        public void SetManeuversLocked(bool locked)
+        {
+            rpcClient.SetManeuverLock(locked);
+        }
+
+        public void SetManeuverEnabled(ManeuverType maneuver, bool enabled)
+        {
+            rpcClient.SetManeuverEnabled(maneuver, enabled);
+        }
+
         public void UpdateMissionRuntime(double elapsed)
         {
             msnRuntime?.Update(elapsed);
@@ -1200,6 +1210,7 @@ namespace LibreLancer.Server
 
             if (Space != null)
             {
+                msnRuntime?.SystemExit(System, "Player");
                 Space.Leave(false);
             }
 
@@ -1252,11 +1263,17 @@ namespace LibreLancer.Server
             }, msnPreload);
         }
 
-        void IServerPlayer.Launch()
+        public void LaunchFromBase()
         {
             if (Character?.Ship == null)
             {
                 FLLog.Error("Server", $"{Name} cannot launch without a ship");
+                return;
+            }
+
+            if (Base == null)
+            {
+                rpcClient.OnConsoleMessage("You are not on a base.");
                 return;
             }
 
@@ -1266,32 +1283,47 @@ namespace LibreLancer.Server
             Game.Worlds.RequestWorld(sys!, (world) =>
             {
                 Space = new SpacePlayer(world, this);
+                var launchBase = Base;
                 var obj = sys!.Objects.FirstOrDefault((o) =>
                 {
                     return (o.Dock is { Kind: DockKinds.Base } &&
-                            o.Dock.Target!.Equals(Base, StringComparison.OrdinalIgnoreCase));
+                            o.Dock.Target!.Equals(launchBase, StringComparison.OrdinalIgnoreCase));
                 });
                 System = b.System!;
                 Orientation = Quaternion.Identity;
                 Position = Vector3.Zero;
 
-                if (obj == null)
-                {
-                    FLLog.Error("Base", "Can't find object in " + sys.Nickname + " docking to " + b.Nickname);
-                }
-                else
-                {
-                    Position = obj.Position;
-                    Orientation = obj.Rotation;
-                    Position = Vector3.Transform(new Vector3(0, 0, 500), Orientation) +
-                               obj.Position; // TODO: This is bad
-                }
-
                 Baseside = null;
                 Base = null;
                 world.EnqueueAction(() =>
                 {
-                    var undockFrom = world.GameWorld.GetObject(obj?.Nickname);
+                    GameObject? undockFrom = null;
+                    if (obj != null)
+                    {
+                        undockFrom = world.GameWorld.GetObject(obj.Nickname);
+                        Position = obj.Position;
+                        Orientation = obj.Rotation;
+                    }
+                    else if (launchBase != null)
+                    {
+                        undockFrom = MissionRuntime?.SpawnMissionSolarForBase(launchBase, world);
+                        if (undockFrom != null)
+                        {
+                            Position = undockFrom.WorldTransform.Position;
+                            Orientation = undockFrom.LocalTransform.Orientation;
+                        }
+                    }
+
+                    if (undockFrom == null)
+                    {
+                        FLLog.Error("Base", "Can't find object in " + sys.Nickname + " docking to " + b.Nickname);
+                    }
+                    else
+                    {
+                        Position = Vector3.Transform(new Vector3(0, 0, 500), Orientation) +
+                                   Position; // TODO: This is bad
+                    }
+
                     SDockableComponent? sd = null;
                     var undockIndex = 0;
 
@@ -1333,5 +1365,7 @@ namespace LibreLancer.Server
                 });
             }, msnPreload);
         }
+
+        void IServerPlayer.Launch() => LaunchFromBase();
     }
 }

--- a/src/LibreLancer/Server/ServerWorld.cs
+++ b/src/LibreLancer/Server/ServerWorld.cs
@@ -256,6 +256,7 @@ namespace LibreLancer.Server
                 }
 
                 jumpers.Add(JumperNpc.FromGameObject(go));
+                msn.SystemExit(System.Nickname, npc.Nickname);
                 RemoveSpawnedObject(go, false);
             }
 
@@ -665,6 +666,11 @@ namespace LibreLancer.Server
 
         private void RemoveObjectInternal(GameObject obj)
         {
+            if ((obj.Flags & GameObjectFlags.Exists) == 0)
+            {
+                return;
+            }
+
             obj.Unregister(GameWorld);
             GameWorld.RemoveObject(obj);
             withAnimations.Remove(obj);
@@ -691,9 +697,16 @@ namespace LibreLancer.Server
         {
             actions.Enqueue(() =>
             {
+                if ((obj.Flags & GameObjectFlags.Exists) == 0)
+                {
+                    spawnedObjects.Remove(obj);
+                    return;
+                }
+
                 RemoveObjectInternal(obj);
                 spawnedObjects.Remove(obj);
-                IdGenerator.Free(obj.NetID);
+                if (obj.NetID != 0)
+                    IdGenerator.Free(obj.NetID);
                 foreach (var p in Players) p.Key.Despawn(obj.NetID, exploded);
             });
         }

--- a/src/LibreLancer/Server/StoryProgress.cs
+++ b/src/LibreLancer/Server/StoryProgress.cs
@@ -41,10 +41,10 @@ public class StoryProgress
             player.LoadMission();
         }
 
-        if (oldStory.CashUp > 0)
+        if (next.CashUp > 0)
         {
-            NextLevelWorth = player.CalculateNetWorth() + oldStory.CashUp;
-            FLLog.Info("Mission", $"SET Next Level Worth: {NextLevelWorth} (+{oldStory.CashUp})");
+            NextLevelWorth = player.CalculateNetWorth() + next.CashUp;
+            FLLog.Info("Mission", $"SET Next Level Worth: {NextLevelWorth} (+{next.CashUp})");
         }
 
         FLLog.Info("Mission", $"Transitioned from {old} to {next.Nickname}");
@@ -70,7 +70,7 @@ public class StoryProgress
         else if (CurrentStory.CashUp > 0)
         {
             var playerNet = player.CalculateNetWorth();
-            if(playerNet >= NextLevelWorth)
+            if (playerNet >= NextLevelWorth)
             {
                 FLLog.Info("Mission", $"Current worth {playerNet} > {NextLevelWorth}");
                 Advance(player);

--- a/src/LibreLancer/World/Components/Autopilot/AutopilotComponent.cs
+++ b/src/LibreLancer/World/Components/Autopilot/AutopilotComponent.cs
@@ -587,6 +587,8 @@ namespace LibreLancer.World.Components
         {
             var formation = Parent.Formation!;
             var body = Parent.PhysicsComponent!.Body!;
+            if (body.IsDisposed)
+                return FormationControl.Separation.None;
             var requiredNeighbors = formation.Followers.Count + 1;
             if (separationNeighbors.Length < requiredNeighbors)
                 separationNeighbors = new FormationControl.Neighbor[requiredNeighbors];
@@ -594,9 +596,9 @@ namespace LibreLancer.World.Components
 
             void AddNeighbor(GameObject ship)
             {
-                if (ship == Parent || ship.PhysicsComponent?.Body == null)
+                var otherBody = ship.PhysicsComponent?.Body;
+                if (ship == Parent || otherBody is not { IsDisposed: false })
                     return;
-                var otherBody = ship.PhysicsComponent.Body;
                 separationNeighbors[neighborCount++] = new FormationControl.Neighbor(otherBody.Position,
                     otherBody.LinearVelocity, otherBody.Collider.Radius, StableFormationId(ship, formation));
             }
@@ -668,21 +670,31 @@ namespace LibreLancer.World.Components
 
         public override bool Update(ShipSteeringComponent control, ShipInputComponent? input, double time, GameWorld world)
         {
-            if (Parent.Formation == null ||
-                Parent.Formation.LeadShip == Parent)
+            var formation = Parent.Formation;
+            if (formation == null ||
+                formation.LeadShip == Parent)
             {
                 return true;
             }
 
-            var body = Parent.PhysicsComponent!.Body!;
-            var targetPoint = Parent.Formation.GetShipPosition(Parent, Component.LocalPlayer);
-            var lead = Parent.Formation.LeadShip;
+            var body = Parent.PhysicsComponent?.Body;
+            var lead = formation.LeadShip;
             var leadBody = lead.PhysicsComponent?.Body;
+            if ((lead.Flags & GameObjectFlags.Exists) != GameObjectFlags.Exists ||
+                body is not { IsDisposed: false } ||
+                leadBody is not { IsDisposed: false })
+            {
+                if (formation.Contains(Parent))
+                    formation.Remove(Parent);
+                return true;
+            }
+
+            var targetPoint = formation.GetShipPosition(Parent, Component.LocalPlayer);
             var slotError = targetPoint - body.Position;
             var distance = slotError.Length();
-            var leadPosition = leadBody?.Position ?? lead.WorldTransform.Position;
-            var leadVelocity = leadBody?.LinearVelocity ?? Vector3.Zero;
-            var leadAngularVelocity = leadBody?.AngularVelocity ?? Vector3.Zero;
+            var leadPosition = leadBody.Position;
+            var leadVelocity = leadBody.LinearVelocity;
+            var leadAngularVelocity = leadBody.AngularVelocity;
             var slotVelocity = FormationControl.SlotVelocity(leadVelocity, leadAngularVelocity,
                 targetPoint - leadPosition);
             var desiredVelocity = FormationControl.DesiredVelocity(slotVelocity, slotError);
@@ -691,8 +703,7 @@ namespace LibreLancer.World.Components
             var selfForward = body.RotateVector(-Vector3.UnitZ);
             var travelDirection = slotVelocity.LengthSquared() > 400
                 ? slotVelocity
-                : leadBody?.RotateVector(-Vector3.UnitZ) ??
-                  Vector3.Transform(-Vector3.UnitZ, lead.WorldTransform.Orientation);
+                : leadBody.RotateVector(-Vector3.UnitZ);
 
             control.Cruise = ShouldCruise(lead);
             control.CruiseSpeedOffset =
@@ -737,7 +748,7 @@ namespace LibreLancer.World.Components
                 Component.OutPitch = 0;
             }
 
-            DrawFormationPoints(world, Parent.Formation, targetPoint);
+            DrawFormationPoints(world, formation, targetPoint);
             world.DrawFormationDebugLine(body.Position, targetPoint, Color4.Cyan);
             if (steeringPoint is { } point)
                 world.DrawFormationDebugLine(body.Position, point, Color4.Lime);

--- a/src/LibreLancer/World/Components/PhysicsComponent.cs
+++ b/src/LibreLancer/World/Components/PhysicsComponent.cs
@@ -235,7 +235,8 @@ namespace LibreLancer.World.Components
         public override void Unregister(GameWorld world)
         {
             pworld = null;
-            world.Physics?.RemoveObject(Body);
+            if (Body is { IsDisposed: false })
+                world.Physics?.RemoveObject(Body);
             collider?.Dispose();
         }
     }

--- a/src/LibreLancer/World/ShipFormation.cs
+++ b/src/LibreLancer/World/ShipFormation.cs
@@ -69,6 +69,13 @@ namespace LibreLancer.World
             if (LeadShip == self) return;
             var idx = _followers.IndexOf(self);
             if (idx == -1) throw new InvalidOperationException("Ship not in formation");
+            if (idx >= Offsets.Length)
+            {
+                var oldLength = Offsets.Length;
+                Array.Resize(ref Offsets, idx + 1);
+                for (int i = oldLength; i < Offsets.Length; i++)
+                    Offsets[i] = DefaultOffset(i);
+            }
             Offsets[idx] = offset;
             Version++;
         }
@@ -104,19 +111,43 @@ namespace LibreLancer.World
 
         public void Remove(GameObject obj)
         {
-            if (LeadShip == obj) {
-                if (Followers.Count > 0)
+            if (!Contains(obj))
+                throw new InvalidOperationException("Ship not in formation");
+
+            if (LeadShip == obj)
+            {
+                if (_followers.Count <= 1)
                 {
-                    LeadShip = Followers[0];
-                    _followers.RemoveAt(0);
+                    Disband(obj);
+                    return;
                 }
+
+                LeadShip = _followers[0];
+                _followers.RemoveAt(0);
             }
             else
             {
                 if (!_followers.Remove(obj))
                     throw new InvalidOperationException("Ship not in formation");
+
+                if (_followers.Count == 0)
+                {
+                    Disband(obj);
+                    return;
+                }
             }
+
             obj.Formation = null;
+            Version++;
+        }
+
+        private void Disband(GameObject removed)
+        {
+            LeadShip.Formation = null;
+            foreach (var follower in _followers)
+                follower.Formation = null;
+            removed.Formation = null;
+            _followers.Clear();
             Version++;
         }
 
@@ -146,11 +177,21 @@ namespace LibreLancer.World
 
         public NetFormation ToNetFormation(GameObject self)
         {
+            if (LeadShip != self &&
+                ((LeadShip.Flags & GameObjectFlags.Exists) != GameObjectFlags.Exists || LeadShip.NetID == 0))
+            {
+                return new NetFormation();
+            }
+
+            var followers = Followers
+                .Where(x => x == self || (x.Flags & GameObjectFlags.Exists) == GameObjectFlags.Exists && x.NetID != 0)
+                .Select(x => GetId(x, self))
+                .ToArray();
             var nf = new NetFormation
             {
                 Exists = true,
                 LeadShip = GetId(LeadShip, self),
-                Followers = Followers.Select(x => GetId(x, self)).ToArray(),
+                Followers = followers,
                 YourPosition = GetShipOffset(self)
             };
             return nf;


### PR DESCRIPTION
- Made formations safer by filtering destroyed followers/leader and clearing invalid client-side formation updates, as well by tracking disposed physics bodies, avoiding reads from removed BEPU bodies, removing destroyed ships from formations, and cleaning up invalid formations. The game would crash sometimes when killing npcs in a formation.

- Added mission solar launch support so bases created by mission scripts can be used when launching back to space (ex: Benford/Baxter station)

- Implemented additional mission condition/action behavior, more tradelane checks, maneuver locking/enabling, safer comm voice lookup, mission solar spawning, and safer destroy handling.

- Added mission objective state handling for `Act_SetNNObj`, `Act_SetNNState`, and `Act_GiveNNObjs`.

- Fixed story progression cash gating so the next story entry’s `CashUp` value is used when calculating `NextLevelWorth`, preventing M04 from immediately advancing into M05 after Tobias rewards the player.

- Mission editor ActEnableManeuver updated as said in INi "Act_EnableManeuver = formation, false;
Act_EnableManeuver = Dock, true",