### PR TITLE
Mine asteroids explosion

### DIFF
--- a/src/LibreLancer.Data/GameData/Archetype.cs
+++ b/src/LibreLancer.Data/GameData/Archetype.cs
@@ -20,6 +20,7 @@ public class Archetype : IdentifiableItem
     public List<SeparablePart> SeparableParts = [];
     public float SolarRadius;
     public float Hitpoints;
+    public bool PhantomPhysics;
 
     public bool CanVisit => Type switch
     {

--- a/src/LibreLancer.Data/GameData/Asteroid.cs
+++ b/src/LibreLancer.Data/GameData/Asteroid.cs
@@ -3,4 +3,9 @@ namespace LibreLancer.Data.GameData;
 public class Asteroid : IdentifiableItem
 {
     public ResolvedModel? ModelFile;
+    public Explosion? MineExplosion;
+    public float MineDetectRadius;
+    public float MineExplosionOffset;
+    public float MineRechargeTime;
+    public bool PhantomPhysics;
 }

--- a/src/LibreLancer.Data/GameData/Explosion.cs
+++ b/src/LibreLancer.Data/GameData/Explosion.cs
@@ -3,4 +3,7 @@ namespace LibreLancer.Data.GameData;
 public class Explosion : IdentifiableItem
 {
     public ResolvedFx? Effect;
+    public float Radius;
+    public float HullDamage;
+    public float EnergyDamage;
 }

--- a/src/LibreLancer.Data/GameItemDb.cs
+++ b/src/LibreLancer.Data/GameItemDb.cs
@@ -897,7 +897,7 @@ public class GameItemDb
         var goodsTask = tasks.Begin(InitGoods, equipmentTask);
         var archetypesTask = tasks.Begin(InitArchetypes, loadoutsTask, debrisTask);
         var starsTask = tasks.Begin(InitStars);
-        var astsTask = tasks.Begin(InitAsteroids);
+        var astsTask = tasks.Begin(InitAsteroids, explosionTask);
         tasks.Begin(InitMarkets, baseTask, goodsTask, archetypesTask);
         tasks.Begin(InitNews, baseTask);
         tasks.Begin(() => InitSystems(tasks),
@@ -2201,10 +2201,15 @@ public class GameItemDb
 
         foreach (var orig in flData.Explosions.Explosions)
         {
-            var ex = new Explosion() { Nickname = orig.Nickname };
+            var ex = new Explosion
+            {
+                Nickname = orig.Nickname,
+                Effect = Effects.Get(orig.Effect),
+                Radius = orig.Radius,
+                HullDamage = orig.HullDamage,
+                EnergyDamage = orig.EnergyDamage
+            };
             ex.CRC = CrcTool.FLModelCrc(ex.Nickname);
-            ex.Effect = Effects.Get(orig.Effect);
-
             Explosions.Add(ex);
         }
     }
@@ -2316,8 +2321,17 @@ public class GameItemDb
             var asteroid = new Asteroid
             {
                 Nickname = ast.Nickname,
-                ModelFile = ResolveDrawable(ast.MaterialLibrary ?? "", ast.DaArchetype)
+                ModelFile = ResolveDrawable(ast.MaterialLibrary ?? "", ast.DaArchetype),
+                MineExplosion = ast.IsMine ? Explosions.Get(ast.ExplosionArch) : null,
+                MineDetectRadius = ast.DetectRadius,
+                MineExplosionOffset = ast.ExplosionOffset,
+                MineRechargeTime = ast.RechargeTime,
+                PhantomPhysics = ast.PhantomPhysics
             };
+            if (ast.IsMine && asteroid.MineExplosion == null)
+            {
+                FLLog.Error("Asteroids", $"Explosion arch '{ast.ExplosionArch}' not found for mine '{ast.Nickname}'");
+            }
             asteroid.CRC = CrcTool.FLModelCrc(asteroid.Nickname);
             Asteroids.Add(asteroid);
         }
@@ -2434,7 +2448,8 @@ public class GameItemDb
                 Type = arch.Type,
                 Loadout = GetLoadout(arch.LoadoutName),
                 NavmapIcon = arch.ShapeName,
-                SolarRadius = arch.SolarRadius ?? 0
+                SolarRadius = arch.SolarRadius ?? 0,
+                PhantomPhysics = arch.PhantomPhysics ?? false
             };
 
             foreach (var dockSphere in arch.DockingSpheres)

--- a/src/LibreLancer.Data/Schema/Archetype.cs
+++ b/src/LibreLancer.Data/Schema/Archetype.cs
@@ -39,7 +39,6 @@ public partial class Archetype
     public bool Destructible;
     [Entry("type")]
     public ArchetypeType Type;
-    //TODO: I don't know what this is or what it does
     [Entry("phantom_physics")]
     public bool? PhantomPhysics;
     [Entry("loadout")]

--- a/src/LibreLancer.Data/Schema/Effects/Explosion.cs
+++ b/src/LibreLancer.Data/Schema/Effects/Explosion.cs
@@ -10,6 +10,9 @@ public partial class Explosion
     [Entry("nickname", Required = true)] public string Nickname = null!;
     [Entry("lifetime")] public Vector2 Lifetime;
     [Entry("process")] public string? Process;
+    [Entry("radius")] public float Radius;
+    [Entry("hull_damage")] public float HullDamage;
+    [Entry("energy_damage")] public float EnergyDamage;
     [Entry("num_child_pieces")] public int NumChildPieces;
     [Entry("debris_impulse")] public float DebrisImpulse;
     [Entry("innards_debris_start_time")] public float InnardsDebrisStartTime;

--- a/src/LibreLancer.Data/Schema/Solar/Asteroid.cs
+++ b/src/LibreLancer.Data/Schema/Solar/Asteroid.cs
@@ -24,6 +24,8 @@ public partial class Asteroid
     public int ExplosionOffset;
     [Entry("recharge_time")]
     public float RechargeTime;
+    [Entry("phantom_physics")]
+    public bool PhantomPhysics;
 
     public bool IsMine;
 }

--- a/src/LibreLancer/World/Components/AsteroidFieldComponent.cs
+++ b/src/LibreLancer/World/Components/AsteroidFieldComponent.cs
@@ -22,8 +22,7 @@ namespace LibreLancer.World.Components
         public AsteroidField Field;
         private ConvexMeshCollider? shape;
         private readonly StaticAsteroid[] mines;
-        private readonly Dictionary<(Vector3 Cube, int Mine), double> mineRechargeTimes = new();
-        private double mineTime;
+        private readonly Dictionary<Vector3, float> mineRechargeTimes = new();
 
         public AsteroidFieldComponent(AsteroidField field, ResourceManager res, GameObject parent) : base(parent)
         {
@@ -181,10 +180,24 @@ namespace LibreLancer.World.Components
                 return;
             }
 
+            foreach (var key in mineRechargeTimes.Keys.ToArray())
+            {
+                var rechargeTime = mineRechargeTimes[key] - (float) time;
+                if (rechargeTime <= 0)
+                {
+                    mineRechargeTimes.Remove(key);
+                }
+                else
+                {
+                    mineRechargeTimes[key] = rechargeTime;
+                }
+            }
+
             var amountCubes = (int) Math.Floor((COLLIDE_DISTANCE / Field.CubeSize)) + 1;
 
             // Create series of bounding boxes, merging some as we go
             var fillBoxes = new QuickList<(BoundingBox Bb, Vector4i Dims)>(8, phys.BufferPool);
+            var mineQueries = new QuickList<SphereQuery>(8, phys.BufferPool);
 
             foreach (var pobj in phys.DynamicObjects)
             {
@@ -257,10 +270,10 @@ namespace LibreLancer.World.Components
                     RemoveStatic(ref oldList[i]);
                 }
 
-                mineRechargeTimes.Clear();
                 spawnedA.Count = 0;
                 spawnedB.Count = 0;
                 fillBoxes.Dispose(phys.BufferPool);
+                mineQueries.Dispose(phys.BufferPool);
                 return;
             }
 
@@ -298,6 +311,7 @@ namespace LibreLancer.World.Components
 
                     remove = false;
                     bodies.Add(oldList[i], world?.Physics?.BufferPool);
+                    AddMineQueries(ref mineQueries, oldList[i]);
                     var p = (oldList[i].Position - fillBoxes[j].Bb.Min) / Field.CubeSize;
                     present[Index(fillBoxes[j].Dims, (int) p.X, (int) p.Y, (int) p.Z)] = true;
                     break;
@@ -306,7 +320,6 @@ namespace LibreLancer.World.Components
                 if (remove)
                 {
                     RemoveStatic(ref oldList[i]);
-                    ClearMineRechargeTimes(oldList[i].Position);
                 }
             }
 
@@ -349,6 +362,7 @@ namespace LibreLancer.World.Components
                                 Position = center,
                                 Rotation = cubeRotation
                             }, phys.BufferPool);
+                            AddMineQueries(ref mineQueries, bodies[bodies.Count - 1]);
                             if (shape is { BepuChildCount: > 0 })
                             {
                                 phys.CreateUnmanagedStatic(ref bodies[bodies.Count - 1].Object, transform, shape);
@@ -360,75 +374,45 @@ namespace LibreLancer.World.Components
 
             if (mines.Length > 0)
             {
-                mineTime += time;
-                CheckMines(world, ref bodies);
+                phys.DynamicObjectSphereQuery(mineQueries);
+                CheckMines(world, mineQueries);
             }
             fillBoxes.Dispose(phys.BufferPool);
+            mineQueries.Dispose(phys.BufferPool);
         }
 
-        private void CheckMines(GameWorld world, ref QuickList<SpawnedCube> cubes)
-        {
-            for (var cubeIndex = 0; cubeIndex < cubes.Count; cubeIndex++)
-            {
-                var cube = cubes[cubeIndex];
-
-                for (var mineIndex = 0; mineIndex < mines.Length; mineIndex++)
-                {
-                    var archetype = mines[mineIndex].Archetype!;
-                    var explosion = archetype.MineExplosion!;
-                    var key = (cube.Position, mineIndex);
-                    if (mineRechargeTimes.TryGetValue(key, out var rechargeTime) && rechargeTime > mineTime)
-                    {
-                        continue;
-                    }
-
-                    var minePosition = cube.Position +
-                                       Vector3.Transform(mines[mineIndex].Position * Field.CubeSize, cube.Rotation);
-                    var trigger = GetMineTrigger(minePosition, archetype.MineDetectRadius);
-                    if (trigger == null)
-                    {
-                        continue;
-                    }
-
-                    var direction = trigger.Position - minePosition;
-                    if (direction.LengthSquared() > 0)
-                    {
-                        direction = Vector3.Normalize(direction);
-                    }
-
-                    world.SpawnTempFx(explosion.Effect,
-                        minePosition + (direction * archetype.MineExplosionOffset));
-                    DamageMineExplosion(world, explosion, minePosition);
-                    mineRechargeTimes[key] = mineTime + archetype.MineRechargeTime;
-                }
-            }
-        }
-
-        private void ClearMineRechargeTimes(Vector3 cubePosition)
+        private void AddMineQueries(ref QuickList<SphereQuery> queries, in SpawnedCube cube)
         {
             for (var mineIndex = 0; mineIndex < mines.Length; mineIndex++)
             {
-                mineRechargeTimes.Remove((cubePosition, mineIndex));
+                var mine = mines[mineIndex];
+                var archetype = mine.Archetype!;
+                var minePosition = cube.Position +
+                                   Vector3.Transform(mine.Position * Field.CubeSize, cube.Rotation);
+                queries.Add(new SphereQuery
+                {
+                    Position = minePosition,
+                    Radius = archetype.MineDetectRadius
+                }, phys!.BufferPool);
             }
         }
 
-        private PhysicsObject? GetMineTrigger(Vector3 minePosition, float detectRadius)
+        private void CheckMines(GameWorld world, QuickList<SphereQuery> queries)
         {
-            var detectRadiusSquared = detectRadius * detectRadius;
-            foreach (var pobj in phys!.DynamicObjects)
+            for (var i = 0; i < queries.Count; i++)
             {
-                if (pobj.Tag is not GameObject { Kind: GameObjectKind.Ship })
+                ref var query = ref queries[i];
+                if (!query.Touched || mineRechargeTimes.ContainsKey(query.Position))
                 {
                     continue;
                 }
 
-                if (Vector3.DistanceSquared(pobj.Position, minePosition) <= detectRadiusSquared)
-                {
-                    return pobj;
-                }
+                var archetype = mines[i % mines.Length].Archetype!;
+                var explosion = archetype.MineExplosion!;
+                world.SpawnTempFx(explosion.Effect, query.Position);
+                DamageMineExplosion(world, explosion, query.Position);
+                mineRechargeTimes[query.Position] = archetype.MineRechargeTime;
             }
-
-            return null;
         }
 
         private void DamageMineExplosion(GameWorld world, Explosion explosion, Vector3 minePosition)

--- a/src/LibreLancer/World/Components/AsteroidFieldComponent.cs
+++ b/src/LibreLancer/World/Components/AsteroidFieldComponent.cs
@@ -8,9 +8,11 @@ using System.IO;
 using System.Linq;
 using System.Numerics;
 using BepuUtilities.Collections;
+using LibreLancer.Data.GameData;
 using LibreLancer.Data.GameData.World;
 using LibreLancer.Physics;
 using LibreLancer.Resources;
+using LibreLancer.Server.Components;
 
 namespace LibreLancer.World.Components
 {
@@ -18,11 +20,17 @@ namespace LibreLancer.World.Components
     public class AsteroidFieldComponent : GameComponent
     {
         public AsteroidField Field;
-        private ConvexMeshCollider shape = null!;
+        private ConvexMeshCollider? shape;
+        private readonly StaticAsteroid[] mines;
+        private readonly Dictionary<(Vector3 Cube, int Mine), double> mineRechargeTimes = new();
+        private double mineTime;
 
         public AsteroidFieldComponent(AsteroidField field, ResourceManager res, GameObject parent) : base(parent)
         {
             Field = field;
+            mines = field.Cube?
+                .Where(x => x.Archetype is { MineExplosion: not null, MineDetectRadius: > 0 })
+                .ToArray() ?? [];
 
             var rdist = 0f;
 
@@ -58,17 +66,22 @@ namespace LibreLancer.World.Components
             }
 
             phys = world.Physics;
-            shape = new ConvexMeshCollider(phys);
             var resourceManager = GetResourceManager(world);
 
             if (Field.Cube is not null && resourceManager is not null)
             {
                 foreach (var asteroid in Field.Cube)
                 {
+                    if (asteroid.Archetype?.PhantomPhysics == true)
+                    {
+                        continue;
+                    }
+
                     var sur = asteroid.Archetype?.ModelFile?.LoadFile(resourceManager, MeshLoadMode.CPU)!.Collision;
 
                     if (sur is not null && sur.Value.Valid)
                     {
+                        shape ??= new ConvexMeshCollider(phys);
                         shape.AddPart(sur.Value.FileId, new ConvexMeshId(0, 0),
                             new Transform3D(asteroid.Position * Field.CubeSize, asteroid.Rotation), null);
                     }
@@ -91,14 +104,15 @@ namespace LibreLancer.World.Components
                 return;
             }
 
-            shape?.Dispose();
-
             var oldList = useA ? ref spawnedA : ref spawnedB;
             for (var i = 0; i < oldList.Count; i++)
             {
-                phys.RemoveUnmanagedStatic(ref oldList[i].Object);
+                RemoveStatic(ref oldList[i]);
             }
 
+            shape?.Dispose();
+            shape = null;
+            mineRechargeTimes.Clear();
             spawnedA.Dispose(phys.BufferPool);
             spawnedB.Dispose(phys.BufferPool);
 
@@ -110,7 +124,16 @@ namespace LibreLancer.World.Components
         private struct SpawnedCube
         {
             public Vector3 Position;
+            public Quaternion Rotation;
             public UnmanagedStatic Object;
+        }
+
+        private void RemoveStatic(ref SpawnedCube cube)
+        {
+            if (cube.Object.Valid)
+            {
+                phys!.RemoveUnmanagedStatic(ref cube.Object);
+            }
         }
 
         private QuickList<SpawnedCube> spawnedA;
@@ -231,9 +254,10 @@ namespace LibreLancer.World.Components
             {
                 for (var i = 0; i < oldList.Count; i++)
                 {
-                    phys.RemoveUnmanagedStatic(ref oldList[i].Object);
+                    RemoveStatic(ref oldList[i]);
                 }
 
+                mineRechargeTimes.Clear();
                 spawnedA.Count = 0;
                 spawnedB.Count = 0;
                 fillBoxes.Dispose(phys.BufferPool);
@@ -281,7 +305,8 @@ namespace LibreLancer.World.Components
 
                 if (remove)
                 {
-                    world?.Physics?.RemoveUnmanagedStatic(ref oldList[i].Object);
+                    RemoveStatic(ref oldList[i]);
+                    ClearMineRechargeTimes(oldList[i].Position);
                 }
             }
 
@@ -317,15 +342,110 @@ namespace LibreLancer.World.Components
                                 continue;
                             }
 
-                            var transform = new Transform3D(center, Field.CubeRotation!.GetRotation(tval));
-                            bodies.Add(new SpawnedCube() { Position = center }, world?.Physics?.BufferPool);
-                            world?.Physics?.CreateUnmanagedStatic(ref bodies[bodies.Count - 1].Object, transform, shape);
+                            var cubeRotation = Field.CubeRotation!.GetRotation(tval);
+                            var transform = new Transform3D(center, cubeRotation);
+                            bodies.Add(new SpawnedCube()
+                            {
+                                Position = center,
+                                Rotation = cubeRotation
+                            }, phys.BufferPool);
+                            if (shape is { BepuChildCount: > 0 })
+                            {
+                                phys.CreateUnmanagedStatic(ref bodies[bodies.Count - 1].Object, transform, shape);
+                            }
                         }
                     }
                 }
             }
 
+            if (mines.Length > 0)
+            {
+                mineTime += time;
+                CheckMines(world, ref bodies);
+            }
             fillBoxes.Dispose(phys.BufferPool);
+        }
+
+        private void CheckMines(GameWorld world, ref QuickList<SpawnedCube> cubes)
+        {
+            for (var cubeIndex = 0; cubeIndex < cubes.Count; cubeIndex++)
+            {
+                var cube = cubes[cubeIndex];
+
+                for (var mineIndex = 0; mineIndex < mines.Length; mineIndex++)
+                {
+                    var archetype = mines[mineIndex].Archetype!;
+                    var explosion = archetype.MineExplosion!;
+                    var key = (cube.Position, mineIndex);
+                    if (mineRechargeTimes.TryGetValue(key, out var rechargeTime) && rechargeTime > mineTime)
+                    {
+                        continue;
+                    }
+
+                    var minePosition = cube.Position +
+                                       Vector3.Transform(mines[mineIndex].Position * Field.CubeSize, cube.Rotation);
+                    var trigger = GetMineTrigger(minePosition, archetype.MineDetectRadius);
+                    if (trigger == null)
+                    {
+                        continue;
+                    }
+
+                    var direction = trigger.Position - minePosition;
+                    if (direction.LengthSquared() > 0)
+                    {
+                        direction = Vector3.Normalize(direction);
+                    }
+
+                    world.SpawnTempFx(explosion.Effect,
+                        minePosition + (direction * archetype.MineExplosionOffset));
+                    DamageMineExplosion(world, explosion, minePosition);
+                    mineRechargeTimes[key] = mineTime + archetype.MineRechargeTime;
+                }
+            }
+        }
+
+        private void ClearMineRechargeTimes(Vector3 cubePosition)
+        {
+            for (var mineIndex = 0; mineIndex < mines.Length; mineIndex++)
+            {
+                mineRechargeTimes.Remove((cubePosition, mineIndex));
+            }
+        }
+
+        private PhysicsObject? GetMineTrigger(Vector3 minePosition, float detectRadius)
+        {
+            var detectRadiusSquared = detectRadius * detectRadius;
+            foreach (var pobj in phys!.DynamicObjects)
+            {
+                if (pobj.Tag is not GameObject { Kind: GameObjectKind.Ship })
+                {
+                    continue;
+                }
+
+                if (Vector3.DistanceSquared(pobj.Position, minePosition) <= detectRadiusSquared)
+                {
+                    return pobj;
+                }
+            }
+
+            return null;
+        }
+
+        private void DamageMineExplosion(GameWorld world, Explosion explosion, Vector3 minePosition)
+        {
+            if (world.Server == null)
+            {
+                return;
+            }
+
+            foreach (var other in phys!.SphereTest(minePosition, explosion.Radius))
+            {
+                if (other?.Tag is GameObject g && g.TryGetComponent<SHealthComponent>(out var health))
+                {
+                    health.DamageExplosion(explosion.HullDamage, explosion.EnergyDamage, null, minePosition,
+                        explosion.Radius);
+                }
+            }
         }
     }
 }

--- a/src/LibreLancer/World/Components/PhysicsComponent.cs
+++ b/src/LibreLancer/World/Components/PhysicsComponent.cs
@@ -197,6 +197,7 @@ namespace LibreLancer.World.Components
 
             Body = Mass < float.Epsilon ? world.Physics!.AddStaticObject(Parent!.WorldTransform, cld) : world.Physics!.AddDynamicObject(Mass, Parent!.WorldTransform, cld, Inertia);
             Body.Tag = Parent;
+            Body.Collidable = Collidable;
             collider = cld;
         }
 

--- a/src/LibreLancer/World/GameObject.cs
+++ b/src/LibreLancer/World/GameObject.cs
@@ -394,6 +394,11 @@ namespace LibreLancer.World
             {
                 InitWithModel(arch.ModelFile?.LoadFile(res, flags), arch.SeparableParts, res, draw, phys);
             }
+
+            if (arch.PhantomPhysics && PhysicsComponent != null)
+            {
+                PhysicsComponent.Collidable = false;
+            }
         }
 
         public GameObject()


### PR DESCRIPTION
- Mines now trigger when player or NPC ships enter detect_radius.
-- Explosion effects are positioned from the mine towards the triggering ship using explosion_offset, while damage remains centered on the mine.
-- Mines use radius, hull_damage from their explosion_arch.
-- Mines recharge using recharge_time and explode again if a ship remains nearby.

- Implemented phantom_physics for solar archetypes, jumpholes and other phantom solars no longer collide with ships, as in vanilla.