### PR TITLE
fix: macOS (Apple Silicon) build + native library loading

### DIFF
--- a/src/LibreLancer.Base/Platforms/DllMap.cs
+++ b/src/LibreLancer.Base/Platforms/DllMap.cs
@@ -61,6 +61,16 @@ internal static class DllMap
             mappedName = libs.TryGetValue(libraryName, out mappedName) ? mappedName : libraryName;
         }
 
-        return NativeLibrary.Load(mappedName, assembly, dllImportSearchPath);
+        // A mapping may list several candidates separated by ';' — first one
+        // that loads wins. Lets a single config serve both app-local dylibs
+        // and package-manager install locations (e.g. homebrew on macOS).
+        var candidates = mappedName.Split(';', StringSplitOptions.RemoveEmptyEntries);
+        for (int i = 0; i < candidates.Length - 1; i++)
+        {
+            if (NativeLibrary.TryLoad(candidates[i], assembly, dllImportSearchPath, out var handle))
+                return handle;
+        }
+
+        return NativeLibrary.Load(candidates[^1], assembly, dllImportSearchPath);
     }
 }

--- a/src/LibreLancer.Media/AudioManager.cs
+++ b/src/LibreLancer.Media/AudioManager.cs
@@ -375,13 +375,31 @@ public unsafe class AudioManager
         RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             ? "soft_oal.dll"
             : RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
-                ? "/opt/homebrew/opt/openal-soft/lib/libopenal.dylib"
+                ? "libopenal.dylib"
                 : "libopenal.so.1";
+
+    private static readonly string[] macFallbackPaths =
+    [
+        "/opt/homebrew/opt/openal-soft/lib/libopenal.dylib",
+        "/usr/local/opt/openal-soft/lib/libopenal.dylib"
+    ];
 
     static bool LoadALSoft()
     {
-        if (!NativeLibrary.TryLoad(libraryName, out alsoftDll))
-            return false;
+        // Probe app/assembly directories first (bundled dylib), then fall
+        // back to the homebrew install locations on macOS
+        if (!NativeLibrary.TryLoad(libraryName, typeof(AudioManager).Assembly, null, out alsoftDll))
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                return false;
+            foreach (var path in macFallbackPaths)
+            {
+                if (NativeLibrary.TryLoad(path, out alsoftDll))
+                    break;
+            }
+            if (alsoftDll == IntPtr.Zero)
+                return false;
+        }
         Alc.LoadFunctions(alsoftDll);
         Al.Native.LoadFunctions(alsoftDll);
         // Set logging

--- a/src/PublishAssets/LibreLancer.Base.dll.config
+++ b/src/PublishAssets/LibreLancer.Base.dll.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <dllmap dll="SDL2.dll" os="osx" target="/opt/homebrew/opt/sdl2/lib/libSDL2.dylib"/>
+    <dllmap dll="SDL2.dll" os="osx" target="libSDL2.dylib;/opt/homebrew/opt/sdl2/lib/libSDL2.dylib;/usr/local/opt/sdl2/lib/libSDL2.dylib"/>
     <dllmap dll="SDL2.dll" os="linux" target="libSDL2-2.0.so.0"/>
     <dllmap dll="SDL3" os="linux" target="libSDL3.so.0"/>
 </configuration>

--- a/src/PublishAssets/LibreLancer.Media.dll.config
+++ b/src/PublishAssets/LibreLancer.Media.dll.config
@@ -1,4 +1,4 @@
 ﻿<configuration>
     <dllmap os="linux" dll="soft_oal.dll" target="libopenal.so.1"/>
-    <dllmap os="osx" dll="soft_oal.dll" target="/opt/homebrew/opt/openal-soft/lib/libopenal.dylib"/>
+    <dllmap os="osx" dll="soft_oal.dll" target="libopenal.dylib;/opt/homebrew/opt/openal-soft/lib/libopenal.dylib;/usr/local/opt/openal-soft/lib/libopenal.dylib"/>
 </configuration>

--- a/src/cimgui_ext/CMakeLists.txt
+++ b/src/cimgui_ext/CMakeLists.txt
@@ -42,10 +42,19 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows" AND ${CMAKE_CXX_COMPILER_ID} MATCHES "
     target_link_options(cimgui PRIVATE -static-libgcc -static-libstdc++ -static)
 endif()
 
-if(NOT WIN32)
+if(NOT WIN32 AND NOT APPLE)
     find_package(Freetype REQUIRED)
     target_link_libraries(cimgui PRIVATE ${FREETYPE_LIBRARIES})
     target_include_directories(cimgui PRIVATE ${FREETYPE_INCLUDE_DIRS})
 else()
+    # macOS: no system freetype; use blurgtext's vendored static
+    # freetype+harfbuzz (BT_BUILD_FTHB), same as the Windows build
     target_link_libraries(cimgui PRIVATE FREETYPE_LIBRARY HARFBUZZ_LIBRARY)
+    if(APPLE)
+        # static harfbuzz includes the CoreText shaper
+        find_library(COREFOUNDATION_FRAMEWORK CoreFoundation REQUIRED)
+        find_library(CORETEXT_FRAMEWORK CoreText REQUIRED)
+        find_library(COREGRAPHICS_FRAMEWORK CoreGraphics REQUIRED)
+        target_link_libraries(cimgui PRIVATE ${COREFOUNDATION_FRAMEWORK} ${CORETEXT_FRAMEWORK} ${COREGRAPHICS_FRAMEWORK})
+    endif()
 endif()


### PR DESCRIPTION
Builds on the macOS support restored around BlurgText 0.1 (#385). With the three fixes below, current `main` builds and runs natively on Apple Silicon (macOS 26.5, arm64, Xcode clang 21) with no Homebrew on the build machine — verified through a loopback LLServer multiplayer session (character create → dock → launch → in space) and interactive single-player.

**1. `src/cimgui_ext/CMakeLists.txt`: use vendored freetype on APPLE**

`find_package(Freetype REQUIRED)` fails on macOS without a package manager. blurgtext already builds a static freetype+harfbuzz on APPLE (`BT_BUILD_FTHB=ON` default) and the Windows branch already links those imported targets — this extends that branch to APPLE, plus links CoreFoundation/CoreText/CoreGraphics (the vendored harfbuzz includes the CoreText shaper, so linking fails without them).

**2. `DllMap.cs` + osx dllmaps: fallback chains**

The osx dllmap targets were hardcoded absolute Homebrew paths (`/opt/homebrew/...`), which fail for bundled/portable layouts and for Intel Homebrew (`/usr/local`). `MapAndLoad` now accepts `;`-separated candidates (first one that loads wins; single-target maps behave exactly as before), and the osx entries list: plain dylib name (app-local probing) → Apple Silicon Homebrew → Intel Homebrew.

**3. `AudioManager.cs`: same treatment for OpenAL**

`libraryName` on macOS was a hardcoded `/opt/homebrew/.../libopenal.dylib` (the `LibreLancer.Media.dll.config` dllmap never applied here — `NativeLibrary.TryLoad` doesn't consult DllImport resolvers). Now probes `libopenal.dylib` with assembly-context search first (finds a bundled dylib), then the two Homebrew locations. Sound goes from "disabled" to working (CoreAudio via openal-soft) on a machine with no Homebrew.

**Environment / evidence**
- Apple M5-class, macOS 26.5 (arm64), Xcode clang 21, .NET SDK 10.0.301, CMake 3.31.10; SDL2 2.32.10, SDL3 3.4.12 and openal-soft 1.25.2 built from source; vanilla game data.
- `./build.sh` completes (DXC compiled from source per the build's default non-x64 path); `lancer` renders via OpenGL 4.1 (Metal), `SDL: Using SDL3`; `LLServer` binds and a full loopback session works end-to-end.
- Not addressed here (out of scope, happy to file separately): openal-soft 1.25.2 itself doesn't compile against the macOS 26 SDK (`-Werror=function-effects` vs new CoreAudio `nonblocking` annotations) — an upstream openal-soft issue, workaround is one warning flag.

Happy to adjust the dllmap approach if a different mechanism is preferred (e.g. multiple `<dllmap>` entries per dll instead of `;`-separated targets).