### PR TITLE
Nebule solar culling fix

### DIFF
--- a/src/LibreLancer/Render/AsteroidFieldRenderer.cs
+++ b/src/LibreLancer/Render/AsteroidFieldRenderer.cs
@@ -447,7 +447,10 @@ namespace LibreLancer.Render
                     p = Vector3.Transform(p, bandTransform);
                     var lt = RenderHelpers.ApplyLights(lighting, 0, p, lightingRadius, nr);
 
-                    if (lt.FogMode != FogModes.Linear || Vector3.DistanceSquared(cameraPos, p) <=
+                    var canFogCullBand = lt.FogMode == FogModes.Linear &&
+                                         (nr == null || nr.FogTransitionOpacity() >= 1f);
+
+                    if (!canFogCullBand || Vector3.DistanceSquared(cameraPos, p) <=
                         (lightingRadius + lt.FogRange.Y) * (lightingRadius + lt.FogRange.Y))
                     {
                         buffer.AddCommand(bandMaterial, null, bandHandle, lt, bandCylinder.VertexBuffer, 1.0f,

--- a/src/LibreLancer/Render/ModelRenderer.cs
+++ b/src/LibreLancer/Render/ModelRenderer.cs
@@ -165,7 +165,11 @@ namespace LibreLancer.Render
 
             this.sysr = sys;
 
-            if (sys.DrawNebulae && Nebula != null && nr != Nebula || (forceCull && InheritCull))
+            // Use the same opacity that draws the nebula transition. Objects
+            // outside it remain rendered throughout the fade and are culled
+            // only once that visual fog has reached 100%.
+            if ((sys.DrawNebulae && nr != null && nr.FogTransitionOpacity() >= 1f && Nebula != nr) ||
+                (forceCull && InheritCull))
             {
                 return false;
             }
@@ -248,9 +252,11 @@ namespace LibreLancer.Render
 
                     var lighting = RenderHelpers.ApplyLights(lights, LightGroup, center, part.GetRadius(), nr,
                         LitAmbient, LitDynamic, NoFog);
+                    var canFogCullPart = lighting.FogMode == FogModes.Linear &&
+                                         (nr == null || nr.FogTransitionOpacity() >= 1f || Nebula == nr);
                     var r = part.GetRadius() + lighting.FogRange.Y;
 
-                    if (lighting.FogMode != FogModes.Linear ||
+                    if (!canFogCullPart ||
                         Vector3.DistanceSquared(camera.Position, center) <= (r * r))
                     {
                         var userData = ColorOverride is { } color ? BasicMaterial.SetDc(color) : 0;

--- a/src/LibreLancer/Render/ModelRenderer.cs
+++ b/src/LibreLancer/Render/ModelRenderer.cs
@@ -165,9 +165,6 @@ namespace LibreLancer.Render
 
             this.sysr = sys;
 
-            // Use the same opacity that draws the nebula transition. Objects
-            // outside it remain rendered throughout the fade and are culled
-            // only once that visual fog has reached 100%.
             if ((sys.DrawNebulae && nr != null && nr.FogTransitionOpacity() >= 1f && Nebula != nr) ||
                 (forceCull && InheritCull))
             {

--- a/src/LibreLancer/Render/NebulaRenderer.cs
+++ b/src/LibreLancer/Render/NebulaRenderer.cs
@@ -66,15 +66,15 @@ namespace LibreLancer.Render
 
 		public bool FogTransitioned()
 		{
-			if (Math.Abs(Nebula.Zone!.EdgeFraction) < 0.000000001) // basically == 0. Instant transition
-            {
-                return true;
-            }
-
-            return (1 - Nebula.Zone.ScaledDistance(sysr.Camera.Position)) >= Nebula.Zone.EdgeFraction;
-			// var scaled = Nebula.Zone.Shape.Scale(1 - Nebula.Zone.EdgeFraction);
-			// return scaled.ContainsPoint(sysr.Camera.Position);
+			return FogTransitionOpacity() >= 1f;
 		}
+
+        public float FogTransitionOpacity()
+        {
+            if (Math.Abs(Nebula.Zone!.EdgeFraction) < 0.000000001) // Instant transition
+                return 1f;
+            return CalculateTransition(Nebula.Zone);
+        }
 
         private float CalculateTransition(Zone zone)
 		{
@@ -87,7 +87,7 @@ namespace LibreLancer.Render
 		public void RenderFogTransition(RenderContext ren)
 		{
 			var c = GetFogColor();
-			c.A = CalculateTransition(Nebula.Zone!);
+			c.A = FogTransitionOpacity();
             ren.TintViewport(c);
         }
 
@@ -217,6 +217,7 @@ namespace LibreLancer.Render
 				var factor = CalculateTransition(ex.Zone!);
 				FogRange.Y = MathHelper.Lerp(FogRange.Y, ex.FogFar, factor);
 			}
+
 			lightning = null;
 			if (dynLightningActive)
 			{


### PR DESCRIPTION
Outside nebula objects were disappearing before the nebula transition fully completed. This changes outside-object culling to the same visual transition opacity used by the nebula fade, so they remain rendered until the fog is actually fully opaque.