### PR TITLE
Add 3DB Icon Browser and Improve Texture, Material, and Mod Data Handling

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -60,6 +60,20 @@ $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 $env:DOTNET_CLI_TELEMETRY_OPTOUT=1
 $env:DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=2
 
+# Windows fresh setups often have CMake installed, but the current shell has not
+# picked up PATH changes yet. Make the standard install location visible here.
+$DefaultCMakePath = Join-Path ([Environment]::GetFolderPath("ProgramFiles")) "CMake\bin"
+if ((Get-Command cmake -ErrorAction SilentlyContinue) -eq $null -and (Test-Path (Join-Path $DefaultCMakePath "cmake.exe"))) {
+    $env:Path = "$DefaultCMakePath;$env:Path"
+}
+
+# LLShaderCompiler compiles many shader permutations in parallel. On some Windows
+# machines that can leave 9-byte/corrupt shader bundles after an out-of-memory
+# failure. Keep the default conservative unless the caller already chose a value.
+if ([string]::IsNullOrWhiteSpace($env:DOTNET_PROCESSOR_COUNT)) {
+    $env:DOTNET_PROCESSOR_COUNT = "2"
+}
+
 # Get .NET Core CLI path if installed.
 $SDKResult = "notfound";
 if (Get-Command dotnet -ErrorAction SilentlyContinue) {

--- a/src/Editor/LancerEdit/MainWindow.cs
+++ b/src/Editor/LancerEdit/MainWindow.cs
@@ -663,6 +663,14 @@ namespace LancerEdit
                         AddTab(new MissionScriptEditorTab(OpenDataContext, this, x));
                     }, AppFilters.IniFilters, GetDataPath());
                 }
+                if (Theme.IconMenuItem(Icons.Images, "3DB Icon Browser", OpenDataContext != null))
+                {
+                    var fd = TabControl.Tabs.FirstOrDefault(x => x is ThreeDbIconBrowserTab);
+                    if (fd != null)
+                        TabControl.SetSelected(fd);
+                    else
+                        AddTab(new ThreeDbIconBrowserTab(this, OpenDataContext));
+                }
                 ImGui.Separator();
                 if (Theme.IconMenuItem(Icons.Fire, "Projectile Viewer", OpenDataContext != null))
                     AddTab(new ProjectileViewerTab(this, OpenDataContext));
@@ -1256,9 +1264,14 @@ namespace LancerEdit
                                 Type = ResourceUsageType.Material,
                                 MaterialId = matId,
                                 Name = ResolveMaterialName(matId),
-                                Missing = true
+                                Missing = true,
+                                Hint = miss.Hint
                             };
                             ResourceIndex[key] = usage;
+                        }
+                        else if (string.IsNullOrEmpty(usage.Hint))
+                        {
+                            usage.Hint = miss.Hint;
                         }
 
                         if (!string.IsNullOrEmpty(miss.Reference))
@@ -1342,6 +1355,7 @@ namespace LancerEdit
         public string Name; // texture name OR material display name
         public uint? MaterialId; // only for materials
         public bool Missing;
+        public string Hint;
 
         public HashSet<string> UsedBy = new(); // model / drawable names
         public HashSet<string> ProvidedBy = new(); // utf filenames (optional, can be empty)

--- a/src/Editor/LancerEdit/Model/ModelViewer.cs
+++ b/src/Editor/LancerEdit/Model/ModelViewer.cs
@@ -105,6 +105,11 @@ namespace LancerEdit
         private VerticalTabLayout layout;
 
         public ModelViewer(string name, IDrawable drawable, MainWindow win, UtfTab parent, ModelNodes hprefs)
+            : this(name, drawable, win, parent, hprefs, null)
+        {
+        }
+
+        public ModelViewer(string name, IDrawable drawable, MainWindow win, UtfTab parent, ModelNodes hprefs, ResourceManager resources)
         {
             blenderEnabled = Blender.BlenderPathValid(win.Config.BlenderPath);
             selectedCam = win.Config.DefaultCameraMode;
@@ -116,7 +121,7 @@ namespace LancerEdit
             this.TabColor = parent.TabColor;
             this.hprefs = hprefs;
             rstate = win.RenderContext;
-            res = parent.DetachedResources ?? win.Resources;
+            res = resources ?? parent.DetachedResources ?? win.Resources;
             buffer = win.Commands;
             _window = win;
             SaveStrategy = parent.SaveStrategy;
@@ -1254,7 +1259,7 @@ namespace LancerEdit
 
         public override void DetectResources(List<MissingReference> missing, List<uint> matrefs, List<TextureReference> texrefs)
         {
-            ResourceDetection.DetectDrawable(Name, drawable, res, missing, matrefs, texrefs);
+            ResourceDetection.DetectDrawable(Name, drawable, res, missing, matrefs, texrefs, parent?.FilePath);
         }
 
 

--- a/src/Editor/LancerEdit/Resource/MissingReference.cs
+++ b/src/Editor/LancerEdit/Resource/MissingReference.cs
@@ -9,10 +9,19 @@ namespace LancerEdit
 	{
 		public string Missing;
 		public string Reference;
+		public string Hint;
 		public MissingReference(string m, string r)
 		{
 			Missing = m;
 			Reference = r;
+			Hint = null;
+		}
+
+		public MissingReference(string m, string r, string hint)
+		{
+			Missing = m;
+			Reference = r;
+			Hint = hint;
 		}
 	}
 }

--- a/src/Editor/LancerEdit/Resource/ResourceDetection.cs
+++ b/src/Editor/LancerEdit/Resource/ResourceDetection.cs
@@ -4,12 +4,15 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
+using LibreLancer.ContentEdit;
 using LibreLancer;
 using LibreLancer.Data;
 using LibreLancer.Graphics;
 using LibreLancer.Render.Materials;
 using LibreLancer.Resources;
+using LibreLancer.Utf;
 using LibreLancer.Utf.Cmp;
 using LibreLancer.Utf.Mat;
 namespace LancerEdit
@@ -46,16 +49,18 @@ namespace LancerEdit
     }
 	static class ResourceDetection
 	{
-		public static void DetectDrawable(string name, IDrawable drawable, ResourceManager res, List<MissingReference> missing, List<uint> matrefs, List<TextureReference> texrefs)
+		static readonly Dictionary<string, string> materialLibraryHints = new(StringComparer.OrdinalIgnoreCase);
+
+		public static void DetectDrawable(string name, IDrawable drawable, ResourceManager res, List<MissingReference> missing, List<uint> matrefs, List<TextureReference> texrefs, string sourcePath = null)
 		{
 			if (drawable is CmpFile)
 			{
 				var cmp = (CmpFile)drawable;
-				foreach (var part in cmp.ModelParts()) DetectResourcesModel(part.Model, name + ", " + part.Model.Path, res, missing, matrefs, texrefs);
+				foreach (var part in cmp.ModelParts()) DetectResourcesModel(part.Model, name + ", " + part.Model.Path, res, missing, matrefs, texrefs, sourcePath);
 			}
 			if (drawable is ModelFile)
 			{
-				DetectResourcesModel((ModelFile)drawable, name, res, missing, matrefs, texrefs);
+				DetectResourcesModel((ModelFile)drawable, name, res, missing, matrefs, texrefs, sourcePath);
 			}
 			if (drawable is SphFile)
 			{
@@ -77,26 +82,103 @@ namespace LancerEdit
 				}
 			}
 		}
-		static void DetectResourcesModel(ModelFile mdl, string mdlname, ResourceManager res, List<MissingReference> missing, List<uint> matrefs, List<TextureReference> texrefs)
+		static void DetectResourcesModel(ModelFile mdl, string mdlname, ResourceManager res, List<MissingReference> missing, List<uint> matrefs, List<TextureReference> texrefs, string sourcePath)
         {
             if (mdl.Levels.Length <= 0) return;
 			var lvl = mdl.Levels[0];
             var msh = res.FindMesh(lvl.MeshCrc);
-            if (msh == null) return;
+			if (msh == null) return;
 			for (int i = lvl.StartMesh; i < (lvl.StartMesh + lvl.MeshCount); i++)
             {
-                var mat = res.FindMaterial(msh.Meshes[i].MaterialCrc);
+                var materialCrc = msh.Meshes[i].MaterialCrc;
+                if (materialCrc == 0)
+                    continue;
+                var mat = res.FindMaterial(materialCrc);
 				if (mat == null)
 				{
-					var str = "Material: 0x" + msh.Meshes[i].MaterialCrc.ToString("X");
-					if (!HasMissing(missing, str)) missing.Add(new MissingReference(str, string.Format("{0}, VMesh(0x{1:X}) #{2}", mdlname, lvl.MeshCrc, i)));
+					var str = "Material: 0x" + materialCrc.ToString("X");
+					if (!HasMissing(missing, str)) missing.Add(new MissingReference(
+						str,
+						string.Format("{0}, VMesh(0x{1:X}) #{2}", mdlname, lvl.MeshCrc, i),
+						FindMaterialLibraryHint(sourcePath, materialCrc)));
 				}
 				else
 				{
-					if (!matrefs.Contains(msh.Meshes[i].MaterialCrc)) matrefs.Add(msh.Meshes[i].MaterialCrc);
+					if (!matrefs.Contains(materialCrc)) matrefs.Add(materialCrc);
 					DoMaterialRefs(mat, res, missing, texrefs, string.Format(" - {0} VMesh(0x{1:X}) #{2}", mdlname, lvl.MeshCrc, i));
 				}
 			}
+		}
+
+		static string FindMaterialLibraryHint(string sourcePath, uint materialCrc)
+		{
+			if (string.IsNullOrWhiteSpace(sourcePath))
+				return null;
+
+			var cacheKey = $"{sourcePath}|{materialCrc:X}";
+			if (materialLibraryHints.TryGetValue(cacheKey, out var cached))
+				return cached;
+
+			var hint = BuildMaterialLibraryHint(sourcePath, materialCrc);
+			materialLibraryHints[cacheKey] = hint;
+			return hint;
+		}
+
+		static string BuildMaterialLibraryHint(string sourcePath, uint materialCrc)
+		{
+			try
+			{
+				if (!File.Exists(sourcePath))
+					return null;
+
+				var directory = Path.GetDirectoryName(sourcePath);
+				if (string.IsNullOrEmpty(directory))
+					return null;
+
+				foreach (var matPath in Directory.EnumerateFiles(directory, "*.mat"))
+				{
+					if (MatFileContainsMaterial(matPath, materialCrc))
+					{
+						var rel = ToDataRelativePath(matPath);
+						return $"Recommended fix: add material_library = {rel}";
+					}
+				}
+
+				var expected = Path.ChangeExtension(sourcePath, ".mat");
+				var expectedRel = ToDataRelativePath(expected);
+				var existsText = File.Exists(expected)
+					? "The same-name MAT exists but does not contain this CRC."
+					: "No adjacent MAT containing this CRC was found.";
+				return $"{existsText} Check material_library. Candidate: material_library = {expectedRel}";
+			}
+			catch (Exception ex)
+			{
+				return $"Could not inspect adjacent MAT files: {ex.Message}";
+			}
+		}
+
+		static bool MatFileContainsMaterial(string matPath, uint materialCrc)
+		{
+			try
+			{
+				var utf = new EditableUtf(matPath);
+				UtfLoader.LoadResourceNode(utf.Export(), null, out var mat, out _, out _);
+				return mat?.Materials.ContainsKey(materialCrc) == true;
+			}
+			catch
+			{
+				return false;
+			}
+		}
+
+		static string ToDataRelativePath(string path)
+		{
+			var normalized = path.Replace('/', '\\');
+			var marker = "\\DATA\\";
+			var idx = normalized.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+			if (idx >= 0)
+				return normalized.Substring(idx + marker.Length);
+			return Path.GetFileName(path);
 		}
 
 		static void DoMaterialRefs(Material m, ResourceManager res, List<MissingReference> missing, List<TextureReference> texrefs, string refstr)

--- a/src/Editor/LancerEdit/Resource/ResourcesTab.cs
+++ b/src/Editor/LancerEdit/Resource/ResourcesTab.cs
@@ -155,6 +155,14 @@ namespace LancerEdit
                     return false;
             }
 
+            if (!string.IsNullOrEmpty(sourceFilter))
+            {
+                if (!u.ProvidedBy.Any(x =>
+                        x.Contains(sourceFilter, StringComparison.OrdinalIgnoreCase)) &&
+                    (u.Hint == null || !u.Hint.Contains(sourceFilter, StringComparison.OrdinalIgnoreCase)))
+                    return false;
+            }
+
             return true;
         }
 
@@ -211,7 +219,16 @@ namespace LancerEdit
 
             if (u.ProvidedBy.Count == 0)
             {
-                ImGui.TextDisabled("-");
+                if (!string.IsNullOrEmpty(u.Hint))
+                {
+                    ImGui.TextColored(color, u.Hint);
+                    if (ImGui.IsItemHovered())
+                        ImGui.SetTooltip(u.Hint);
+                }
+                else
+                {
+                    ImGui.TextDisabled("-");
+                }
                 return;
             }
 
@@ -255,6 +272,8 @@ namespace LancerEdit
             {
                 if (ImGui.MenuItem("Copy Material CRC"))
                     win.SetClipboardText($"0x{u.MaterialId.Value:X}");
+                if (!string.IsNullOrEmpty(u.Hint) && ImGui.MenuItem("Copy Recommendation"))
+                    win.SetClipboardText(u.Hint);
             }
 
             ImGui.EndPopup();

--- a/src/Editor/LancerEdit/Resource/ThreeDbIconBrowserTab.cs
+++ b/src/Editor/LancerEdit/Resource/ThreeDbIconBrowserTab.cs
@@ -1,0 +1,343 @@
+// MIT License - Copyright (c) Callum McGing
+// This file is subject to the terms and conditions defined in
+// LICENSE, which is part of this source code package
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using ImGuiNET;
+using LibreLancer.Graphics;
+using LibreLancer.ImUI;
+using LibreLancer.Resources;
+using LibreLancer.Utf;
+
+namespace LancerEdit;
+
+public class ThreeDbIconBrowserTab : EditorTab
+{
+    const int LoadsPerFrame = 4;
+
+    static readonly ThreeDbIconCollectionDefinition[] CollectionDefinitions =
+    [
+        new(
+            "Map Game Object Icons",
+            @"DATA\INTERFACE\NEURONET\NAVMAP\NEWNAVMAP\SPACEOBJECTS",
+            false),
+        new(
+            "Base Map Icons",
+            @"DATA\INTERFACE\NEURONET\NAVMAP\NEWNAVMAP",
+            false),
+    ];
+
+    readonly MainWindow win;
+    readonly GameDataContext context;
+    readonly List<ThreeDbIconCollection> collections = [];
+    readonly List<ThreeDbIconEntry> filtered = [];
+
+    string search = "";
+    int selectedCollection = 0;
+    int page = 0;
+    bool needsFilter = true;
+
+    public ThreeDbIconBrowserTab(MainWindow win, GameDataContext context)
+    {
+        this.win = win;
+        this.context = context;
+        Title = "3DB Icon Browser";
+        BuildCollections();
+    }
+
+    void BuildCollections()
+    {
+        foreach (var definition in CollectionDefinitions)
+        {
+            var files = GetThreeDbFiles(definition.Path, definition.Recursive)
+                .Select(path => new ThreeDbIconEntry(definition.Name, path))
+                .OrderBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            collections.Add(new ThreeDbIconCollection(definition.Name, definition.Path, files));
+        }
+    }
+
+    IEnumerable<string> GetThreeDbFiles(string path, bool recursive)
+    {
+        foreach (var file in context.GameData.VFS.GetFiles(path))
+        {
+            if (file.EndsWith(".3db", StringComparison.OrdinalIgnoreCase))
+                yield return CombineVfs(path, file);
+        }
+
+        if (!recursive)
+            yield break;
+
+        foreach (var dir in context.GameData.VFS.GetDirectories(path))
+        {
+            foreach (var file in GetThreeDbFiles(CombineVfs(path, dir), true))
+                yield return file;
+        }
+    }
+
+    static string CombineVfs(string path, string file) =>
+        path.TrimEnd('\\', '/') + "\\" + file.TrimStart('\\', '/');
+
+    public override void Draw(double elapsed)
+    {
+        DrawToolbar();
+        ImGui.Separator();
+
+        if (needsFilter)
+            ApplyFilter();
+
+        var cellWidth = 170 * ImGuiHelper.Scale;
+        var thumb = 96 * ImGuiHelper.Scale;
+        var columns = GetGridColumns(cellWidth);
+        var pageSize = GetDynamicPageSize(columns, thumb);
+        var totalPages = Math.Max(1, (int)Math.Ceiling(filtered.Count / (double)pageSize));
+        page = Math.Clamp(page, 0, totalPages - 1);
+
+        var start = page * pageSize;
+        var pageItems = filtered.Skip(start).Take(pageSize).ToArray();
+        LoadVisiblePreviews(pageItems);
+        DrawLoadingProgress();
+        DrawPager(totalPages, pageSize);
+        DrawGrid(pageItems, columns, thumb, cellWidth);
+    }
+
+    void DrawToolbar()
+    {
+        ImGui.SetNextItemWidth(260 * ImGuiHelper.Scale);
+        if (ImGui.InputTextWithHint("##search3db", "Search 3DB icons", ref search, 128))
+        {
+            page = 0;
+            needsFilter = true;
+        }
+
+        ImGui.SameLine();
+        var names = new[] { "All Collections" }.Concat(collections.Select(x => x.Name)).ToArray();
+        ImGui.SetNextItemWidth(260 * ImGuiHelper.Scale);
+        if (ImGui.Combo("Collection", ref selectedCollection, names, names.Length))
+        {
+            page = 0;
+            needsFilter = true;
+        }
+
+        ImGui.SameLine();
+        ImGui.TextDisabled($"{filtered.Count} icons");
+    }
+
+    void ApplyFilter()
+    {
+        filtered.Clear();
+        IEnumerable<ThreeDbIconEntry> src = selectedCollection == 0
+            ? collections.SelectMany(x => x.Entries)
+            : collections[selectedCollection - 1].Entries;
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            src = src.Where(x =>
+                x.Name.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                x.Path.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                x.Collection.Contains(search, StringComparison.OrdinalIgnoreCase));
+        }
+
+        filtered.AddRange(src);
+        needsFilter = false;
+    }
+
+    void LoadVisiblePreviews(IReadOnlyList<ThreeDbIconEntry> entries)
+    {
+        var loaded = 0;
+        foreach (var entry in entries)
+        {
+            if (entry.Loaded)
+                continue;
+            LoadPreview(entry);
+            loaded++;
+            if (loaded >= LoadsPerFrame)
+                break;
+        }
+        if (entries.Any(x => !x.Loaded))
+            ImGuiHelper.AnimatingElement();
+    }
+
+    void LoadPreview(ThreeDbIconEntry entry)
+    {
+        entry.Loaded = true;
+        try
+        {
+            context.Resources.LoadResourceFile(entry.Path);
+            var textureName = context.Resources.TexturesInFile(entry.Path).FirstOrDefault();
+            if (textureName == null)
+            {
+                using var stream = context.GameData.VFS.Open(entry.Path);
+                UtfLoader.LoadResourceFile(stream, entry.Path, context.Resources, out var mat, out var txm, out _);
+                textureName = txm?.Textures.Keys.FirstOrDefault();
+                if (textureName == null && mat != null)
+                {
+                    var materialTextureNames = mat.Materials.Values
+                        .SelectMany(GetMaterialTextureNames)
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToArray();
+                    textureName = materialTextureNames.FirstOrDefault(x => context.Resources.FindTexture(x) is Texture2D) ??
+                                  materialTextureNames.FirstOrDefault();
+                }
+            }
+            if (textureName == null)
+            {
+                entry.Error = "No texture library or material texture reference";
+                return;
+            }
+            entry.TextureName = textureName;
+            if (context.Resources.FindTexture(textureName) is Texture2D tex)
+            {
+                entry.Texture = tex;
+                entry.TextureId = ImGuiHelper.RegisterTexture(tex);
+            }
+            else
+            {
+                entry.Error = $"Texture '{textureName}' not loaded";
+            }
+        }
+        catch (Exception ex)
+        {
+            entry.Error = ex.Message;
+        }
+    }
+
+    static IEnumerable<string> GetMaterialTextureNames(LibreLancer.Utf.Mat.Material material)
+    {
+        if (!string.IsNullOrWhiteSpace(material.DtName))
+            yield return material.DtName;
+        if (!string.IsNullOrWhiteSpace(material.EtName))
+            yield return material.EtName;
+        if (!string.IsNullOrWhiteSpace(material.BtName))
+            yield return material.BtName;
+        if (!string.IsNullOrWhiteSpace(material.NtName))
+            yield return material.NtName;
+        if (!string.IsNullOrWhiteSpace(material.DmName))
+            yield return material.DmName;
+        if (!string.IsNullOrWhiteSpace(material.Dm0Name))
+            yield return material.Dm0Name;
+        if (!string.IsNullOrWhiteSpace(material.Dm1Name))
+            yield return material.Dm1Name;
+        if (!string.IsNullOrWhiteSpace(material.MtName))
+            yield return material.MtName;
+        if (!string.IsNullOrWhiteSpace(material.RtName))
+            yield return material.RtName;
+        if (!string.IsNullOrWhiteSpace(material.NmName))
+            yield return material.NmName;
+    }
+
+    void DrawLoadingProgress()
+    {
+        var all = filtered.Count;
+        if (all == 0)
+            return;
+        var loaded = filtered.Count(x => x.Loaded);
+        if (loaded >= all)
+            return;
+
+        ImGui.Spacing();
+        ImGui.Text($"{Icons.SyncAlt} Loading previews {loaded}/{all}");
+        ImGui.ProgressBar(loaded / (float)all, new Vector2(-1, 0));
+        ImGui.Spacing();
+    }
+
+    int GetGridColumns(float cellWidth) =>
+        Math.Max(1, (int)(ImGui.GetContentRegionAvail().X / cellWidth));
+
+    int GetDynamicPageSize(int columns, float thumb)
+    {
+        var cardHeight = thumb + 76 * ImGuiHelper.Scale;
+        var reservedHeight = 42 * ImGuiHelper.Scale;
+        if (filtered.Any(x => !x.Loaded))
+            reservedHeight += 48 * ImGuiHelper.Scale;
+        var availableHeight = Math.Max(cardHeight, ImGui.GetContentRegionAvail().Y - reservedHeight);
+        var rows = Math.Max(1, (int)(availableHeight / cardHeight));
+        return Math.Max(columns, columns * rows);
+    }
+
+    void DrawPager(int totalPages, int pageSize)
+    {
+        if (ImGui.Button(Icons.ArrowLeft.ToString(), new Vector2(34 * ImGuiHelper.Scale, 0)) && page > 0)
+            page--;
+        ImGui.SameLine();
+        ImGui.Text($"Page {page + 1} / {totalPages}   {pageSize} per page");
+        ImGui.SameLine();
+        if (ImGui.Button(Icons.ArrowRight.ToString(), new Vector2(34 * ImGuiHelper.Scale, 0)) && page + 1 < totalPages)
+            page++;
+    }
+
+    void DrawGrid(IReadOnlyList<ThreeDbIconEntry> entries, int columns, float thumb, float cellWidth)
+    {
+        if (!ImGui.BeginTable("##3dbicons", columns, ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.PadOuterX))
+            return;
+
+        foreach (var entry in entries)
+        {
+            ImGui.TableNextColumn();
+            ImGui.PushID(entry.Path);
+            DrawIconCard(entry, thumb, cellWidth);
+            ImGui.PopID();
+        }
+
+        ImGui.EndTable();
+    }
+
+    void DrawIconCard(ThreeDbIconEntry entry, float thumb, float cellWidth)
+    {
+        var imageSize = new Vector2(thumb);
+        if (entry.TextureId.HasValue)
+        {
+            if (ImGui.ImageButton("preview", entry.TextureId.Value, imageSize, new Vector2(0, 1), new Vector2(1, 0)))
+                OpenFull(entry);
+        }
+        else
+        {
+            ImGui.Button(entry.Loaded ? Icons.Warning.ToString() : Icons.SyncAlt.ToString(), imageSize);
+        }
+
+        if (ImGui.IsItemHovered())
+        {
+            ImGui.BeginTooltip();
+            ImGui.Text(entry.Name);
+            ImGui.Text(entry.Path);
+            if (!string.IsNullOrEmpty(entry.TextureName))
+                ImGui.Text("Texture: " + entry.TextureName);
+            if (!string.IsNullOrEmpty(entry.Error))
+                ImGui.TextColored(Theme.ErrorTextColor, entry.Error);
+            ImGui.EndTooltip();
+        }
+
+        var label = entry.Name;
+        if (label.Length > 24)
+            label = label.Substring(0, 21) + "...";
+        ImGui.TextWrapped(label);
+        ImGui.TextDisabled(entry.Collection);
+        if (ImGui.Button("Open Full", new Vector2(cellWidth - 18 * ImGuiHelper.Scale, 0)))
+            OpenFull(entry);
+    }
+
+    void OpenFull(ThreeDbIconEntry entry)
+    {
+        if (entry.Texture != null)
+            win.AddTab(new TextureViewer(entry.Name, entry.Texture, null, false));
+    }
+
+    record ThreeDbIconCollectionDefinition(string Name, string Path, bool Recursive);
+    record ThreeDbIconCollection(string Name, string Path, List<ThreeDbIconEntry> Entries);
+
+    class ThreeDbIconEntry(string collection, string path)
+    {
+        public string Collection = collection;
+        public string Path = path;
+        public string Name = System.IO.Path.GetFileName(path);
+        public bool Loaded;
+        public string TextureName;
+        public Texture2D Texture;
+        public ImTextureRef? TextureId;
+        public string Error;
+    }
+}

--- a/src/Editor/LancerEdit/Utf/UtfTab.cs
+++ b/src/Editor/LancerEdit/Utf/UtfTab.cs
@@ -15,6 +15,7 @@ using LibreLancer;
 using LibreLancer.ContentEdit;
 using LibreLancer.ContentEdit.Model;
 using LibreLancer.Data;
+using LibreLancer.Data.GameData;
 using LibreLancer.Dialogs;
 using LibreLancer.Graphics;
 using LibreLancer.ImageLib;
@@ -37,6 +38,10 @@ namespace LancerEdit
         List<JointMapView> jointViews = new List<JointMapView>();
         private HashSet<uint> materials = new();
         private HashSet<string> textures = new(StringComparer.OrdinalIgnoreCase);
+        private LUtfNode inlineTextureNode;
+        private Texture2D inlineTexturePreview;
+        private TextureCube inlineCubePreview;
+        private ImTextureRef? inlineTextureId;
 
         public GameResourceManager DetachedResources;
         public int DetachedResourceCount;
@@ -139,6 +144,7 @@ namespace LancerEdit
 
         public override void Dispose()
         {
+            ClearInlineTexturePreview();
             DereferenceDetached();
             main.Resources.RemoveResourcesForId(Unique.ToString());
         }
@@ -156,6 +162,86 @@ namespace LancerEdit
             strings.Reverse();
             var path = string.Join("/", strings);
             return path;
+        }
+
+        bool TryGetGameDataDrawable(out IDrawable drawable, out ResourceManager resources)
+        {
+            drawable = null;
+            resources = null;
+
+            if (main.OpenDataContext == null || string.IsNullOrEmpty(FilePath))
+                return false;
+
+            var targetPath = Path.GetFullPath(FilePath);
+            var items = main.OpenDataContext.GameData.Items;
+            IDrawable foundDrawable = null;
+            ResourceManager foundResources = null;
+
+            bool Matches(ResolvedModel mdl)
+            {
+                if (mdl?.ModelFile == null)
+                    return false;
+                var modelPath = mdl.ModelFile;
+                if (!Path.IsPathRooted(modelPath))
+                    modelPath = Path.Combine(main.OpenDataContext.Folder, modelPath);
+                return string.Equals(Path.GetFullPath(modelPath), targetPath, StringComparison.OrdinalIgnoreCase);
+            }
+
+            bool TryLoad(ResolvedModel mdl)
+            {
+                if (!Matches(mdl))
+                    return false;
+
+                var loaded = mdl.LoadFile(main.OpenDataContext.Resources);
+                foundDrawable = loaded?.Drawable;
+                foundResources = main.OpenDataContext.Resources;
+                return foundDrawable != null;
+            }
+
+            foreach (var arch in items.Archetypes)
+                if (TryLoad(arch.ModelFile))
+                {
+                    drawable = foundDrawable;
+                    resources = foundResources;
+                    return true;
+                }
+            foreach (var ship in items.Ships)
+                if (TryLoad(ship.ModelFile))
+                {
+                    drawable = foundDrawable;
+                    resources = foundResources;
+                    return true;
+                }
+            foreach (var asteroid in items.Asteroids)
+                if (TryLoad(asteroid.ModelFile))
+                {
+                    drawable = foundDrawable;
+                    resources = foundResources;
+                    return true;
+                }
+            foreach (var asteroid in items.DynamicAsteroids)
+                if (TryLoad(asteroid.ModelFile))
+                {
+                    drawable = foundDrawable;
+                    resources = foundResources;
+                    return true;
+                }
+            foreach (var simple in items.SimpleObjects)
+                if (TryLoad(simple.Model))
+                {
+                    drawable = foundDrawable;
+                    resources = foundResources;
+                    return true;
+                }
+            foreach (var equipment in items.Equipment)
+                if (TryLoad(equipment.ModelFile))
+                {
+                    drawable = foundDrawable;
+                    resources = foundResources;
+                    return true;
+                }
+
+            return false;
         }
 
         public void GenerateTangents()
@@ -270,11 +356,16 @@ namespace LancerEdit
                 if (tb.ButtonItem("View Model"))
                 {
                     IDrawable drawable = null;
+                    ResourceManager modelResources = null;
                     ModelNodes hpn = new ModelNodes();
                     hpn.RootNode = Utf.Root;
                     try
                     {
-                        drawable = LibreLancer.Utf.UtfLoader.GetDrawable(Utf.Export(), main.Resources);
+                        if (!TryGetGameDataDrawable(out drawable, out modelResources))
+                        {
+                            drawable = LibreLancer.Utf.UtfLoader.GetDrawable(Utf.Export(), main.Resources);
+                            modelResources = main.Resources;
+                        }
                         if (Utf.Root.Children.Any((x) => x.Name.Equals("cmpnd", StringComparison.OrdinalIgnoreCase)))
                         {
                             foreach (var child in Utf.Root.Children.Where((x) => x.Name.EndsWith(".3db", StringComparison.OrdinalIgnoreCase)))
@@ -301,7 +392,7 @@ namespace LancerEdit
                     if (drawable != null)
                     {
                         ReferenceDetached();
-                        main.AddTab(new ModelViewer(DocumentName, drawable, main, this, hpn));
+                        main.AddTab(new ModelViewer(DocumentName, drawable, main, this, hpn, modelResources));
                     }
                 }
 
@@ -498,6 +589,7 @@ namespace LancerEdit
                             ImGui.Text(((int*)ptr)[i].ToString());
                         }
                     }
+                    DrawInlineTexturePreview(selectedNode);
                 }
                 else
                 {
@@ -545,13 +637,7 @@ namespace LancerEdit
                     try
                     {
 #endif
-                    using (var stream = new MemoryStream(selectedNode.Data))
-                    {
-                        if (DDS.StreamIsDDS(stream))
-                            tex = DDS.FromStream(main.RenderContext, stream);
-                        else
-                            tex = TGA.TextureFromStream(main.RenderContext, stream);
-                    }
+                    tex = LoadTextureFromNode(selectedNode);
                     var title = string.Format("{0} ({1})", selectedNode.Name, Title);
                     if (tex is Texture2D tex2d)
                     {
@@ -709,6 +795,69 @@ namespace LancerEdit
             }
             foreach (var jmv in removeJmv) jointViews.Remove(jmv);
             ImGui.EndChild();
+        }
+
+        Texture LoadTextureFromNode(LUtfNode node)
+        {
+            if (node?.Data == null || node.Data.Length == 0)
+                return null;
+            using var stream = new MemoryStream(node.Data);
+            if (DDS.StreamIsDDS(stream))
+                return DDS.FromStream(main.RenderContext, stream);
+            return TGA.TextureFromStream(main.RenderContext, stream);
+        }
+
+        void ClearInlineTexturePreview()
+        {
+            if (inlineTexturePreview != null)
+            {
+                ImGuiHelper.DeregisterTexture(inlineTexturePreview);
+                inlineTexturePreview.Dispose();
+            }
+            inlineCubePreview?.Dispose();
+            inlineTexturePreview = null;
+            inlineCubePreview = null;
+            inlineTextureId = null;
+            inlineTextureNode = null;
+        }
+
+        void DrawInlineTexturePreview(LUtfNode node)
+        {
+            if (inlineTextureNode != node)
+            {
+                ClearInlineTexturePreview();
+                inlineTextureNode = node;
+                try
+                {
+                    var tex = LoadTextureFromNode(node);
+                    switch (tex)
+                    {
+                        case Texture2D tex2d:
+                            inlineTexturePreview = tex2d;
+                            inlineTextureId = ImGuiHelper.RegisterTexture(tex2d);
+                            break;
+                        case TextureCube cube:
+                            inlineCubePreview = cube;
+                            break;
+                    }
+                }
+                catch
+                {
+                    inlineTextureNode = node;
+                }
+            }
+
+            if (inlineTexturePreview == null || inlineTextureId == null)
+                return;
+
+            ImGui.Spacing();
+            ImGui.Text("Texture Preview:");
+            var maxSize = Math.Min(256 * ImGuiHelper.Scale, ImGui.GetContentRegionAvail().X);
+            var scale = Math.Min(maxSize / inlineTexturePreview.Width, maxSize / inlineTexturePreview.Height);
+            scale = Math.Clamp(scale, 0.05f, 1f);
+            var size = new Vector2(inlineTexturePreview.Width, inlineTexturePreview.Height) * scale;
+            ImGui.Image(inlineTextureId.Value, size, new Vector2(0, 1), new Vector2(1, 0));
+            ImGui.TextDisabled($"{inlineTexturePreview.Width} x {inlineTexturePreview.Height} {inlineTexturePreview.Format}");
         }
 
         void ImportTexture()

--- a/src/LibreLancer.Data/GameData/Items/MissileEquip.cs
+++ b/src/LibreLancer.Data/GameData/Items/MissileEquip.cs
@@ -4,6 +4,6 @@ public class MissileEquip : Equipment
 {
     public required Data.Schema.Equipment.Munition Def;
     public required Data.Schema.Equipment.Motor? Motor;
-    public required Data.Schema.Equipment.Explosion Explosion;
+    public Data.Schema.Equipment.Explosion? Explosion;
     public ResolvedFx? ExplodeFx;
 }

--- a/src/LibreLancer.Data/GameItemDb.cs
+++ b/src/LibreLancer.Data/GameItemDb.cs
@@ -1005,6 +1005,16 @@ public class GameItemDb
             equip.Volume = val.Volume;
         }
 
+        void AddEquipment(Equipment equip)
+        {
+            if (Equipment.Contains(equip.Nickname))
+            {
+                FLLog.Warning("Equipment", $"Duplicate equipment nickname '{equip.Nickname}', replacing previous entry");
+            }
+
+            Equipment.Add(equip);
+        }
+
         //Process munitions first
         foreach (var mn in flData.Equipment.Munitions)
         {
@@ -1012,17 +1022,43 @@ public class GameItemDb
 
             if (!string.IsNullOrEmpty(mn.Motor))
             {
+                var motor = flData.Equipment.Motors.FirstOrDefault(x =>
+                    x.Nickname.Equals(mn.Motor, StringComparison.OrdinalIgnoreCase));
+                if (motor == null)
+                {
+                    FLLog.Warning(
+                        "Equipment",
+                        $"Munition '{mn.Nickname}' references missing motor '{mn.Motor}'");
+                }
+
+                Data.Schema.Equipment.Explosion? explosion = null;
+                if (!string.IsNullOrEmpty(mn.ExplosionArch))
+                {
+                    explosion = flData.Equipment.Explosions.FirstOrDefault(x =>
+                        x.Nickname.Equals(mn.ExplosionArch, StringComparison.OrdinalIgnoreCase));
+                    if (explosion == null)
+                    {
+                        FLLog.Warning(
+                            "Equipment",
+                            $"Munition '{mn.Nickname}' references missing explosion_arch '{mn.ExplosionArch}'");
+                    }
+                }
+                else
+                {
+                    FLLog.Warning(
+                        "Equipment",
+                        $"Munition '{mn.Nickname}' has motor '{mn.Motor}' but no explosion_arch");
+                }
+
                 var mequip = new MissileEquip()
                 {
                     Def = mn,
                     ModelFile = ResolveDrawable(mn.MaterialLibrary, mn.DaArchetype),
-                    Motor = flData.Equipment.Motors.First(x =>
-                        x.Nickname.Equals(mn.Motor, StringComparison.OrdinalIgnoreCase)),
-                    Explosion = flData.Equipment.Explosions.First(x =>
-                        x.Nickname.Equals(mn.ExplosionArch, StringComparison.OrdinalIgnoreCase))
+                    Motor = motor,
+                    Explosion = explosion
                 };
 
-                if (!string.IsNullOrEmpty(mequip.Explosion.Effect))
+                if (!string.IsNullOrEmpty(mequip.Explosion?.Effect))
                 {
                     mequip.ExplodeFx = Effects.Get(mequip.Explosion.Effect);
                 }
@@ -1042,7 +1078,7 @@ public class GameItemDb
             }
 
             SetCommonFields(equip, mn);
-            Equipment.Add(equip);
+            AddEquipment(equip);
         }
 
         // Then all equipment
@@ -1052,7 +1088,12 @@ public class GameItemDb
 
             if (val is Light l)
             {
-                lights.Add(val.Nickname, new LightInheritHelper(l));
+                if (lights.ContainsKey(val.Nickname))
+                {
+                    FLLog.Warning("Light", $"Duplicate light nickname '{val.Nickname}', replacing previous entry");
+                }
+
+                lights[val.Nickname] = new LightInheritHelper(l);
             }
             else if (val is InternalFx)
             {
@@ -1264,7 +1305,7 @@ public class GameItemDb
             }
 
             SetCommonFields(equip, val);
-            Equipment.Add(equip);
+            AddEquipment(equip);
         }
 
         //Resolve light inheritance
@@ -1284,7 +1325,7 @@ public class GameItemDb
             var eq = GetLight(lt);
             eq.Nickname = lt.Nickname;
             eq.CRC = FLHash.CreateID(eq.Nickname);
-            Equipment.Add(eq);
+            AddEquipment(eq);
         }
 
         // LootCrateEquipment references


### PR DESCRIPTION
# Description of Changes

In this PR, I expanded LancerEdit’s capabilities for working with `.3db` icons, textures, and materials, while also making modded game data loading significantly more tolerant of incomplete and duplicate configurations.

## Added

### `.3db` Icon Browser

A new tool has been added to the `Data` menu:

`Data -> 3DB Icon Browser`

It becomes available after loading game data through `Data -> Load`.

The browser scans configured `.3db` icon collections directly from the loaded game data VFS and allows users to quickly find the required resources without manually browsing directories.

Search is supported by:

- file name;
- path;
- collection name.

The browser also includes:

- filtering by individual collections;
- lazy thumbnail generation;
- loading progress display;
- full-size texture viewing;
- dynamic pagination, where the number of items per page is calculated from the current window size instead of using a fixed value.

The initial implementation includes two main groups of Freelancer navigation icons:

- `DATA\INTERFACE\NEURONET\NAVMAP\NEWNAVMAP\SPACEOBJECTS`
- `DATA\INTERFACE\NEURONET\NAVMAP\NEWNAVMAP`

These collections cover space object icons and icons used on base navigation maps.

<img width="455" height="488" alt="image" src="https://github.com/user-attachments/assets/f1895213-9382-43f9-b67f-1f53877683db" />
<img width="2942" height="1729" alt="image-1" src="https://github.com/user-attachments/assets/d2abb231-506d-48d4-a861-47ed029c2204" />
<img width="2950" height="1430" alt="image-2" src="https://github.com/user-attachments/assets/1fda9581-e273-4806-9330-e02ca73d672e" />

### Inline Texture Preview in UTF/3DB Tabs

Inline texture previews have been added to UTF/3DB tabs.

When a texture data node such as `MIP0` is selected, the image is now displayed directly in the selected node information panel.

The existing `Texture Viewer` action remains available and can still be used to open the texture separately at full size.

<img width="1979" height="817" alt="image-3" src="https://github.com/user-attachments/assets/9e12a5fd-2b36-410f-a0b5-dc4483286ae7" />

### Missing Material Diagnostics

Missing material diagnostics have been extended during model loading.

A missing material message can now include an additional `Hint` containing a recommended `material_library` entry.

When a model is opened, LancerEdit checks nearby `.mat` files located next to the model. If one of them contains a material with the required CRC, the editor suggests that file as a possible configuration fix.

The `Resources` tab can now:

- display these hints;
- filter results by the presence of a `Hint`;
- copy the prepared recommendation from the context menu.

This makes it easier to identify missing or incorrectly configured `material_library` entries in INI files.

## Changed

### Improved `UtfTab -> View Model`

The logic used to open models from UTF/CMP files has been reworked when a game data folder is already loaded in LancerEdit.

The editor now first attempts to determine whether the opened file belongs to one of the known game data objects:

- archetypes;
- ships;
- asteroids;
- dynamic asteroids;
- simple objects;
- equipment.

If a match is found, the model is opened through:

`ResolvedModel.LoadFile()`

using:

`OpenDataContext.Resources`

As a result, direct UTF/CMP viewing now uses the same `material_library` resolution path as regular object loading from game data.

This means that a model opened directly from a file can now correctly load materials referenced through INI configuration instead of being limited to resources found next to the model file itself.

If the file cannot be matched to the loaded game data, the previous behavior remains unchanged: the model is opened as a standalone file through the editor resource manager.

### Explicit `ResourceManager` Support in `ModelViewer`

`ModelViewer` can now receive an explicit `ResourceManager` instance.

This allows model tabs opened from loaded game data to use the resources from the current `OpenDataContext`, rather than relying only on resources inherited from the parent tab or the editor-wide resource manager.

This change is required for correct material and texture loading in models that depend on the loaded mod configuration.

### Improved Texture Detection in `.3db` Files

Previously, `.3db` icon previews expected the file to contain a direct `Texture library` node.

This node is no longer required.

If a texture cannot be found directly, the browser analyzes `Material library` entries, resolves the texture references used by those materials, and attempts to locate the corresponding resources.

The following map types are supported:

- diffuse;
- emissive;
- bump;
- normal;
- detail;
- metallic;
- roughness.

If a preview still cannot be generated, the error message now reports the specific unresolved texture name whenever possible.

This makes diagnostics considerably clearer, especially for `.3db` files where textures are referenced indirectly through materials.

### Improved Windows Build Reliability

A check for the default CMake installation directory has been added to `build.ps1`.

If CMake is already installed but the current shell has not yet received the updated `PATH`, the script automatically adds the default CMake path to the environment of the current process.

The following variable:

`DOTNET_PROCESSOR_COUNT`

is now set to `2` by default when it has not been explicitly configured by the user.

This reduces memory pressure during the first Windows build, especially during shader compilation, where running too many compiler processes in parallel could previously cause out-of-memory failures or unstable builds.

## Fixed

### Duplicate Equipment Nicknames

Game data loading no longer crashes when multiple equipment entries use the same `nickname`.

These cases are now logged as warnings.

When a conflict occurs, the later entry replaces the previously loaded one.

For modded game data, this behavior is more practical than throwing a strict exception because it allows loading to continue and follows the common configuration override pattern.

### Duplicate Light Nicknames

<img width="1770" height="1648" alt="image-4" src="https://github.com/user-attachments/assets/b332c695-d1d8-460b-882b-2ee300195999" />

The same handling has been added for light entries.

Duplicate light nicknames no longer cause equipment initialization to fail.

The editor logs a warning, and the later entry replaces the previously loaded one.

### Incomplete Munition References

A crash in `GameItemDb.InitEquipment()` has been fixed for munitions with missing or invalid references to:

- `motor`;
- `explosion_arch`.

Strict `First(...)` calls have been replaced with safe lookup attempts.

If a referenced object cannot be found, loading continues and the log includes:

- the nickname of the affected munition;
- the name of the missing reference.

In addition, the following property:

`MissileEquip.Explosion`

is now nullable.

This allows incomplete or incorrectly configured mods to continue loading without terminating the entire process, while still preserving enough information for further diagnostics.
