### PR TITLE
M05 fixes

### DIFF
--- a/src/LibreLancer/Missions/Actions/ScriptedAction_Spawn.cs
+++ b/src/LibreLancer/Missions/Actions/ScriptedAction_Spawn.cs
@@ -139,19 +139,10 @@ namespace LibreLancer.Missions.Actions
             }
 
             var pos = archPos;
-            GameObject relObj;
 
             // Spawn relative to object
-            if (!string.IsNullOrWhiteSpace(ship.RelativePosition.ObjectName) &&
-                (relObj = runtime.Player.Space.World.GameWorld.GetObject(ship.RelativePosition.ObjectName)!) != null)
-            {
-                var dir = new Vector3(runtime.Random.NextFloat(-1, 1),
-                    runtime.Random.NextFloat(-0.1f, 0.1f),
-                    runtime.Random.NextFloat(-1, 1)).Normalized();
-                var range = runtime.Random.NextFloat(ship.RelativePosition.MinRange,
-                    ship.RelativePosition.MaxRange);
-                pos = relObj.WorldTransform.Position + (dir * range);
-            }
+            if (TryGetRelativePosition(ship.RelativePosition, runtime, out var relativePosition))
+                pos = relativePosition;
 
             var arrivalObject = string.IsNullOrWhiteSpace(ship.ArrivalObj.Object) || spawnpos.Present
                 ? null
@@ -179,6 +170,27 @@ namespace LibreLancer.Missions.Actions
             {
                 SpawnShipInWorld(ship, spawnpos, spawnorient, objList, script, runtime);
             });
+        }
+
+        protected bool TryGetRelativePosition(MissionRelativePosition relativePosition, MissionRuntime runtime,
+            out Vector3 position)
+        {
+            position = Vector3.Zero;
+
+            if (string.IsNullOrWhiteSpace(relativePosition.ObjectName))
+                return false;
+
+            var relObj = runtime.Player.Space!.World.GameWorld.GetObject(relativePosition.ObjectName);
+            if (relObj == null)
+                return false;
+
+            var dir = new Vector3(
+                runtime.Random.NextFloat(-1, 1),
+                runtime.Random.NextFloat(-0.1f, 0.1f),
+                runtime.Random.NextFloat(-1, 1)).Normalized();
+            var range = runtime.Random.NextFloat(relativePosition.MinRange, relativePosition.MaxRange);
+            position = relObj.WorldTransform.Position + (dir * range);
+            return true;
         }
     }
 
@@ -263,6 +275,8 @@ namespace LibreLancer.Missions.Actions
             }
 
             var fpos = Position.Get(form.Position);
+            if (!Position.Present && TryGetRelativePosition(form.RelativePosition, runtime, out var relativePosition))
+                fpos = relativePosition;
             var forient = Orientation.Get(form.Orientation);
             var mat = Matrix4x4.CreateFromQuaternion(forient) *
                       Matrix4x4.CreateTranslation(fpos);

--- a/src/LibreLancer/Missions/MissionRuntime.cs
+++ b/src/LibreLancer/Missions/MissionRuntime.cs
@@ -245,6 +245,15 @@ namespace LibreLancer.Missions
             return null;
         }
 
+        public bool IsMissionSolarBase(string? baseName)
+        {
+            if (string.IsNullOrWhiteSpace(baseName))
+                return false;
+
+            return Script.Solars.Values.Any(x =>
+                baseName.Equals(x.Base, StringComparison.OrdinalIgnoreCase));
+        }
+
         public void ActivateTrigger(string trigger)
         {
             var t = Script.AvailableTriggers[trigger];

--- a/src/LibreLancer/Server/Components/SNPCComponent.cs
+++ b/src/LibreLancer/Server/Components/SNPCComponent.cs
@@ -67,6 +67,17 @@ namespace LibreLancer.Server.Components
 
         public void Docked()
         {
+            if (MissionRuntime != null)
+            {
+                if (Parent.TryGetComponent<AutopilotComponent>(out var autopilot))
+                    autopilot.Cancel();
+                if (Parent.TryGetComponent<ShipSteeringComponent>(out var steering))
+                {
+                    steering.InThrottle = 0;
+                    steering.Cruise = false;
+                }
+                return;
+            }
             manager.Despawn(Parent, false);
         }
 

--- a/src/LibreLancer/Server/Components/STradelaneMoveComponent.cs
+++ b/src/LibreLancer/Server/Components/STradelaneMoveComponent.cs
@@ -208,6 +208,8 @@ namespace LibreLancer.Server.Components
             if (Parent.TryGetComponent<AutopilotComponent>(out var ap))
             {
                 ap.Cancel();
+                if (Parent.Formation != null && Parent.Formation.LeadShip != Parent)
+                    ap.StartFormation();
             }
 
             if (TryGetMissionRuntime(out var msn, out var isPlayer))

--- a/src/LibreLancer/Server/Player.cs
+++ b/src/LibreLancer/Server/Player.cs
@@ -146,6 +146,7 @@ namespace LibreLancer.Server
                 MissionRuntime.PlayerLaunch();
                 MissionRuntime.CheckMissionScript();
                 MissionRuntime.EnteredSpace();
+                MissionRuntime.CheckMissionScript();
             }
         }
 

--- a/src/LibreLancer/Server/ServerWorld.cs
+++ b/src/LibreLancer/Server/ServerWorld.cs
@@ -975,6 +975,35 @@ namespace LibreLancer.Server
         private double noPlayersTime;
         private double maxNoPlayers = 2.0;
 
+        private bool ShouldKeepAliveForMissionSolarBase()
+        {
+            var player = Server.LocalPlayer;
+            return PlayerCount == 0 &&
+                   player?.MissionRuntime != null &&
+                   player.Space == null &&
+                   player.MissionRuntime.IsMissionSolarBase(player.Base) &&
+                   System.Nickname.Equals(player.System, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private void FreezeShipsForMissionSolarBase()
+        {
+            foreach (var obj in spawnedObjects)
+            {
+                if (!obj.TryGetComponent<ShipPhysicsComponent>(out var physics))
+                    continue;
+
+                obj.PhysicsComponent!.Body.LinearVelocity = Vector3.Zero;
+                obj.PhysicsComponent.Body.AngularVelocity = Vector3.Zero;
+                physics.EnginePower = 0;
+
+                if (obj.TryGetComponent<ShipSteeringComponent>(out var steering))
+                {
+                    steering.InThrottle = 0;
+                    steering.Cruise = false;
+                }
+            }
+        }
+
         public bool Update(double delta, double totalTime, uint currentTick, int step)
         {
             // Avoid locks during Update
@@ -997,6 +1026,13 @@ namespace LibreLancer.Server
             // pause
             if (paused)
             {
+                return true;
+            }
+
+            if (ShouldKeepAliveForMissionSolarBase())
+            {
+                FreezeShipsForMissionSolarBase();
+                noPlayersTime = 0;
                 return true;
             }
 


### PR DESCRIPTION
- Fix for when NPCs  in formation with the player, all enter a tradelane, to keep the formation going on the exit.

- Added NPCs consistency for when docking on mission solars, seem like Freelancer let them there for when the player undocks. Ex: Juni doesn't have a spawn call after leaving Sprague, neither Sinclair or Juni when leaving Baxter. (I've checked M04 Belford station, it does not duplicate Juni in this case)
-- All npcs who remain after a mission solar dock, have their cruise set to off and throttle to 0

- Rheinland ships now uncloak correctly and spawn correctly at their positions, before they would spawn somewhere in the system center (This also fixes m03 uncloaking Rheinland ships)