### PR TITLE
Add Voice, Stars, and Vignette Data Browsers

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -60,6 +60,20 @@ $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 $env:DOTNET_CLI_TELEMETRY_OPTOUT=1
 $env:DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=2
 
+# Windows fresh setups often have CMake installed, but the current shell has not
+# picked up PATH changes yet. Make the standard install location visible here.
+$DefaultCMakePath = Join-Path ([Environment]::GetFolderPath("ProgramFiles")) "CMake\bin"
+if ((Get-Command cmake -ErrorAction SilentlyContinue) -eq $null -and (Test-Path (Join-Path $DefaultCMakePath "cmake.exe"))) {
+    $env:Path = "$DefaultCMakePath;$env:Path"
+}
+
+# LLShaderCompiler compiles many shader permutations in parallel. On some Windows
+# machines that can leave 9-byte/corrupt shader bundles after an out-of-memory
+# failure. Keep the default conservative unless the caller already chose a value.
+if ([string]::IsNullOrWhiteSpace($env:DOTNET_PROCESSOR_COUNT)) {
+    $env:DOTNET_PROCESSOR_COUNT = "2"
+}
+
 # Get .NET Core CLI path if installed.
 $SDKResult = "notfound";
 if (Get-Command dotnet -ErrorAction SilentlyContinue) {

--- a/src/Editor/LancerEdit/GameContent/Popups/SunImmediateRenderer.cs
+++ b/src/Editor/LancerEdit/GameContent/Popups/SunImmediateRenderer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Numerics;
 using LibreLancer;
+using LibreLancer.Data;
 using LibreLancer.Data.GameData.Archetypes;
 using LibreLancer.Graphics;
 using LibreLancer.Graphics.Vertices;
@@ -17,6 +18,7 @@ public class SunImmediateRenderer : IDisposable
     private SunSpineMaterial spineMaterial;
     private SunRadialMaterial centerMaterial;
     private SunRadialMaterial glowMaterial;
+    private readonly ResourceManager resources;
 
     VertexBillboardColor2[] vertices;
     private VertexBuffer vertexBuffer;
@@ -26,6 +28,7 @@ public class SunImmediateRenderer : IDisposable
 
     public SunImmediateRenderer(ResourceManager resources)
     {
+        this.resources = resources;
         vtype = new VertexBillboardColor2();
         spineMaterial = new SunSpineMaterial(resources, null, Vector2.One);
 
@@ -71,7 +74,30 @@ public class SunImmediateRenderer : IDisposable
         }
     }
 
-    public unsafe void Render(Sun sun, Color4 background, RenderContext render, Rectangle? viewport)
+    private TextureShape? ResolveShape(string? name)
+    {
+        if (!string.IsNullOrEmpty(name) &&
+            resources.TryGetShape(name, out var shape) &&
+            shape.HasValue)
+        {
+            return shape.Value;
+        }
+        return null;
+    }
+
+    public unsafe void Render(Sun sun, Color4 background, RenderContext render, Rectangle? viewport) =>
+        Render(sun, background, render, viewport, 1f);
+
+    public unsafe void Render(Sun sun, Color4 background, RenderContext render, Rectangle? viewport, float zoom)
+        => Render(sun, background, render, viewport, zoom, 0);
+
+    public unsafe void Render(Sun sun, Color4 background, RenderContext render, Rectangle? viewport, float zoom, float angleOffset)
+        => Render(sun, background, render, viewport, zoom, angleOffset, Vector2.Zero);
+
+    public unsafe void Render(Sun sun, Color4 background, RenderContext render, Rectangle? viewport, float zoom, float angleOffset, Vector2 screenOffset)
+        => Render(sun, background, render, viewport, zoom, angleOffset, screenOffset, true);
+
+    public unsafe void Render(Sun sun, Color4 background, RenderContext render, Rectangle? viewport, float zoom, float angleOffset, Vector2 screenOffset, bool fitFullBillboard)
     {
         if (viewport != null && render.ScissorEnabled && !viewport.Value.Intersects(render.ScissorRectangle))
         {
@@ -108,37 +134,50 @@ public class SunImmediateRenderer : IDisposable
 
         }
 
-        // Calculate size of sun
-        float renderSize = sun.Radius;
-        if (sun.SpinesSprite != null)
+        float renderSize = MathF.Max(1, sun.Radius);
+        if (fitFullBillboard)
         {
-            float rmax = sun.Radius;
-            if (renderSize * sun.SpinesScale > renderSize)
-                rmax = sun.Radius * sun.SpinesScale;
+            if (sun.GlowSprite != null)
+                renderSize = MathF.Max(renderSize, sun.Radius * MathF.Max(1, sun.GlowScale));
+            if (sun.CenterSprite != null)
+                renderSize = MathF.Max(renderSize, sun.Radius * MathF.Max(1, sun.CenterScale));
+        }
+        if (sun.SpinesSprite != null && sun.Spines is { Count: > 0 })
+        {
+            renderSize = MathF.Max(renderSize, sun.Radius * MathF.Max(1, sun.SpinesScale));
             foreach (var s in sun.Spines)
             {
-                var multMax = MathF.Max(s.WidthScale / s.LengthScale, s.LengthScale);
-                if (sun.Radius * sun.SpinesScale * multMax > rmax)
-                    rmax = sun.Radius * sun.SpinesScale * multMax;
+                var lengthScale = MathF.Max(0.001f, s.LengthScale);
+                var multMax = MathF.Max(s.WidthScale / lengthScale, lengthScale);
+                renderSize = MathF.Max(renderSize, sun.Radius * MathF.Max(1, sun.SpinesScale) * multMax);
             }
-
-            renderSize = rmax;
         }
 
         //camera
-        cam.Update(render.CurrentViewport.Width, render.CurrentViewport.Height, new Vector3(0, 0, -renderSize * 0.9f),
+        zoom = MathHelper.Clamp(zoom, 0.1f, 10f);
+        cam.Update(render.CurrentViewport.Width, render.CurrentViewport.Height, new Vector3(0, 0, -(renderSize * 0.9f) / zoom),
             Vector3.Zero);
         render.SetCamera(cam);
         render.Cull = false;
         render.DepthEnabled = false;
 
+        var sunPosition = new Vector3(
+            screenOffset.X * renderSize / zoom,
+            -screenOffset.Y * renderSize / zoom,
+            0);
         var count = SunRenderer.GetVertexCount(sun);
         EnsureCapacity(render, count);
-        SunRenderer.CreateVertices(vertices, Vector3.Zero, sun);
+        var centerShape = ResolveShape(sun.CenterSprite);
+        var glowShape = ResolveShape(sun.GlowSprite);
+        var spinesShape = ResolveShape(sun.SpinesSprite);
+        SunRenderer.CreateVertices(vertices, sunPosition, sun, angleOffset,
+            centerShape?.Dimensions,
+            glowShape?.Dimensions,
+            spinesShape?.Dimensions);
         vertexBuffer.SetData<VertexBillboardColor2>(vertices.AsSpan().Slice(0, count));
-        spineMaterial.Texture = sun.SpinesSprite;
-        centerMaterial.Texture = sun.CenterSprite;
-        glowMaterial.Texture = sun.GlowSprite;
+        spineMaterial.Texture = spinesShape?.Texture ?? sun.SpinesSprite;
+        centerMaterial.Texture = centerShape?.Texture ?? sun.CenterSprite;
+        glowMaterial.Texture = glowShape?.Texture ?? sun.GlowSprite;
         int idx = 0;
         if (sun.CenterSprite != null)
         {

--- a/src/Editor/LancerEdit/GameContent/StarViewerTab.cs
+++ b/src/Editor/LancerEdit/GameContent/StarViewerTab.cs
@@ -1,0 +1,296 @@
+using System;
+using System.Linq;
+using System.Numerics;
+using ImGuiNET;
+using LancerEdit.GameContent.Stars;
+using LibreLancer;
+using GameArchetype = LibreLancer.Data.GameData.Archetype;
+using LibreLancer.Data.GameData.Archetypes;
+using LibreLancer.ImUI;
+using LibreLancer.Data.Schema.Solar;
+
+namespace LancerEdit.GameContent;
+
+public class StarViewerTab : GameContentTab
+{
+    private readonly MainWindow win;
+    private readonly GameDataContext context;
+    private readonly StarPreviewRenderer renderer;
+    private readonly Sun sun;
+    private readonly StarPreviewState previewState;
+    private readonly GameArchetype[] sunArchetypes;
+    private int selectedArchetype;
+    private Vector3 background = new(0.008f, 0.011f, 0.022f);
+    private bool showBackdrop;
+    private bool showDebugLensFlare;
+
+    public StarViewerTab(MainWindow win, GameDataContext context, Sun sun)
+    {
+        this.win = win;
+        this.context = context;
+        this.sun = sun;
+        previewState = StarPreviewState.Get(context, sun);
+        renderer = new StarPreviewRenderer(context);
+        sunArchetypes = context.GameData.Items.Archetypes
+            .Where(x => x.Type == ArchetypeType.sun)
+            .OrderBy(x => x.Nickname)
+            .ToArray();
+        selectedArchetype = Math.Max(0, Array.FindIndex(sunArchetypes,
+            x => x.Nickname.Equals("sun_2000", StringComparison.OrdinalIgnoreCase)));
+        Title = $"Star Preview - {sun.Nickname}";
+    }
+
+    public override unsafe void Draw(double elapsed)
+    {
+        DrawToolbar();
+        ImGui.Separator();
+
+        var avail = ImGui.GetContentRegionAvail();
+        var sideWidth = Math.Clamp(avail.X * 0.28f, 260 * ImGuiHelper.Scale, 420 * ImGuiHelper.Scale);
+        ImGui.BeginChild("##starViewport", new Vector2(avail.X - sideWidth - ImGui.GetStyle().ItemSpacing.X, 0), ImGuiChildFlags.Borders);
+        DrawViewport();
+        ImGui.EndChild();
+
+        ImGui.SameLine();
+        ImGui.BeginChild("##starInfo", new Vector2(0, 0), ImGuiChildFlags.Borders);
+        DrawInfo();
+        ImGui.EndChild();
+    }
+
+    void DrawToolbar()
+    {
+        if (ImGui.Button("Reset Preview"))
+        {
+            previewState.Reset();
+        }
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(220 * ImGuiHelper.Scale);
+        ImGui.SliderFloat("Zoom", ref previewState.Zoom, 0.1f, 6f, "%.2f");
+        ImGui.SameLine();
+        DrawArchetypeCombo();
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(180 * ImGuiHelper.Scale);
+        ImGui.ColorEdit3("Background", ref background, ImGuiColorEditFlags.NoInputs);
+        ImGui.SameLine();
+        ImGui.Checkbox("Backdrop", ref showBackdrop);
+        ImGui.SameLine();
+        ImGui.Checkbox("Debug Lens Flare", ref showDebugLensFlare);
+    }
+
+    unsafe void DrawViewport()
+    {
+        var min = ImGui.GetCursorScreenPos();
+        var size = ImGui.GetContentRegionAvail();
+        size.X = MathF.Max(size.X, 64 * ImGuiHelper.Scale);
+        size.Y = MathF.Max(size.Y, 64 * ImGuiHelper.Scale);
+        ImGui.InvisibleButton("##starObjectView", size);
+        HandleViewportInput(size);
+
+        var max = min + size;
+        var rect = new Rectangle((int)min.X, (int)min.Y, (int)size.X, (int)size.Y);
+        var drawList = ImGui.GetWindowDrawList();
+        drawList.AddCallback((_, cmd) =>
+        {
+            win.RenderContext.PushScissor(ImGuiHelper.GetClipRect(cmd), false);
+            renderer.Render(sun, new Color4(background.X, background.Y, background.Z, 1f),
+                win.RenderContext, rect, previewState.Zoom, 0, previewState.ViewOffset);
+            win.RenderContext.PopScissor();
+        }, IntPtr.Zero);
+        if (showBackdrop)
+            DrawSpaceOverlay(drawList, min, max);
+        if (showDebugLensFlare)
+            DrawLensOverlay(drawList, min, max);
+        drawList.AddRect(min, max, ImGui.GetColorU32(ImGuiCol.Border));
+    }
+
+    void HandleViewportInput(Vector2 size)
+    {
+        if (!ImGui.IsItemHovered() && !ImGui.IsItemActive())
+            return;
+
+        var wheel = ImGui.GetIO().MouseWheel;
+        if (ImGui.IsItemHovered() && wheel != 0)
+        {
+            previewState.Zoom = Math.Clamp(previewState.Zoom * MathF.Pow(1.12f, wheel), 0.1f, 6f);
+            ImGuiHelper.AnimatingElement();
+        }
+
+        if (ImGui.IsMouseDragging(ImGuiMouseButton.Left, 1f))
+        {
+            var delta = ImGui.GetMouseDragDelta(ImGuiMouseButton.Left, 1f);
+            ImGui.ResetMouseDragDelta(ImGuiMouseButton.Left);
+            previewState.ViewOffset += new Vector2(delta.X / MathF.Max(1f, size.X), delta.Y / MathF.Max(1f, size.Y));
+            previewState.ViewOffset.X = Math.Clamp(previewState.ViewOffset.X, -0.45f, 0.45f);
+            previewState.ViewOffset.Y = Math.Clamp(previewState.ViewOffset.Y, -0.35f, 0.35f);
+            ImGuiHelper.AnimatingElement();
+        }
+    }
+
+    void DrawArchetypeCombo()
+    {
+        if (sunArchetypes.Length == 0)
+        {
+            ImGui.TextDisabled("Archetype: (none)");
+            return;
+        }
+
+        ImGui.SetNextItemWidth(180 * ImGuiHelper.Scale);
+        if (ImGui.BeginCombo("Archetype", sunArchetypes[selectedArchetype].Nickname))
+        {
+            for (var i = 0; i < sunArchetypes.Length; i++)
+            {
+                if (ImGui.Selectable(sunArchetypes[i].Nickname, i == selectedArchetype))
+                    selectedArchetype = i;
+            }
+            ImGui.EndCombo();
+        }
+    }
+
+    void DrawSpaceOverlay(ImDrawListPtr drawList, Vector2 min, Vector2 max)
+    {
+        var size = max - min;
+        var seed = sun.Nickname.GetHashCode();
+        for (var i = 0; i < 80; i++)
+        {
+            seed = unchecked(seed * 1664525 + 1013904223);
+            var x = ((seed >>> 8) & 0xFFFF) / 65535f;
+            seed = unchecked(seed * 1664525 + 1013904223);
+            var y = ((seed >>> 8) & 0xFFFF) / 65535f;
+            seed = unchecked(seed * 1664525 + 1013904223);
+            var alpha = 0.18f + (((seed >>> 8) & 0xFF) / 255f) * 0.42f;
+            var p = min + new Vector2(x * size.X, y * size.Y);
+            drawList.AddCircleFilled(p, 1.1f * ImGuiHelper.Scale, ImGui.GetColorU32(new Vector4(0.82f, 0.9f, 1f, alpha)));
+        }
+    }
+
+    void DrawLensOverlay(ImDrawListPtr drawList, Vector2 min, Vector2 max)
+    {
+        var source = context.GameData.Items.Ini.Stars?.Stars
+            .FirstOrDefault(x => x.Nickname.Equals(sun.Nickname, StringComparison.OrdinalIgnoreCase));
+        if (source == null)
+            return;
+
+        var size = max - min;
+        var center = (min + max) * 0.5f;
+        var starPos = center + new Vector2(previewState.ViewOffset.X * size.X, previewState.ViewOffset.Y * size.Y);
+        var unit = MathF.Min(size.X, size.Y);
+
+        if (!string.IsNullOrWhiteSpace(source.LensGlow))
+        {
+            var glow = context.GameData.Items.Ini.Stars.LensGlows
+                .FirstOrDefault(x => x.Nickname.Equals(source.LensGlow, StringComparison.OrdinalIgnoreCase));
+            if (glow != null)
+            {
+                var radius = unit * 0.06f * MathF.Max(1, glow.RadiusScale);
+                DrawSoftCircle(drawList, starPos, radius, glow.InnerColor, 0.16f, 6);
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(source.LensFlare))
+            return;
+
+        var flare = context.GameData.Items.Ini.Stars.LensFlares
+            .FirstOrDefault(x => x.Nickname.Equals(source.LensFlare, StringComparison.OrdinalIgnoreCase));
+        if (flare == null)
+            return;
+
+        var axis = center - starPos;
+        if (axis.LengthSquared() < 1f)
+            axis = new Vector2(unit * 0.18f, 0);
+
+        foreach (var bead in flare.Beads)
+        {
+            var p = starPos + axis * (1f + bead.A * 2.8f);
+            var radius = Math.Clamp(flare.MinRadius + (flare.MaxRadius - flare.MinRadius) * bead.B,
+                flare.MinRadius, flare.MaxRadius) * ImGuiHelper.Scale * 0.42f;
+            var color = new Color3f(bead.C, bead.D, bead.E);
+            DrawSoftCircle(drawList, p, radius, color, Math.Clamp(bead.F * 1.8f, 0.02f, 0.28f), 4);
+        }
+    }
+
+    static void DrawSoftCircle(ImDrawListPtr drawList, Vector2 center, float radius, Color3f color, float alpha, int rings)
+    {
+        for (var i = rings; i >= 1; i--)
+        {
+            var t = i / (float)rings;
+            var a = alpha * (1f - t * 0.72f);
+            drawList.AddCircleFilled(center, radius * t,
+                ImGui.GetColorU32(new Vector4(color.R, color.G, color.B, a)));
+        }
+    }
+
+    void DrawInfo()
+    {
+        ImGui.Text(sun.Nickname);
+        ImGui.TextDisabled("Freelancer sun billboard preview");
+        ImGui.Spacing();
+        DrawThumbnailReference();
+        ImGui.Spacing();
+
+        var source = context.GameData.Items.Ini.Stars?.Stars
+            .FirstOrDefault(x => x.Nickname.Equals(sun.Nickname, StringComparison.OrdinalIgnoreCase));
+        var archetype = sunArchetypes.Length > 0 ? sunArchetypes[selectedArchetype] : null;
+
+        if (!ImGui.BeginTable("##starInfoTable", 2, ImGuiTableFlags.SizingStretchProp | ImGuiTableFlags.RowBg))
+            return;
+
+        DetailRow("Object Archetype", archetype?.Nickname);
+        DetailRow("Preview Source", "stararch.ini billboard");
+        DetailRow("Archetype Type", archetype?.Type.ToString());
+        DetailRow("Solar Radius", archetype?.SolarRadius.ToString("0.####"));
+        DetailRow("Preview Zoom", $"{previewState.Zoom:0.##}x");
+        DetailRow("Radius", sun.Radius.ToString("0.####"));
+        DetailRow("Visual Radius", StarPreviewRenderer.GetVisualRadius(sun).ToString("0.####"));
+        DetailRow("Star Glow", source?.StarGlow);
+        DetailRow("Glow Texture", sun.GlowSprite);
+        DetailRow("Glow Scale", sun.GlowScale.ToString("0.####"));
+        DetailRow("Star Center", source?.StarCenter);
+        DetailRow("Center Texture", sun.CenterSprite);
+        DetailRow("Center Scale", sun.CenterScale.ToString("0.####"));
+        DetailRow("Spines", source?.Spines);
+        DetailRow("Spines Texture", sun.SpinesSprite);
+        DetailRow("Spines Scale", sun.SpinesScale.ToString("0.####"));
+        DetailRow("Spines Count", (sun.Spines?.Count ?? 0).ToString());
+        DetailRow("Lens Flare", source?.LensFlare);
+        DetailRow("Lens Glow", source?.LensGlow);
+
+        ImGui.EndTable();
+    }
+
+    unsafe void DrawThumbnailReference()
+    {
+        var size = new Vector2(128 * ImGuiHelper.Scale);
+        ImGui.TextDisabled($"Preview thumbnail ({StarPreviewRenderer.ThumbnailTextureSize} x {StarPreviewRenderer.ThumbnailTextureSize})");
+        var min = ImGui.GetCursorScreenPos();
+        ImGui.Dummy(size);
+        var drawList = ImGui.GetWindowDrawList();
+        var rect = new Rectangle(
+            (int)min.X,
+            (int)min.Y,
+            Math.Max(1, (int)size.X),
+            Math.Max(1, (int)size.Y));
+        drawList.AddCallback((_, cmd) =>
+        {
+            win.RenderContext.PushScissor(ImGuiHelper.GetClipRect(cmd), false);
+            renderer.Render(sun, new Color4(background.X, background.Y, background.Z, 1f),
+                win.RenderContext, rect, previewState.Zoom, 0, previewState.ViewOffset);
+            win.RenderContext.PopScissor();
+        }, IntPtr.Zero);
+        drawList.AddRect(min, min + size, ImGui.GetColorU32(ImGuiCol.Border));
+    }
+
+    static void DetailRow(string label, string value)
+    {
+        ImGui.TableNextRow();
+        ImGui.TableNextColumn();
+        ImGui.TextDisabled(label);
+        ImGui.TableNextColumn();
+        ImGui.TextWrapped(string.IsNullOrWhiteSpace(value) ? "(none)" : value);
+    }
+
+    public override void Dispose()
+    {
+        renderer.Dispose();
+        base.Dispose();
+    }
+}

--- a/src/Editor/LancerEdit/GameContent/Stars/StarPreviewRenderer.cs
+++ b/src/Editor/LancerEdit/GameContent/Stars/StarPreviewRenderer.cs
@@ -1,0 +1,69 @@
+using System;
+using LibreLancer;
+using LibreLancer.Data.GameData.Archetypes;
+using LibreLancer.Graphics;
+using LibreLancer.Render;
+
+namespace LancerEdit.GameContent.Stars;
+
+public sealed class StarPreviewRenderer : IDisposable
+{
+    public const float ThumbnailZoom = 1f;
+    public const int ThumbnailTextureSize = 128;
+    public const string ThumbnailSource = "Star Preview thumbnail";
+    public static readonly Color4 ThumbnailBackground = new(0.008f, 0.011f, 0.022f, 1f);
+    public const float PreviewZoom = 1f;
+    public static readonly Color4 PreviewBackground = new(0.008f, 0.011f, 0.022f, 1f);
+
+    private readonly Popups.SunImmediateRenderer renderer;
+
+    public StarPreviewRenderer(GameDataContext context)
+    {
+        StarResourceLoader.EnsureLoaded(context);
+        renderer = new Popups.SunImmediateRenderer(context.Resources);
+    }
+
+    public void Render(Sun sun, Color4 background, RenderContext renderContext, Rectangle viewport) =>
+        renderer.Render(sun, background, renderContext, viewport, ThumbnailZoom);
+
+    public void Render(Sun sun, Color4 background, RenderContext renderContext, Rectangle viewport, float zoom) =>
+        renderer.Render(sun, background, renderContext, viewport, zoom);
+
+    public void Render(Sun sun, Color4 background, RenderContext renderContext, Rectangle viewport, float zoom, float angleOffset) =>
+        renderer.Render(sun, background, renderContext, viewport, zoom, angleOffset);
+
+    public void Render(Sun sun, Color4 background, RenderContext renderContext, Rectangle viewport, float zoom, float angleOffset, System.Numerics.Vector2 screenOffset) =>
+        renderer.Render(sun, background, renderContext, viewport, zoom, angleOffset, screenOffset);
+
+    public Texture2D RenderTexture(Sun sun, Color4 background, RenderContext renderContext, int width, int height, float zoom = ThumbnailZoom)
+    {
+        var restore = renderContext.RenderTarget;
+        var target = new RenderTarget2D(renderContext, width, height);
+        renderContext.RenderTarget = target;
+        renderer.Render(sun, background, renderContext, new Rectangle(0, 0, width, height), zoom);
+        renderContext.RenderTarget = restore;
+        target.Dispose(true);
+        return target.Texture;
+    }
+
+    public static float GetVisualRadius(Sun sun)
+    {
+        var radius = MathF.Max(1, sun.Radius);
+        var visualRadius = radius;
+        if (!string.IsNullOrWhiteSpace(sun.GlowSprite))
+            visualRadius = MathF.Max(visualRadius, radius * MathF.Max(1, sun.GlowScale));
+        if (!string.IsNullOrWhiteSpace(sun.CenterSprite))
+            visualRadius = MathF.Max(visualRadius, radius * MathF.Max(1, sun.CenterScale));
+        if (!string.IsNullOrWhiteSpace(sun.SpinesSprite) && sun.Spines is { Count: > 0 })
+        {
+            foreach (var spine in sun.Spines)
+            {
+                var mult = MathF.Max(spine.WidthScale / MathF.Max(0.001f, spine.LengthScale), spine.LengthScale);
+                visualRadius = MathF.Max(visualRadius, radius * MathF.Max(1, sun.SpinesScale) * mult);
+            }
+        }
+        return visualRadius;
+    }
+
+    public void Dispose() => renderer.Dispose();
+}

--- a/src/Editor/LancerEdit/GameContent/Stars/StarPreviewState.cs
+++ b/src/Editor/LancerEdit/GameContent/Stars/StarPreviewState.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using LibreLancer;
+using LibreLancer.Data.GameData.Archetypes;
+
+namespace LancerEdit.GameContent.Stars;
+
+public sealed class StarPreviewState
+{
+    private static readonly ConditionalWeakTable<GameDataContext, Dictionary<string, StarPreviewState>> States = new();
+
+    public float Zoom = 1f;
+    public Vector2 ViewOffset = Vector2.Zero;
+
+    public static StarPreviewState Get(GameDataContext context, Sun sun)
+    {
+        var states = States.GetValue(context, _ => new Dictionary<string, StarPreviewState>(StringComparer.OrdinalIgnoreCase));
+        if (!states.TryGetValue(sun.Nickname, out var state))
+        {
+            state = new StarPreviewState();
+            states[sun.Nickname] = state;
+        }
+        return state;
+    }
+
+    public void Reset()
+    {
+        Zoom = 1f;
+        ViewOffset = Vector2.Zero;
+    }
+}

--- a/src/Editor/LancerEdit/GameContent/Stars/StarResourceLoader.cs
+++ b/src/Editor/LancerEdit/GameContent/Stars/StarResourceLoader.cs
@@ -1,0 +1,35 @@
+using LibreLancer.Data;
+using LibreLancer.Resources;
+using LibreLancer;
+
+namespace LancerEdit.GameContent.Stars;
+
+public static class StarResourceLoader
+{
+    public static void EnsureLoaded(GameDataContext context)
+    {
+        if (context.GameData.Items.Ini.Stars == null)
+            return;
+
+        foreach (var section in context.GameData.Items.Ini.Stars.TextureFiles)
+        {
+            foreach (var file in section.Files)
+                context.Resources.LoadResourceFile(context.GameData.Items.DataPath(file));
+
+            if (context.Resources is not GameResourceManager resourceManager)
+                continue;
+
+            foreach (var shape in section.Shapes)
+            {
+                if (string.IsNullOrWhiteSpace(shape) ||
+                    resourceManager.TryGetShape(shape, out _))
+                {
+                    continue;
+                }
+
+                resourceManager.AddShape(shape,
+                    new TextureShape(shape, shape, new RectangleF(0, 0, 1, 1)));
+            }
+        }
+    }
+}

--- a/src/Editor/LancerEdit/GameContent/Stars/StarThumbnailStore.cs
+++ b/src/Editor/LancerEdit/GameContent/Stars/StarThumbnailStore.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using ImGuiNET;
+using LibreLancer;
+using LibreLancer.Data.GameData.Archetypes;
+using LibreLancer.Graphics;
+using LibreLancer.ImUI;
+using LibreLancer.Render;
+
+namespace LancerEdit.GameContent.Stars;
+
+public static class StarThumbnailStore
+{
+    private static readonly ConditionalWeakTable<GameDataContext, Cache> Caches = new();
+
+    public static StarThumbnail Get(GameDataContext context, RenderContext renderContext, Sun sun)
+    {
+        var cache = Caches.GetValue(context, x => new Cache(x));
+        return cache.Get(renderContext, sun);
+    }
+
+    public static void Clear(GameDataContext context)
+    {
+        if (Caches.TryGetValue(context, out var cache))
+            cache.Clear();
+    }
+
+    private sealed class Cache
+    {
+        private static readonly string CacheVersion =
+            $"{StarPreviewRenderer.ThumbnailSource}:{StarPreviewRenderer.ThumbnailTextureSize}:v7";
+
+        private readonly StarPreviewRenderer renderer;
+        private readonly Dictionary<string, StarThumbnail> thumbnails = new(StringComparer.OrdinalIgnoreCase);
+
+        public Cache(GameDataContext context) => renderer = new StarPreviewRenderer(context);
+
+        public StarThumbnail Get(RenderContext renderContext, Sun sun)
+        {
+            var key = $"{CacheVersion}:{sun.Nickname}";
+            if (thumbnails.TryGetValue(key, out var thumbnail))
+                return thumbnail;
+
+            var texture = renderer.RenderTexture(
+                sun,
+                StarPreviewRenderer.ThumbnailBackground,
+                renderContext,
+                StarPreviewRenderer.ThumbnailTextureSize,
+                StarPreviewRenderer.ThumbnailTextureSize,
+                StarPreviewRenderer.ThumbnailZoom);
+            thumbnail = new StarThumbnail(texture, ImGuiHelper.RegisterTexture(texture));
+            thumbnails[key] = thumbnail;
+            return thumbnail;
+        }
+
+        public void Clear()
+        {
+            foreach (var thumbnail in thumbnails.Values)
+            {
+                ImGuiHelper.DeregisterTexture(thumbnail.Texture);
+                thumbnail.Texture.Dispose();
+            }
+            thumbnails.Clear();
+        }
+    }
+}
+
+public sealed record StarThumbnail(Texture2D Texture, ImTextureRef TextureId);

--- a/src/Editor/LancerEdit/GameContent/StarsBrowserTab.cs
+++ b/src/Editor/LancerEdit/GameContent/StarsBrowserTab.cs
@@ -1,0 +1,424 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using ImGuiNET;
+using LancerEdit.GameContent.Stars;
+using LibreLancer;
+using LibreLancer.Data.GameData.Archetypes;
+using LibreLancer.Data.GameData.World;
+using LibreLancer.ImUI;
+using LibreLancer.Data.Schema.Solar;
+
+namespace LancerEdit.GameContent;
+
+public class StarsBrowserTab : GameContentTab
+{
+    private readonly MainWindow win;
+    private readonly GameDataContext context;
+    private readonly StarPreviewRenderer previewRenderer;
+    private readonly Sun[] fullList;
+    private readonly Dictionary<string, StarUsage[]> usagesByStar;
+    private Sun[] displayList;
+    private Sun selected;
+    private string filterText = "";
+    private int usageFilter;
+    private bool usedFirst = true;
+
+    private static readonly string[] UsageModes =
+    [
+        "All",
+        "Used only",
+        "Unused only"
+    ];
+
+    public StarsBrowserTab(MainWindow win, GameDataContext context)
+    {
+        this.win = win;
+        this.context = context;
+        previewRenderer = new StarPreviewRenderer(context);
+        fullList = context.GameData.Items.Stars.OrderBy(x => x.Nickname).ToArray();
+        usagesByStar = BuildUsageLookup(context);
+        displayList = SortStars(fullList);
+        selected = displayList.FirstOrDefault();
+        Title = "Stars Browser";
+    }
+
+    public override unsafe void Draw(double elapsed)
+    {
+        DrawToolbar();
+        ImGui.Separator();
+
+        var avail = ImGui.GetContentRegionAvail();
+        var leftWidth = Math.Clamp(avail.X * 0.58f, 360 * ImGuiHelper.Scale, Math.Max(360 * ImGuiHelper.Scale, avail.X - 300 * ImGuiHelper.Scale));
+        ImGui.BeginChild("##starsList", new Vector2(leftWidth, 0), ImGuiChildFlags.Borders);
+        DrawGrid();
+        ImGui.EndChild();
+
+        ImGui.SameLine();
+        ImGui.BeginChild("##starDetails", new Vector2(0, 0), ImGuiChildFlags.Borders);
+        DrawSelected();
+        ImGui.EndChild();
+    }
+
+    void DrawToolbar()
+    {
+        ImGui.SetNextItemWidth(300 * ImGuiHelper.Scale);
+        if (ImGui.InputTextWithHint("##starSearch", "Search stars", ref filterText, 250))
+        {
+            ApplyFilter();
+        }
+        ImGui.SameLine();
+        ImGui.TextDisabled($"{displayList.Length} / {fullList.Length} stars");
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(120 * ImGuiHelper.Scale);
+        if (ImGui.Combo("Usage", ref usageFilter, UsageModes, UsageModes.Length))
+            ApplyFilter();
+        ImGui.SameLine();
+        if (ImGui.Checkbox("Used first", ref usedFirst))
+            ApplyFilter();
+        ImGui.SameLine();
+        if (ImGui.Button("Refresh previews"))
+        {
+            StarThumbnailStore.Clear(context);
+            ImGuiHelper.AnimatingElement();
+        }
+    }
+
+    void ApplyFilter()
+    {
+        IEnumerable<Sun> stars = fullList;
+
+        if (!string.IsNullOrWhiteSpace(filterText))
+            stars = stars.Where(x => x.Nickname.Contains(filterText, StringComparison.OrdinalIgnoreCase));
+
+        stars = usageFilter switch
+        {
+            1 => stars.Where(IsUsed),
+            2 => stars.Where(x => !IsUsed(x)),
+            _ => stars
+        };
+
+        displayList = SortStars(stars);
+
+        if (selected == null || !displayList.Contains(selected))
+            selected = displayList.FirstOrDefault();
+    }
+
+    unsafe void DrawGrid()
+    {
+        if (displayList.Length == 0)
+        {
+            ImGui.TextDisabled("No stars found");
+            return;
+        }
+
+        var availableWidth = ImGui.GetContentRegionAvail().X;
+        var desiredCellWidth = 150 * ImGuiHelper.Scale;
+        var columns = Math.Max(1, (int)(availableWidth / desiredCellWidth));
+        var cellWidth = MathF.Max(96 * ImGuiHelper.Scale, availableWidth / columns);
+        var thumb = MathF.Min(110 * ImGuiHelper.Scale, MathF.Max(72 * ImGuiHelper.Scale, cellWidth - 18 * ImGuiHelper.Scale));
+        if (!ImGui.BeginTable("##starsGrid", columns, ImGuiTableFlags.SizingStretchSame | ImGuiTableFlags.PadOuterX))
+            return;
+
+        var clipper = new ImGuiListClipper();
+        var rows = (displayList.Length + columns - 1) / columns;
+        clipper.Begin(rows);
+        while (clipper.Step())
+        {
+            for (int row = clipper.DisplayStart; row < clipper.DisplayEnd; row++)
+            {
+                ImGui.TableNextRow();
+                for (int col = 0; col < columns; col++)
+                {
+                    var index = row * columns + col;
+                    ImGui.TableNextColumn();
+                    if (index >= displayList.Length)
+                        continue;
+
+                    var sun = displayList[index];
+                    ImGui.PushID(sun.Nickname);
+                    if (SunButton(sun, new Vector2(thumb), sun == selected))
+                    {
+                        selected = sun;
+                        if (ImGui.IsMouseDoubleClicked(ImGuiMouseButton.Left))
+                            OpenViewer(sun);
+                    }
+
+                    var label = sun.Nickname;
+                    if (label.Length > 22)
+                        label = label.Substring(0, 19) + "...";
+                    ImGui.TextWrapped(label);
+                    ImGui.TextDisabled($"r {sun.Radius:0.##}");
+                    var usageCount = UsageCount(sun);
+                    ImGui.TextDisabled(usageCount > 0 ? $"used {usageCount}" : "unused");
+                    ImGui.PopID();
+                }
+            }
+        }
+        ImGui.EndTable();
+    }
+
+    unsafe bool SunButton(Sun sun, Vector2 size, bool isSelected)
+    {
+        var clicked = ImGui.InvisibleButton("##sun", size);
+        var hovered = ImGui.IsItemHovered();
+        var min = ImGui.GetItemRectMin();
+        var max = ImGui.GetItemRectMax();
+        var drawList = ImGui.GetWindowDrawList();
+        DrawCardPreview(sun, min, max, drawList);
+        var border = isSelected
+            ? ImGui.GetColorU32(ImGuiCol.ButtonActive)
+            : hovered
+                ? ImGui.GetColorU32(ImGuiCol.ButtonHovered)
+                : ImGui.GetColorU32(ImGuiCol.Border);
+        drawList.AddRect(min, max, border);
+
+        if (hovered)
+        {
+            ImGui.BeginTooltip();
+            ImGui.Text(sun.Nickname);
+            ImGui.Text($"Radius: {sun.Radius:0.##}");
+            ImGui.Text("Preview: stararch.ini billboard");
+            ImGui.EndTooltip();
+        }
+
+        return clicked;
+    }
+
+    unsafe void DrawCardPreview(Sun sun, Vector2 min, Vector2 max, ImDrawListPtr drawList)
+    {
+        var previewState = StarPreviewState.Get(context, sun);
+        var rect = new Rectangle(
+            (int)min.X,
+            (int)min.Y,
+            Math.Max(1, (int)(max.X - min.X)),
+            Math.Max(1, (int)(max.Y - min.Y)));
+        drawList.AddCallback((_, cmd) =>
+        {
+            win.RenderContext.PushScissor(ImGuiHelper.GetClipRect(cmd), false);
+            previewRenderer.Render(sun, StarPreviewRenderer.PreviewBackground, win.RenderContext,
+                rect, previewState.Zoom, 0, previewState.ViewOffset);
+            win.RenderContext.PopScissor();
+        }, IntPtr.Zero);
+    }
+
+    unsafe void DrawSelected()
+    {
+        if (selected == null)
+        {
+            ImGui.TextDisabled("No star selected");
+            return;
+        }
+
+        ImGui.Text(selected.Nickname);
+        ImGui.SameLine();
+        if (ImGui.Button("Open Preview"))
+            OpenViewer(selected);
+        ImGui.Spacing();
+
+        var previewSize = MathF.Min(260 * ImGuiHelper.Scale, MathF.Max(120 * ImGuiHelper.Scale, ImGui.GetContentRegionAvail().X * 0.42f));
+        ImGui.BeginGroup();
+        SunButton(selected, new Vector2(previewSize), true);
+        ImGui.EndGroup();
+
+        ImGui.SameLine();
+        ImGui.BeginGroup();
+
+        var source = context.GameData.Items.Ini.Stars?.Stars
+            .FirstOrDefault(x => x.Nickname.Equals(selected.Nickname, StringComparison.OrdinalIgnoreCase));
+
+        if (source != null)
+            DrawIniDetails(source);
+        else
+            ImGui.TextDisabled("Source stararch.ini entry not available");
+
+        DrawUsageDetails(selected);
+        ImGui.EndGroup();
+
+        DrawRuntimeDetails(selected);
+    }
+
+    void DrawIniDetails(Star source)
+    {
+        if (!ImGui.BeginTable("##starDetailsTable", 2, ImGuiTableFlags.SizingStretchProp | ImGuiTableFlags.RowBg))
+            return;
+
+        DetailRow("Nickname", source.Nickname);
+        DetailRow("Radius", source.Radius.ToString("0.####"));
+        DetailRow("Star Glow", source.StarGlow);
+        DetailRow("Star Center", source.StarCenter);
+        DetailRow("Spines", source.Spines);
+        DetailRow("Lens Flare", source.LensFlare);
+        DetailRow("Lens Glow", source.LensGlow);
+        DetailRow("Intensity Fade In", source.IntensityFadeIn.ToString());
+        DetailRow("Intensity Fade Out", source.IntensityFadeOut.ToString());
+        DetailRow("Zone Occlusion Fade In", source.ZoneOcclusionFadeIn?.ToString("0.####"));
+        DetailRow("Zone Occlusion Fade Out", source.ZoneOcclusionFadeOut?.ToString("0.####"));
+
+        ImGui.EndTable();
+    }
+
+    void DrawUsageDetails(Sun sun)
+    {
+        ImGui.Spacing();
+        ImGui.SeparatorText("Usage");
+
+        if (!usagesByStar.TryGetValue(sun.Nickname, out var usages) || usages.Length == 0)
+        {
+            ImGui.TextDisabled("Not used by any system object");
+            return;
+        }
+
+        ImGui.TextDisabled($"{usages.Length} object(s)");
+        var tableFlags = ImGuiTableFlags.SizingStretchProp | ImGuiTableFlags.RowBg;
+        var tableSize = Vector2.Zero;
+        if (usages.Length > 6)
+        {
+            tableFlags |= ImGuiTableFlags.ScrollY;
+            tableSize = new Vector2(0, 170 * ImGuiHelper.Scale);
+        }
+
+        if (!ImGui.BeginTable("##starUsageTable", 3, tableFlags, tableSize))
+            return;
+
+        ImGui.TableSetupColumn("System");
+        ImGui.TableSetupColumn("Object");
+        ImGui.TableSetupColumn("Archetype");
+        ImGui.TableHeadersRow();
+
+        foreach (var usage in usages)
+        {
+            ImGui.TableNextRow();
+            ImGui.TableNextColumn();
+            ImGui.TextWrapped(DisplayName(usage.SystemNickname, usage.SystemName));
+            ImGui.TableNextColumn();
+            ImGui.TextWrapped(DisplayName(usage.ObjectNickname, usage.ObjectName));
+            ImGui.TableNextColumn();
+            ImGui.TextWrapped(usage.ArchetypeNickname);
+        }
+
+        ImGui.EndTable();
+    }
+
+    void DrawRuntimeDetails(Sun sun)
+    {
+        ImGui.Spacing();
+        ImGui.SeparatorText("Rendered Layers");
+
+        if (!ImGui.BeginTable("##starRuntimeTable", 2, ImGuiTableFlags.SizingStretchProp | ImGuiTableFlags.RowBg))
+            return;
+
+        var usage = PrimaryUsage(sun);
+        DetailRow("Preview Source", "stararch.ini billboard");
+        DetailRow("Preview Object", usage != null ? DisplayName(usage.ObjectNickname, usage.ObjectName) : "(none)");
+        DetailRow("Visual Radius", StarPreviewRenderer.GetVisualRadius(sun).ToString("0.####"));
+        DetailRow("Glow Texture", sun.GlowSprite);
+        DetailRow("Glow Scale", sun.GlowScale.ToString("0.####"));
+        DetailRow("Glow Inner", FormatColor(sun.GlowColorInner));
+        DetailRow("Glow Outer", FormatColor(sun.GlowColorOuter));
+        DetailRow("Center Texture", sun.CenterSprite);
+        DetailRow("Center Scale", sun.CenterScale.ToString("0.####"));
+        DetailRow("Center Inner", FormatColor(sun.CenterColorInner));
+        DetailRow("Center Outer", FormatColor(sun.CenterColorOuter));
+        DetailRow("Spines Texture", sun.SpinesSprite);
+        DetailRow("Spines Scale", sun.SpinesScale.ToString("0.####"));
+        DetailRow("Spines Count", (sun.Spines?.Count ?? 0).ToString());
+
+        ImGui.EndTable();
+    }
+
+    static string FormatColor(Color3f color) =>
+        $"{color.R:0.###}, {color.G:0.###}, {color.B:0.###}";
+
+    Sun[] SortStars(IEnumerable<Sun> stars) =>
+        (usedFirst
+            ? stars.OrderByDescending(IsUsed).ThenBy(x => x.Nickname)
+            : stars.OrderBy(IsUsed).ThenBy(x => x.Nickname)).ToArray();
+
+    bool IsUsed(Sun sun) => UsageCount(sun) > 0;
+
+    int UsageCount(Sun sun) =>
+        usagesByStar.TryGetValue(sun.Nickname, out var usages) ? usages.Length : 0;
+
+    static Dictionary<string, StarUsage[]> BuildUsageLookup(GameDataContext context)
+    {
+        var usages = new Dictionary<string, List<StarUsage>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var system in context.GameData.Items.Systems)
+        {
+            foreach (var obj in system.Objects)
+            {
+                if (obj.Star == null)
+                    continue;
+
+                if (!usages.TryGetValue(obj.Star.Nickname, out var starUsages))
+                {
+                    starUsages = [];
+                    usages[obj.Star.Nickname] = starUsages;
+                }
+
+                starUsages.Add(new StarUsage(
+                    system.Nickname,
+                    ResolveName(context, system.IdsName),
+                    obj.Nickname,
+                    ResolveName(context, obj.IdsName),
+                    obj.Archetype?.Nickname ?? "(none)"));
+            }
+        }
+
+        return usages.ToDictionary(
+            x => x.Key,
+            x => x.Value
+                .OrderBy(u => u.SystemNickname)
+                .ThenBy(u => u.ObjectNickname)
+                .ToArray(),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    static string ResolveName(GameDataContext context, int idsName)
+    {
+        if (idsName == 0)
+            return "";
+        return context.GameData.GetString(idsName) ?? "";
+    }
+
+    static string DisplayName(string nickname, string name) =>
+        string.IsNullOrWhiteSpace(name) ? nickname : $"{name} ({nickname})";
+
+    void OpenViewer(Sun sun)
+    {
+        var title = $"Star Preview - {sun.Nickname}";
+        var existing = win.TabControl.Tabs.FirstOrDefault(x => x.Title == title);
+        if (existing != null)
+            win.TabControl.SetSelected(existing);
+        else
+            win.AddTab(new StarViewerTab(win, context, sun));
+    }
+
+    StarUsage PrimaryUsage(Sun sun) =>
+        usagesByStar.TryGetValue(sun.Nickname, out var usages)
+            ? usages.FirstOrDefault()
+            : null;
+
+    static void DetailRow(string label, string value)
+    {
+        ImGui.TableNextRow();
+        ImGui.TableNextColumn();
+        ImGui.TextDisabled(label);
+        ImGui.TableNextColumn();
+        ImGui.TextWrapped(string.IsNullOrWhiteSpace(value) ? "(none)" : value);
+    }
+
+    public override void Dispose()
+    {
+        previewRenderer.Dispose();
+        base.Dispose();
+    }
+
+    private sealed record StarUsage(
+        string SystemNickname,
+        string SystemName,
+        string ObjectNickname,
+        string ObjectName,
+        string ArchetypeNickname);
+}

--- a/src/Editor/LancerEdit/GameContent/VignetteNodes/VignetteGraphModel.cs
+++ b/src/Editor/LancerEdit/GameContent/VignetteNodes/VignetteGraphModel.cs
@@ -1,0 +1,473 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using LibreLancer.Data.Ini;
+
+namespace LancerEdit.GameContent.VignetteNodes;
+
+public enum VignetteNodeKind
+{
+    Data,
+    Decision,
+    Documentation,
+    Unknown
+}
+
+public enum VignetteDiagnosticSeverity
+{
+    Info,
+    Warning,
+    Error
+}
+
+public sealed record VignetteNodeProperty(string Name, string Value, int Line);
+
+public sealed record VignetteGraphEdge(int SourceNodeId, int TargetNodeId, string Relation, bool Broken);
+
+public sealed record VignetteDiagnostic(
+    VignetteDiagnosticSeverity Severity,
+    int? NodeId,
+    string Message);
+
+public sealed class VignetteGraphNode
+{
+    public required int Index { get; init; }
+    public required int Id { get; init; }
+    public required string SectionName { get; init; }
+    public required VignetteNodeKind Kind { get; init; }
+    public required int Line { get; init; }
+    public required IReadOnlyList<VignetteNodeProperty> Properties { get; init; }
+    public required IReadOnlyList<int> ChildIds { get; init; }
+    public required string RawIni { get; init; }
+    public List<VignetteGraphEdge> Incoming { get; } = [];
+    public List<VignetteGraphEdge> Outgoing { get; } = [];
+    public List<VignetteDiagnostic> Diagnostics { get; } = [];
+    public bool IsRoot { get; internal set; }
+    public bool IsTerminal { get; internal set; }
+    public bool IsUnreachable { get; internal set; }
+    public bool IsInCycle { get; internal set; }
+
+    public string DisplayName => $"#{Id} {Kind}";
+    public string Summary => Kind switch
+    {
+        VignetteNodeKind.Decision => FirstValue("nickname") ?? "decision",
+        VignetteNodeKind.Documentation => FirstValue("documentation") ?? "documentation",
+        VignetteNodeKind.Data => DataSummary(),
+        _ => SectionName
+    };
+
+    public string? FirstValue(string name) =>
+        Properties.FirstOrDefault(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase))?.Value;
+
+    public IReadOnlyList<string> Values(string name) =>
+        Properties
+            .Where(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+            .Select(x => x.Value)
+            .ToArray();
+
+    public IReadOnlyList<string> SemanticLines() =>
+        Kind switch
+        {
+            VignetteNodeKind.Data => DataSemanticLines().ToArray(),
+            VignetteNodeKind.Decision => DecisionSemanticLines().ToArray(),
+            VignetteNodeKind.Documentation => DocumentationSemanticLines().ToArray(),
+            _ => [SectionName]
+        };
+
+    string DataSummary()
+    {
+        var parts = DataSummaryParts().ToArray();
+        return parts.Length == 0 ? "data node" : string.Join(", ", parts);
+    }
+
+    IEnumerable<string> DataSummaryParts()
+    {
+        foreach (var offerText in Values("offer_text").Take(1))
+            yield return ShortTupleSummary("offer", offerText);
+        foreach (var objectiveText in Values("objective_text").Take(1))
+            yield return ShortTupleSummary("objective", objectiveText);
+        foreach (var commSequence in Values("comm_sequence").Take(1))
+            yield return ShortTupleSummary("comm", commSequence);
+        if (FirstValue("weight") is { } weight)
+            yield return $"weight {weight}";
+        if (FirstValue("difficulty") is { } difficulty)
+            yield return $"difficulty {difficulty}";
+        if (FirstValue("allowable_zone_types") is { } zone)
+            yield return $"zone {zone}";
+        if (FirstValue("offer_group") is { } offer)
+            yield return $"offer {offer}";
+        if (FirstValue("hostile_group") is { } hostile)
+            yield return $"hostile {hostile}";
+    }
+
+    IEnumerable<string> DataSemanticLines()
+    {
+        foreach (var value in Values("offer_text"))
+            yield return DescribeOfferText(value);
+        foreach (var value in Values("objective_text"))
+            yield return DescribeObjectiveText(value);
+        foreach (var value in Values("Reward_text"))
+            yield return DescribeTextTuple("reward_text", value);
+        foreach (var value in Values("Failure_text"))
+            yield return DescribeTextTuple("failure_text", value);
+        foreach (var value in Values("comm_sequence"))
+            yield return DescribeCommSequence(value);
+        if (FirstValue("difficulty") is { } difficulty)
+            yield return $"difficulty: {difficulty}";
+        if (FirstValue("weight") is { } weight)
+            yield return $"weight: {weight}";
+        if (FirstValue("offer_group") is { } offer)
+            yield return $"offer groups: {offer}";
+        if (FirstValue("hostile_group") is { } hostile)
+            yield return $"hostile groups: {hostile}";
+        if (FirstValue("allowable_zone_types") is { } zones)
+            yield return $"allowable zones: {zones}";
+        if (FirstValue("implemented") is { } implemented)
+            yield return $"implemented: {implemented}";
+    }
+
+    IEnumerable<string> DecisionSemanticLines()
+    {
+        if (FirstValue("nickname") is { } nickname)
+            yield return $"branch: {nickname}";
+        yield return ChildIds.Count switch
+        {
+            0 => "no child nodes",
+            1 => $"branch match -> {ChildIds[0]}",
+            2 => $"true/left: {ChildIds[0]}, false/right: {ChildIds[1]}",
+            _ => $"children: {string.Join(", ", ChildIds)}"
+        };
+    }
+
+    IEnumerable<string> DocumentationSemanticLines()
+    {
+        if (FirstValue("documentation") is { } documentation)
+            yield return $"documentation: {documentation}";
+        if (ChildIds.Count > 0)
+            yield return $"next: {string.Join(", ", ChildIds)}";
+    }
+
+    static string DescribeOfferText(string value)
+    {
+        var parts = SplitCsv(value);
+        if (parts.Length == 0)
+            return "offer_text: empty";
+        var mode = IsOfferMode(parts[0]) ? parts[0] : "inline";
+        var ids = parts.Where(IsInteger).ToArray();
+        var tokens = parts.Where(x => !IsInteger(x) && !IsOfferMode(x)).ToArray();
+        return JoinParts("offer_text", mode, ids, tokens);
+    }
+
+    static string DescribeObjectiveText(string value)
+    {
+        var parts = SplitCsv(value);
+        if (parts.Length == 0)
+            return "objective_text: empty";
+        var tokens = parts.Skip(2).Where(x => !string.IsNullOrWhiteSpace(x)).ToArray();
+        var ids = parts.Length > 1 && IsInteger(parts[1]) ? new[] { parts[1] } : [];
+        var head = parts.Length > 1 ? $"template {parts[0]}" : parts[0];
+        return JoinParts("objective_text", head, ids, tokens);
+    }
+
+    static string DescribeTextTuple(string field, string value)
+    {
+        var parts = SplitCsv(value);
+        if (parts.Length == 0)
+            return $"{field}: empty";
+        var ids = IsInteger(parts[0]) ? new[] { parts[0] } : [];
+        var tokens = parts.Skip(1).Where(x => !string.IsNullOrWhiteSpace(x)).ToArray();
+        return JoinParts(field, null, ids, tokens);
+    }
+
+    static string DescribeCommSequence(string value)
+    {
+        var parts = SplitCsv(value);
+        if (parts.Length < 7)
+            return $"comm_sequence: {value}";
+        var messages = parts.Skip(6).Where((_, i) => i % 2 == 0).Where(x => !string.IsNullOrWhiteSpace(x)).ToArray();
+        var text = $"comm_sequence: event {parts[0]}, receiver {parts[1]}, speaker {parts[5]}";
+        if (messages.Length > 0)
+            text += $", messages {string.Join(", ", messages)}";
+        return text;
+    }
+
+    static string JoinParts(string field, string? head, IReadOnlyList<string> ids, IReadOnlyList<string> tokens)
+    {
+        var result = new List<string>();
+        if (!string.IsNullOrWhiteSpace(head))
+            result.Add(head);
+        if (ids.Count > 0)
+            result.Add($"IDS_NAME {string.Join(", ", ids)}");
+        if (tokens.Count > 0)
+            result.Add($"tokens {string.Join(", ", tokens.Select(DescribeToken))}");
+        return result.Count == 0 ? $"{field}: empty" : $"{field}: {string.Join("; ", result)}";
+    }
+
+    static string DescribeToken(string token) =>
+        token.ToUpperInvariant() switch
+        {
+            "MISSION_DIFFICULTY" => $"{token} (mission difficulty placeholder)",
+            "REWARD_MONEY" => $"{token} (reward money placeholder)",
+            "OFFER_BASE" => $"{token} (offer base placeholder)",
+            "OFFER_GROUP" => $"{token} (offer faction placeholder)",
+            "HOSTILE_GROUP" => $"{token} (hostile faction placeholder)",
+            "TARGET_FULL_NAME" => $"{token} (target full name placeholder)",
+            "TARGET_ZONE" => $"{token} (target zone placeholder)",
+            "OTHER_SOLAR" => $"{token} (secondary solar placeholder)",
+            _ => token
+        };
+
+    static string ShortTupleSummary(string label, string value)
+    {
+        var parts = SplitCsv(value);
+        if (parts.Length == 0)
+            return label;
+        if (label.Equals("offer", StringComparison.OrdinalIgnoreCase))
+        {
+            var mode = IsOfferMode(parts[0]) ? parts[0] : "inline";
+            var ids = parts.FirstOrDefault(IsInteger);
+            return ids == null ? $"{label} {mode}" : $"{label} {mode} {ids}";
+        }
+        var first = parts.FirstOrDefault(x => !string.IsNullOrWhiteSpace(x));
+        return first == null ? label : $"{label} {first}";
+    }
+
+    static string[] SplitCsv(string value) =>
+        value.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+    static bool IsInteger(string value) =>
+        int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _);
+
+    static bool IsOfferMode(string value) =>
+        value.Equals("append", StringComparison.OrdinalIgnoreCase) ||
+        value.Equals("replace", StringComparison.OrdinalIgnoreCase) ||
+        value.Equals("singular", StringComparison.OrdinalIgnoreCase) ||
+        value.Equals("plural", StringComparison.OrdinalIgnoreCase);
+}
+
+public sealed class VignetteGraph
+{
+    public required IReadOnlyList<VignetteGraphNode> Nodes { get; init; }
+    public required IReadOnlyList<VignetteGraphEdge> Edges { get; init; }
+    public required IReadOnlyList<VignetteDiagnostic> Diagnostics { get; init; }
+    public required string SourcePath { get; init; }
+    public required string? BackingPath { get; init; }
+
+    public VignetteGraphNode? NodeById(int id) => Nodes.FirstOrDefault(x => x.Id == id);
+}
+
+public static class VignetteGraphAnalyzer
+{
+    private static readonly HashSet<string> KnownEntries = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "node_id",
+        "child_node",
+        "nickname",
+        "documentation",
+        "offer_group",
+        "hostile_group",
+        "difficulty",
+        "weight",
+        "allowable_zone_types",
+        "implemented",
+        "failure_text",
+        "reward_text",
+        "objective_text",
+        "offer_text",
+        "comm_sequence"
+    };
+
+    public static VignetteGraph FromSections(IEnumerable<Section> sections, string sourcePath, string? backingPath)
+    {
+        var nodes = sections
+            .Where(IsVignetteSection)
+            .Select(CreateNode)
+            .ToList();
+        var diagnostics = new List<VignetteDiagnostic>();
+        var byId = new Dictionary<int, VignetteGraphNode>();
+
+        foreach (var node in nodes)
+        {
+            if (byId.TryAdd(node.Id, node))
+                continue;
+            AddDiagnostic(diagnostics, node, VignetteDiagnosticSeverity.Error,
+                $"Duplicate node_id {node.Id}.");
+            AddDiagnostic(diagnostics, byId[node.Id], VignetteDiagnosticSeverity.Error,
+                $"Duplicate node_id {node.Id}.");
+        }
+
+        var edges = new List<VignetteGraphEdge>();
+        foreach (var node in nodes)
+        {
+            for (int i = 0; i < node.ChildIds.Count; i++)
+            {
+                var childId = node.ChildIds[i];
+                var edge = new VignetteGraphEdge(node.Id, childId, EdgeRelation(node, i), !byId.ContainsKey(childId));
+                edges.Add(edge);
+                node.Outgoing.Add(edge);
+                if (byId.TryGetValue(childId, out var child))
+                    child.Incoming.Add(edge);
+                else
+                    AddDiagnostic(diagnostics, node, VignetteDiagnosticSeverity.Error,
+                        $"Broken reference to node_id {childId}.");
+            }
+        }
+
+        foreach (var node in nodes)
+        {
+            node.IsRoot = node.Incoming.Count == 0;
+            node.IsTerminal = node.Outgoing.Count == 0;
+            foreach (var property in node.Properties)
+            {
+                if (!KnownEntries.Contains(property.Name))
+                    AddDiagnostic(diagnostics, node, VignetteDiagnosticSeverity.Info,
+                        $"Unknown property '{property.Name}' is preserved.");
+            }
+        }
+
+        var roots = nodes.Where(x => x.IsRoot).ToArray();
+        if (roots.Length == 0 && nodes.Count > 0)
+            diagnostics.Add(new(VignetteDiagnosticSeverity.Error, null, "No root node found."));
+        if (roots.Length > 1)
+            diagnostics.Add(new(VignetteDiagnosticSeverity.Warning, null, $"Multiple root candidates: {string.Join(", ", roots.Select(x => x.Id))}."));
+
+        MarkUnreachable(nodes, roots.FirstOrDefault(), byId, diagnostics);
+        MarkCycles(nodes, byId, diagnostics);
+
+        return new VignetteGraph
+        {
+            Nodes = nodes,
+            Edges = edges,
+            Diagnostics = diagnostics,
+            SourcePath = sourcePath,
+            BackingPath = backingPath
+        };
+    }
+
+    private static bool IsVignetteSection(Section section) =>
+        section.Name.Equals("DataNode", StringComparison.OrdinalIgnoreCase) ||
+        section.Name.Equals("DecisionNode", StringComparison.OrdinalIgnoreCase) ||
+        section.Name.Equals("DocumentationNode", StringComparison.OrdinalIgnoreCase);
+
+    private static VignetteGraphNode CreateNode(Section section, int index)
+    {
+        var properties = section.Select(e => new VignetteNodeProperty(e.Name, Values(e), e.Line)).ToArray();
+        var nodeId = ReadInt(section, "node_id") ?? index;
+        var children = section
+            .Where(e => e.Name.Equals("child_node", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(e => e.Where(v => int.TryParse(v.ToString(), out _)).Select(v => int.Parse(v.ToString())))
+            .ToArray();
+        var raw = new StringBuilder();
+        raw.AppendLine($"[{section.Name}]");
+        foreach (var entry in section)
+            raw.AppendLine(entry.ToString());
+        return new VignetteGraphNode
+        {
+            Index = index,
+            Id = nodeId,
+            SectionName = section.Name,
+            Kind = Kind(section.Name),
+            Line = section.Line,
+            Properties = properties,
+            ChildIds = children,
+            RawIni = raw.ToString().TrimEnd()
+        };
+    }
+
+    private static VignetteNodeKind Kind(string sectionName) =>
+        sectionName.Equals("DataNode", StringComparison.OrdinalIgnoreCase) ? VignetteNodeKind.Data :
+        sectionName.Equals("DecisionNode", StringComparison.OrdinalIgnoreCase) ? VignetteNodeKind.Decision :
+        sectionName.Equals("DocumentationNode", StringComparison.OrdinalIgnoreCase) ? VignetteNodeKind.Documentation :
+        VignetteNodeKind.Unknown;
+
+    private static string EdgeRelation(VignetteGraphNode node, int childIndex) =>
+        node.Kind switch
+        {
+            VignetteNodeKind.Decision when node.ChildIds.Count == 1 => "branch match",
+            VignetteNodeKind.Decision => childIndex == 0 ? "true/left" :
+                childIndex == 1 ? "false/right" : $"branch option {childIndex + 1}",
+            VignetteNodeKind.Documentation => childIndex == 0 ? "next after documentation" : $"next {childIndex + 1}",
+            VignetteNodeKind.Data => childIndex == 0 ? "next after data" : $"next {childIndex + 1}",
+            _ => childIndex == 0 ? "next" : $"next {childIndex + 1}"
+        };
+
+    private static int? ReadInt(Section section, string name)
+    {
+        var entry = section.FirstOrDefault(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+        if (entry is { Count: > 0 } && int.TryParse(entry[0].ToString(), out var value))
+            return value;
+        return null;
+    }
+
+    private static string Values(Entry entry) =>
+        entry.Count == 0 ? "" : string.Join(", ", entry.Select(x => x.ToString()));
+
+    private static void AddDiagnostic(List<VignetteDiagnostic> all, VignetteGraphNode node,
+        VignetteDiagnosticSeverity severity, string message)
+    {
+        var diagnostic = new VignetteDiagnostic(severity, node.Id, message);
+        all.Add(diagnostic);
+        node.Diagnostics.Add(diagnostic);
+    }
+
+    private static void MarkUnreachable(List<VignetteGraphNode> nodes, VignetteGraphNode? root,
+        Dictionary<int, VignetteGraphNode> byId, List<VignetteDiagnostic> diagnostics)
+    {
+        if (root == null)
+            return;
+        var reachable = new HashSet<int>();
+        var stack = new Stack<VignetteGraphNode>();
+        stack.Push(root);
+        while (stack.Count > 0)
+        {
+            var node = stack.Pop();
+            if (!reachable.Add(node.Id))
+                continue;
+            foreach (var edge in node.Outgoing)
+                if (byId.TryGetValue(edge.TargetNodeId, out var child))
+                    stack.Push(child);
+        }
+        foreach (var node in nodes.Where(x => !reachable.Contains(x.Id)))
+        {
+            node.IsUnreachable = true;
+            AddDiagnostic(diagnostics, node, VignetteDiagnosticSeverity.Warning, "Unreachable from primary root.");
+        }
+    }
+
+    private static void MarkCycles(List<VignetteGraphNode> nodes, Dictionary<int, VignetteGraphNode> byId,
+        List<VignetteDiagnostic> diagnostics)
+    {
+        var state = new Dictionary<int, int>();
+        var stack = new List<VignetteGraphNode>();
+        foreach (var node in nodes)
+            Visit(node);
+        return;
+
+        void Visit(VignetteGraphNode node)
+        {
+            if (state.GetValueOrDefault(node.Id) == 2)
+                return;
+            if (state.GetValueOrDefault(node.Id) == 1)
+            {
+                var idx = stack.FindIndex(x => x.Id == node.Id);
+                foreach (var cyc in stack.Skip(Math.Max(0, idx)))
+                {
+                    if (cyc.IsInCycle)
+                        continue;
+                    cyc.IsInCycle = true;
+                    AddDiagnostic(diagnostics, cyc, VignetteDiagnosticSeverity.Warning, "Cycle detected.");
+                }
+                return;
+            }
+            state[node.Id] = 1;
+            stack.Add(node);
+            foreach (var edge in node.Outgoing)
+                if (byId.TryGetValue(edge.TargetNodeId, out var child))
+                    Visit(child);
+            stack.RemoveAt(stack.Count - 1);
+            state[node.Id] = 2;
+        }
+    }
+}

--- a/src/Editor/LancerEdit/GameContent/VignetteNodesBrowserTab.cs
+++ b/src/Editor/LancerEdit/GameContent/VignetteNodesBrowserTab.cs
@@ -527,29 +527,38 @@ public sealed class VignetteNodesBrowserTab : GameContentTab
 
     private void DrawTreeHelp()
     {
-        if (!ImGui.CollapsingHeader($"{Icons.QuestionCircle} DSL help / Справка по DSL"))
+        if (!ImGui.CollapsingHeader($"{Icons.QuestionCircle} DSL help"))
             return;
 
-        ImGui.TextWrapped("RU: Это человекочитаемый вид vignetteparams.ini. Строки с # являются подсказками и игнорируются компилятором. Команды заканчиваются ;, поэтому ; не используется как комментарий.");
-        ImGui.TextWrapped("EN: This is a readable view of vignetteparams.ini. # lines are hints ignored by the compiler. Statements end with ;, so ; is not used as a comment marker.");
+        ImGui.TextWrapped("This is a readable view of vignetteparams.ini. # lines are hints ignored by the compiler. Statements end with ;, so ; is not used as a comment marker.");
         ImGui.Separator();
-        DrawTreeHelpLine("group name factions...;", "RU: именованный список фракций. EN: named faction list.");
-        DrawTreeHelpLine("doc Name;", "RU: DocumentationNode / логический раздел. EN: documentation node / logical section.");
-        DrawTreeHelpLine("if Condition / elif group(name) / else / end", "RU: DecisionNode и ветвления. EN: decision node and branching.");
-        DrawTreeHelpLine("sub node_123 ... end", "RU: переиспользуемая ветка, на которую есть несколько ссылок. EN: reusable branch referenced more than once.");
-        DrawTreeHelpLine("call node_123;", "RU: переход к sub-ветке. EN: jump/call into a sub branch.");
-        DrawTreeHelpLine("offer_group / hostile_group", "RU: фракции оффера и противники. EN: offer and hostile factions.");
-        DrawTreeHelpLine("offer_text / objective_text", "RU: IDS_NAME строки с токенами. EN: IDS_NAME text with tokens.");
-        DrawTreeHelpLine("comm_sequence", "RU: реплики/события коммуникаций. EN: comm event lines.");
-        DrawTreeHelpLine("noop;", "RU: пустая ветка, которой не было в исходном INI. EN: empty branch missing from the original INI.");
+        if (ImGui.BeginTable("##vignetteTreeHelpTable", 2,
+                ImGuiTableFlags.BordersInnerV | ImGuiTableFlags.RowBg | ImGuiTableFlags.Resizable))
+        {
+            ImGui.TableSetupColumn("Syntax", ImGuiTableColumnFlags.WidthStretch, 0.45f);
+            ImGui.TableSetupColumn("Meaning", ImGuiTableColumnFlags.WidthStretch, 1.0f);
+            ImGui.TableHeadersRow();
+            DrawTreeHelpLine("group name factions...;", "Named faction list reused by branch conditions and offer/hostile groups.");
+            DrawTreeHelpLine("doc Name;", "Creates a DocumentationNode / logical section.");
+            DrawTreeHelpLine("if Condition / elif group(name) / else / end", "Creates DecisionNode branching. group(name) expands to a faction-group condition.");
+            DrawTreeHelpLine("sub node_123 ... end", "Reusable branch body. The decompiler emits a sub when the same node is referenced more than once.");
+            DrawTreeHelpLine("call node_123;", "Jumps into a reusable sub branch.");
+            DrawTreeHelpLine("offer_group / hostile_group", "Defines offer factions and enemy factions for the current mission branch.");
+            DrawTreeHelpLine("offer_text / objective_text", "Adds IDS_NAME-backed mission text with runtime tokens.");
+            DrawTreeHelpLine("comm_sequence", "Adds communication event lines for mission radio/dialog messages.");
+            DrawTreeHelpLine("noop;", "Empty branch placeholder for an alternative that was missing in the original INI.");
+            ImGui.EndTable();
+        }
     }
 
     private static void DrawTreeHelpLine(string syntax, string description)
     {
+        ImGui.TableNextRow();
+        ImGui.TableNextColumn();
         ImGui.PushFont(ImGuiHelper.SystemMonospace, 0);
         ImGui.Text(syntax);
         ImGui.PopFont();
-        ImGui.SameLine(360 * ImGuiHelper.Scale);
+        ImGui.TableNextColumn();
         ImGui.TextWrapped(description);
     }
 

--- a/src/Editor/LancerEdit/GameContent/VignetteNodesBrowserTab.cs
+++ b/src/Editor/LancerEdit/GameContent/VignetteNodesBrowserTab.cs
@@ -1,0 +1,1591 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using ImGuiNET;
+using LancerEdit.GameContent.VignetteNodes;
+using LibreLancer;
+using LibreLancer.ContentEdit.RandomMissions;
+using LibreLancer.Data.Ini;
+using LibreLancer.Data.Schema.RandomMissions;
+using LibreLancer.ImUI;
+using LibreLancer.ImUI.NodeEditor;
+
+namespace LancerEdit.GameContent;
+
+public sealed class VignetteNodesBrowserTab : GameContentTab
+{
+    private readonly MainWindow win;
+    private readonly GameDataContext context;
+    private readonly string sourcePath;
+    private VignetteGraph graph;
+    private VignetteGraphNode? selected;
+    private VignetteGraphNode[] visibleNodes = [];
+    private readonly NodeEditorConfig graphConfig;
+    private readonly NodeEditorContext graphContext;
+    private readonly ColorTextEdit treeEditor;
+    private readonly Queue<(NodeId Id, Vector2 Pos)> graphPositions = [];
+    private bool graphNeedsLayout;
+    private bool graphNavigateToSelected;
+    private bool showIdsText = true;
+    private bool showFactionNames = true;
+    private bool showFlowHints = true;
+    private string search = "";
+    private string treeText = "";
+    private string[] treeLines = [];
+    private string treeCompileStatus = "";
+    private string treeSearch = "";
+    private string treeSearchStatus = "";
+    private int pendingTreeJumpLine = -1;
+    private int highlightedTreeLine = -1;
+    private string treeSenseSearch = "";
+    private int treeSearchIndex;
+    private int treeSenseFilter;
+    private int kindFilter;
+    private int stateFilter;
+
+    private static readonly string[] KindFilters =
+    [
+        "All",
+        "Data",
+        "Decision",
+        "Documentation",
+        "Unknown"
+    ];
+
+    private static readonly string[] StateFilters =
+    [
+        "All",
+        "Has outgoing links",
+        "Has incoming links",
+        "No incoming links",
+        "No outgoing links",
+        "Broken references",
+        "Unknown type",
+        "Unreachable"
+    ];
+
+    private static readonly string[] TreeSenseFilters =
+    [
+        "All",
+        "Syntax",
+        "Conditions",
+        "Groups",
+        "Factions",
+        "IDS_NAME",
+        "Nodes"
+    ];
+
+    public VignetteNodesBrowserTab(MainWindow win, GameDataContext context)
+    {
+        this.win = win;
+        this.context = context;
+        Title = "Vignette Nodes Browser";
+        graphConfig = new NodeEditorConfig { SettingsFile = null };
+        graphContext = new NodeEditorContext(graphConfig);
+        treeEditor = new ColorTextEdit();
+        treeEditor.SetMode(ColorTextEditMode.Lua);
+        treeEditor.SetReadOnly(true);
+        NodeBuilder.LoadTexture(win.RenderContext);
+        sourcePath = context.GameData.Items.Ini.Freelancer.DataPath + "randommissions\\vignetteparams.ini";
+        Reload();
+    }
+
+    public override void Draw(double elapsed)
+    {
+        DrawToolbar();
+        ImGui.Separator();
+        if (graph == null)
+            return;
+
+        var avail = ImGui.GetContentRegionAvail();
+        var leftWidth = Math.Clamp(avail.X * 0.30f, 260 * ImGuiHelper.Scale, 420 * ImGuiHelper.Scale);
+        ImGui.BeginChild("##vignetteNodeList", new Vector2(leftWidth, 0), ImGuiChildFlags.Borders);
+        DrawNodeList();
+        ImGui.EndChild();
+
+        ImGui.SameLine();
+        ImGui.BeginChild("##vignetteNodeDetails", new Vector2(0, 0), ImGuiChildFlags.Borders);
+        DrawDetails();
+        ImGui.EndChild();
+    }
+
+    private void DrawToolbar()
+    {
+        ImGui.Text("VignetteParams.ini");
+        ImGui.SameLine();
+        ImGui.TextDisabled(graph?.BackingPath ?? sourcePath);
+        ImGui.SameLine();
+        if (ImGui.Button($"{Icons.SyncAlt}##refreshVignetteNodes"))
+            Reload();
+        if (ImGui.IsItemHovered())
+            ImGui.SetTooltip("Reload from game data.");
+
+        ImGui.SetNextItemWidth(300 * ImGuiHelper.Scale);
+        if (ImGui.InputTextWithHint("##vignetteSearch", "Search nodes, properties, links, raw INI", ref search, 256))
+            RebuildVisibleNodes();
+        ImGui.SameLine();
+        if (ImGui.Button($"{Icons.X}##clearVignetteSearch", new Vector2(32 * ImGuiHelper.Scale, 0)))
+        {
+            search = "";
+            RebuildVisibleNodes();
+        }
+        if (ImGui.IsItemHovered())
+            ImGui.SetTooltip("Clear search.");
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(150 * ImGuiHelper.Scale);
+        if (ImGui.Combo("Type", ref kindFilter, KindFilters, KindFilters.Length))
+            RebuildVisibleNodes();
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(180 * ImGuiHelper.Scale);
+        if (ImGui.Combo("State", ref stateFilter, StateFilters, StateFilters.Length))
+            RebuildVisibleNodes();
+        ImGui.SameLine();
+        ImGui.TextDisabled($"{visibleNodes.Length}/{graph?.Nodes.Count ?? 0} nodes");
+        ImGui.SameLine();
+        ImGui.Checkbox("IDS text", ref showIdsText);
+        ImGui.SameLine();
+        ImGui.Checkbox("Faction names", ref showFactionNames);
+        ImGui.SameLine();
+        ImGui.Checkbox("Flow hints", ref showFlowHints);
+    }
+
+    private void Reload()
+    {
+        if (!context.GameData.VFS.FileExists(sourcePath))
+        {
+            win.Popups.MessageBox("Vignette Nodes Browser", $"{sourcePath} was not found in loaded game data.");
+            graph = new VignetteGraph
+            {
+                Nodes = [],
+                Edges = [],
+                Diagnostics = [new(VignetteDiagnosticSeverity.Error, null, "VignetteParams.ini was not found.")],
+                SourcePath = sourcePath,
+                BackingPath = null
+            };
+            selected = null;
+            treeText = "";
+            treeLines = [];
+            treeEditor.SetText(treeText);
+            graphNeedsLayout = true;
+            RebuildVisibleNodes();
+            return;
+        }
+
+        var sections = IniFile.ParseFile(sourcePath, context.GameData.VFS).ToArray();
+        graph = VignetteGraphAnalyzer.FromSections(sections, sourcePath, context.GameData.VFS.GetBackingFileName(sourcePath));
+        treeText = BuildTreeText();
+        treeLines = SplitTreeLines(treeText);
+        treeEditor.SetText(treeText);
+        selected = graph.Nodes.FirstOrDefault(x => x.IsRoot) ?? graph.Nodes.FirstOrDefault();
+        graphNeedsLayout = true;
+        graphNavigateToSelected = true;
+        RebuildVisibleNodes();
+    }
+
+    private void RebuildVisibleNodes()
+    {
+        IEnumerable<VignetteGraphNode> nodes = graph?.Nodes ?? [];
+        if (kindFilter > 0)
+        {
+            var kind = (VignetteNodeKind)(kindFilter - 1);
+            nodes = nodes.Where(x => x.Kind == kind);
+        }
+        nodes = stateFilter switch
+        {
+            1 => nodes.Where(x => x.Outgoing.Count > 0),
+            2 => nodes.Where(x => x.Incoming.Count > 0),
+            3 => nodes.Where(x => x.Incoming.Count == 0),
+            4 => nodes.Where(x => x.Outgoing.Count == 0),
+            5 => nodes.Where(x => x.Outgoing.Any(e => e.Broken)),
+            6 => nodes.Where(x => x.Kind == VignetteNodeKind.Unknown),
+            7 => nodes.Where(x => x.IsUnreachable),
+            _ => nodes
+        };
+        if (!string.IsNullOrWhiteSpace(search))
+            nodes = nodes.Where(MatchesSearch);
+        visibleNodes = nodes.OrderBy(x => x.Id).ToArray();
+        if (selected != null && !visibleNodes.Contains(selected))
+            selected = visibleNodes.FirstOrDefault();
+    }
+
+    private bool MatchesSearch(VignetteGraphNode node)
+    {
+        if (node.Id.ToString().Contains(search, StringComparison.OrdinalIgnoreCase) ||
+            node.Kind.ToString().Contains(search, StringComparison.OrdinalIgnoreCase) ||
+            node.SectionName.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+            node.RawIni.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+            node.Summary.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+            HumanSemanticLines(node).Any(x => x.Contains(search, StringComparison.OrdinalIgnoreCase)) ||
+            ResolvedTextLines(node).Any(x => x.Contains(search, StringComparison.OrdinalIgnoreCase)))
+            return true;
+        return node.Properties.Any(x =>
+                   x.Name.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                   x.Value.Contains(search, StringComparison.OrdinalIgnoreCase)) ||
+               node.Incoming.Concat(node.Outgoing).Any(x =>
+                   x.SourceNodeId.ToString().Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                   x.TargetNodeId.ToString().Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                   x.Relation.Contains(search, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private void DrawNodeList()
+    {
+        if (visibleNodes.Length == 0)
+        {
+            ImGui.TextDisabled("No nodes match the current filters.");
+            return;
+        }
+
+        var clipper = new ImGuiListClipper();
+        clipper.Begin(visibleNodes.Length);
+        while (clipper.Step())
+        {
+            for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
+            {
+                var node = visibleNodes[i];
+                var flags = StatusFlags(node);
+                if (ImGui.Selectable($"{node.DisplayName}  {flags}##vnode_{node.Id}_{i}", selected == node))
+                {
+                    selected = node;
+                    graphNavigateToSelected = true;
+                }
+                if (ImGui.IsItemHovered())
+                    ImGui.SetTooltip($"{node.Summary}\nLine {node.Line}");
+                ImGui.TextDisabled(node.Summary);
+            }
+        }
+        clipper.End();
+    }
+
+    private static string StatusFlags(VignetteGraphNode node)
+    {
+        var flags = new List<string>();
+        if (node.IsRoot)
+            flags.Add("root");
+        if (node.IsTerminal)
+            flags.Add("terminal");
+        if (node.Outgoing.Any(x => x.Broken))
+            flags.Add("broken");
+        if (node.IsInCycle)
+            flags.Add("cycle");
+        if (node.IsUnreachable)
+            flags.Add("unreachable");
+        return flags.Count == 0 ? "" : $"({string.Join(", ", flags)})";
+    }
+
+    private void DrawDetails()
+    {
+        if (selected == null)
+        {
+            ImGui.TextDisabled("Select a node.");
+            return;
+        }
+
+        ImGui.Text($"{selected.DisplayName}");
+        ImGui.SameLine();
+        ImGui.TextDisabled($"line {selected.Line}");
+        ImGui.SameLine();
+        if (ImGui.Button($"{Icons.Copy}##copyNodeId", new Vector2(34 * ImGuiHelper.Scale, 0)))
+            win.SetClipboardText(selected.Id.ToString());
+        if (ImGui.IsItemHovered())
+            ImGui.SetTooltip("Copy node identifier.");
+        ImGui.SameLine();
+        if (ImGui.Button($"{Icons.FileExport}##exportDiagnostics", new Vector2(34 * ImGuiHelper.Scale, 0)))
+            win.TextWindows.Add(new TextDisplayWindow(BuildDiagnosticExport(), "vignette-diagnostics.txt", win));
+        if (ImGui.IsItemHovered())
+            ImGui.SetTooltip("Open diagnostic export.");
+
+        if (!ImGui.BeginTabBar("##vignetteNodeTabs"))
+            return;
+        if (ImGui.BeginTabItem("Semantic"))
+        {
+            DrawSemantic();
+            ImGui.EndTabItem();
+        }
+        if (ImGui.BeginTabItem("Properties"))
+        {
+            DrawProperties();
+            ImGui.EndTabItem();
+        }
+        if (ImGui.BeginTabItem("Connections"))
+        {
+            DrawConnections();
+            ImGui.EndTabItem();
+        }
+        if (ImGui.BeginTabItem("Raw INI"))
+        {
+            DrawRawIni();
+            ImGui.EndTabItem();
+        }
+        if (ImGui.BeginTabItem("Diagnostics"))
+        {
+            DrawDiagnostics();
+            ImGui.EndTabItem();
+        }
+        if (ImGui.BeginTabItem("Tree"))
+        {
+            DrawTree();
+            ImGui.EndTabItem();
+        }
+        if (ImGui.BeginTabItem("Graph"))
+        {
+            DrawGraph();
+            ImGui.EndTabItem();
+        }
+        ImGui.EndTabBar();
+    }
+
+    private void DrawSemantic()
+    {
+        if (showFlowHints)
+        {
+            ImGui.Text("Flow");
+            foreach (var line in FlowLines(selected!))
+                ImGui.BulletText(line);
+            ImGui.Separator();
+        }
+
+        ImGui.Text("Fields");
+        var lines = HumanSemanticLines(selected!).ToArray();
+        if (lines.Length == 0)
+        {
+            ImGui.TextDisabled("No semantic fields on this node.");
+        }
+        else
+        {
+            foreach (var line in lines)
+                ImGui.BulletText(line);
+        }
+
+        if (!showIdsText)
+            return;
+
+        var resolved = ResolvedTextLines(selected).ToArray();
+        if (resolved.Length == 0)
+            return;
+
+        ImGui.Separator();
+        ImGui.Text("Resolved IDS_NAME text");
+        foreach (var line in resolved)
+            ImGui.TextWrapped(line);
+    }
+
+    private void DrawTree()
+    {
+        if (ImGui.Button($"{Icons.Copy} Copy tree"))
+            win.SetClipboardText(treeText);
+        ImGui.SameLine();
+        if (ImGui.Button($"{Icons.FileExport} Compile preview"))
+            CompileTreePreview();
+        ImGui.SameLine();
+        ImGui.TextDisabled("Read-only DSL. # comments are ignored by the compiler.");
+        if (!string.IsNullOrWhiteSpace(treeCompileStatus))
+        {
+            ImGui.SameLine();
+            ImGui.TextDisabled(treeCompileStatus);
+        }
+
+        DrawTreeSearch();
+        DrawTreeIntelliSense();
+        DrawTreeHelp();
+        treeEditor.Render("##vignetteTreeEditor");
+    }
+
+    private void DrawTreeViewer()
+    {
+        var lineHeight = ImGui.GetTextLineHeightWithSpacing();
+        if (ImGui.BeginChild("##vignetteTreeViewer", Vector2.Zero, ImGuiChildFlags.Borders,
+                ImGuiWindowFlags.HorizontalScrollbar))
+        {
+            if (pendingTreeJumpLine > 0)
+            {
+                var targetY = Math.Max(0, (pendingTreeJumpLine - 1) * lineHeight - ImGui.GetWindowHeight() * 0.35f);
+                ImGui.SetScrollY(targetY);
+                pendingTreeJumpLine = -1;
+            }
+
+            ImGui.PushFont(ImGuiHelper.SystemMonospace, 0);
+            var clipper = new ImGuiListClipper();
+            clipper.Begin(treeLines.Length);
+            while (clipper.Step())
+            {
+                for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
+                    DrawTreeViewerLine(i + 1, treeLines[i]);
+            }
+            clipper.End();
+            ImGui.PopFont();
+        }
+        ImGui.EndChild();
+    }
+
+    private void DrawTreeViewerLine(int lineNumber, string line)
+    {
+        var lineNumberWidth = 58 * ImGuiHelper.Scale;
+        ImGui.TextColored(new Vector4(0.48f, 0.50f, 0.58f, 1), lineNumber.ToString(CultureInfo.InvariantCulture).PadLeft(5));
+        ImGui.SameLine(lineNumberWidth);
+        var color = lineNumber == highlightedTreeLine
+            ? new Vector4(1.0f, 0.88f, 0.45f, 1)
+            : TreeLineColor(line);
+        ImGui.TextColored(color, line.Length == 0 ? " " : line);
+    }
+
+    private static Vector4 TreeLineColor(string line)
+    {
+        var trimmed = line.TrimStart();
+        if (trimmed.StartsWith("#", StringComparison.Ordinal))
+            return new Vector4(0.20f, 0.85f, 0.52f, 1);
+        if (trimmed.StartsWith("if ", StringComparison.Ordinal) ||
+            trimmed.StartsWith("elif ", StringComparison.Ordinal) ||
+            trimmed == "else" ||
+            trimmed == "end")
+            return new Vector4(0.90f, 0.55f, 0.90f, 1);
+        if (trimmed.StartsWith("group ", StringComparison.Ordinal) ||
+            trimmed.StartsWith("doc ", StringComparison.Ordinal) ||
+            trimmed.StartsWith("sub ", StringComparison.Ordinal) ||
+            trimmed.StartsWith("call ", StringComparison.Ordinal))
+            return new Vector4(0.45f, 0.82f, 1.0f, 1);
+        return new Vector4(0.88f, 0.90f, 0.94f, 1);
+    }
+
+    private void DrawTreeSearch()
+    {
+        ImGui.SetNextItemWidth(280 * ImGuiHelper.Scale);
+        if (ImGui.InputTextWithHint("##vignetteTreeSearch", "Search DSL, factions, IDS_NAME, node_id", ref treeSearch, 256))
+        {
+            treeSearchIndex = 0;
+            treeSearchStatus = "";
+        }
+        ImGui.SameLine();
+        if (ImGui.Button($"{Icons.X}##clearVignetteTreeSearch", new Vector2(32 * ImGuiHelper.Scale, 0)))
+        {
+            treeSearch = "";
+            treeSearchIndex = 0;
+            treeSearchStatus = "";
+        }
+
+        var matches = TreeSearchMatches(treeSearch).ToArray();
+        ImGui.SameLine();
+        ImGui.TextDisabled(string.IsNullOrWhiteSpace(treeSearch) ? "Search in generated DSL and # hints." : $"{matches.Length} match(es)");
+
+        if (matches.Length == 0)
+            return;
+
+        treeSearchIndex = Math.Clamp(treeSearchIndex, 0, matches.Length - 1);
+        ImGui.SameLine();
+        if (ImGui.Button($"{Icons.ArrowUp}##prevVignetteTreeSearch", new Vector2(32 * ImGuiHelper.Scale, 0)))
+        {
+            treeSearchIndex = (treeSearchIndex + matches.Length - 1) % matches.Length;
+            NavigateTreeToLine(matches[treeSearchIndex].Line);
+        }
+        ImGui.SameLine();
+        if (ImGui.Button($"{Icons.ArrowDown}##nextVignetteTreeSearch", new Vector2(32 * ImGuiHelper.Scale, 0)))
+        {
+            treeSearchIndex = (treeSearchIndex + 1) % matches.Length;
+            NavigateTreeToLine(matches[treeSearchIndex].Line);
+        }
+
+        var current = matches[treeSearchIndex];
+        ImGui.SameLine();
+        ImGui.TextDisabled($"Line {current.Line}: {current.Text}");
+        if (!string.IsNullOrEmpty(treeSearchStatus))
+        {
+            ImGui.SameLine();
+            ImGui.TextDisabled(treeSearchStatus);
+        }
+
+        if (matches.Length <= 1)
+            return;
+
+        var previewCount = Math.Min(6, matches.Length);
+        if (ImGui.BeginChild("##vignetteTreeSearchResults", new Vector2(0, (previewCount * 22 + 8) * ImGuiHelper.Scale),
+                ImGuiChildFlags.Borders))
+        {
+            for (int i = 0; i < previewCount; i++)
+            {
+                var matchIndex = (treeSearchIndex + i) % matches.Length;
+                var match = matches[matchIndex];
+                if (ImGui.Selectable($"{match.Line,5}: {match.Text}", matchIndex == treeSearchIndex))
+                {
+                    treeSearchIndex = matchIndex;
+                    NavigateTreeToLine(match.Line);
+                }
+            }
+        }
+        ImGui.EndChild();
+    }
+
+    private void NavigateTreeToLine(int line)
+    {
+        highlightedTreeLine = line;
+        treeSearchStatus = treeEditor.GoToLine(line)
+            ? ""
+            : "Line jump needs rebuilt cimgui native DLL.";
+    }
+
+    private void DrawTreeHelp()
+    {
+        if (!ImGui.CollapsingHeader($"{Icons.QuestionCircle} DSL help / Справка по DSL"))
+            return;
+
+        ImGui.TextWrapped("RU: Это человекочитаемый вид vignetteparams.ini. Строки с # являются подсказками и игнорируются компилятором. Команды заканчиваются ;, поэтому ; не используется как комментарий.");
+        ImGui.TextWrapped("EN: This is a readable view of vignetteparams.ini. # lines are hints ignored by the compiler. Statements end with ;, so ; is not used as a comment marker.");
+        ImGui.Separator();
+        DrawTreeHelpLine("group name factions...;", "RU: именованный список фракций. EN: named faction list.");
+        DrawTreeHelpLine("doc Name;", "RU: DocumentationNode / логический раздел. EN: documentation node / logical section.");
+        DrawTreeHelpLine("if Condition / elif group(name) / else / end", "RU: DecisionNode и ветвления. EN: decision node and branching.");
+        DrawTreeHelpLine("sub node_123 ... end", "RU: переиспользуемая ветка, на которую есть несколько ссылок. EN: reusable branch referenced more than once.");
+        DrawTreeHelpLine("call node_123;", "RU: переход к sub-ветке. EN: jump/call into a sub branch.");
+        DrawTreeHelpLine("offer_group / hostile_group", "RU: фракции оффера и противники. EN: offer and hostile factions.");
+        DrawTreeHelpLine("offer_text / objective_text", "RU: IDS_NAME строки с токенами. EN: IDS_NAME text with tokens.");
+        DrawTreeHelpLine("comm_sequence", "RU: реплики/события коммуникаций. EN: comm event lines.");
+        DrawTreeHelpLine("noop;", "RU: пустая ветка, которой не было в исходном INI. EN: empty branch missing from the original INI.");
+    }
+
+    private static void DrawTreeHelpLine(string syntax, string description)
+    {
+        ImGui.PushFont(ImGuiHelper.SystemMonospace, 0);
+        ImGui.Text(syntax);
+        ImGui.PopFont();
+        ImGui.SameLine(360 * ImGuiHelper.Scale);
+        ImGui.TextWrapped(description);
+    }
+
+    private IEnumerable<(int Line, string Text)> TreeSearchMatches(string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+            yield break;
+
+        for (int i = 0; i < treeLines.Length; i++)
+        {
+            if (treeLines[i].IndexOf(query, StringComparison.OrdinalIgnoreCase) < 0)
+                continue;
+            yield return (i + 1, TrimSearchResult(treeLines[i]));
+        }
+    }
+
+    private static string TrimSearchResult(string line)
+    {
+        line = line.Trim();
+        const int max = 160;
+        return line.Length <= max ? line : line[..max] + "...";
+    }
+
+    private static string[] SplitTreeLines(string text)
+    {
+        return text.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+    }
+
+    private void DrawTreeIntelliSense()
+    {
+        if (!ImGui.CollapsingHeader($"{Icons.Lightbulb} IntelliSense"))
+            return;
+
+        ImGui.SetNextItemWidth(220 * ImGuiHelper.Scale);
+        ImGui.Combo("##vignetteTreeSenseKind", ref treeSenseFilter, TreeSenseFilters, TreeSenseFilters.Length);
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(320 * ImGuiHelper.Scale);
+        ImGui.InputTextWithHint("##vignetteTreeSenseSearch", "Filter keys, factions, IDS_NAME, nodes", ref treeSenseSearch, 256);
+        ImGui.SameLine();
+        if (ImGui.Button($"{Icons.X}##clearVignetteTreeSense", new Vector2(32 * ImGuiHelper.Scale, 0)))
+            treeSenseSearch = "";
+
+        var items = BuildTreeSenseItems()
+            .Where(MatchesTreeSenseFilter)
+            .Take(300)
+            .ToArray();
+
+        ImGui.TextDisabled($"{items.Length} suggestion(s). Click {Icons.Copy} to copy insertion text.");
+        if (!ImGui.BeginTable("##vignetteTreeSenseTable", 4,
+                ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY | ImGuiTableFlags.Resizable,
+                new Vector2(0, 220 * ImGuiHelper.Scale)))
+            return;
+
+        ImGui.TableSetupColumn("", ImGuiTableColumnFlags.WidthFixed, 34 * ImGuiHelper.Scale);
+        ImGui.TableSetupColumn("Kind", ImGuiTableColumnFlags.WidthFixed, 90 * ImGuiHelper.Scale);
+        ImGui.TableSetupColumn("Insert", ImGuiTableColumnFlags.WidthStretch, 0.8f);
+        ImGui.TableSetupColumn("Hint", ImGuiTableColumnFlags.WidthStretch, 1.8f);
+        ImGui.TableHeadersRow();
+
+        foreach (var item in items)
+        {
+            ImGui.TableNextRow();
+            ImGui.TableNextColumn();
+            if (ImGui.Button($"{Icons.Copy}##copySense{item.Kind}{item.InsertText}"))
+                win.SetClipboardText(item.InsertText);
+            if (ImGui.IsItemHovered())
+                ImGui.SetTooltip("Copy insertion text");
+
+            ImGui.TableNextColumn();
+            ImGui.Text(item.Kind);
+            ImGui.TableNextColumn();
+            ImGui.PushFont(ImGuiHelper.SystemMonospace, 0);
+            ImGui.TextWrapped(item.InsertText);
+            ImGui.PopFont();
+            ImGui.TableNextColumn();
+            ImGui.TextWrapped(item.Hint);
+            if (!string.IsNullOrWhiteSpace(item.Details) && ImGui.IsItemHovered())
+                ImGui.SetTooltip(item.Details);
+        }
+        ImGui.EndTable();
+    }
+
+    private bool MatchesTreeSenseFilter(TreeSenseItem item)
+    {
+        if (treeSenseFilter > 0 &&
+            !item.Kind.Equals(TreeSenseFilters[treeSenseFilter], StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (string.IsNullOrWhiteSpace(treeSenseSearch))
+            return true;
+        return item.InsertText.Contains(treeSenseSearch, StringComparison.OrdinalIgnoreCase) ||
+               item.Hint.Contains(treeSenseSearch, StringComparison.OrdinalIgnoreCase) ||
+               item.Details.Contains(treeSenseSearch, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private IEnumerable<TreeSenseItem> BuildTreeSenseItems()
+    {
+        foreach (var item in BuildSyntaxSenseItems())
+            yield return item;
+
+        foreach (var condition in graph.Nodes
+                     .Where(x => x.Kind == VignetteNodeKind.Decision)
+                     .Select(x => x.FirstValue("nickname"))
+                     .Where(x => !string.IsNullOrWhiteSpace(x))
+                     .Distinct(StringComparer.OrdinalIgnoreCase)
+                     .OrderBy(x => x))
+        {
+            yield return new TreeSenseItem("Conditions", condition!, $"Decision condition: {condition}", "Use after if/elif for mission branch checks.");
+        }
+
+        var groupDefinitions = ExtractGroupDefinitions(treeLines);
+        foreach (var group in groupDefinitions.OrderBy(x => x.Key))
+        {
+            yield return new TreeSenseItem("Groups", group.Key, $"group({group.Key}) -> {HumanizeFactionGroup(group.Value)}",
+                $"Raw factions: {group.Value}");
+        }
+
+        foreach (var faction in context.GameData.Items.Factions.OrderBy(x => x.Nickname))
+        {
+            var name = ResolveStringId(faction.IdsName);
+            var hint = string.IsNullOrWhiteSpace(name)
+                ? faction.Nickname
+                : $"{faction.Nickname} -> {NormalizeResolvedText(name)}";
+            yield return new TreeSenseItem("Factions", faction.Nickname, hint, $"IDS_NAME {faction.IdsName}");
+        }
+
+        foreach (var id in TreeIds().OrderBy(x => x))
+        {
+            var text = ResolveStringId(id);
+            var hint = string.IsNullOrWhiteSpace(text)
+                ? $"IDS_NAME {id}"
+                : $"IDS_NAME {id}: {Shorten(NormalizeResolvedText(text), 180)}";
+            yield return new TreeSenseItem("IDS_NAME", id.ToString(CultureInfo.InvariantCulture), hint, hint);
+        }
+
+        foreach (var node in graph.Nodes.OrderBy(x => x.Id))
+        {
+            yield return new TreeSenseItem("Nodes", $"call node_{node.Id};", $"#{node.Id} {node.DisplayName}: {node.Summary}",
+                string.Join("\n", HumanSemanticLines(node).Take(5)));
+        }
+    }
+
+    private static IEnumerable<TreeSenseItem> BuildSyntaxSenseItems()
+    {
+        yield return new TreeSenseItem("Syntax", "group group_name fc_x_grp, fc_y_grp;", "Define a reusable faction group.", "RU: список фракций. EN: named faction list.");
+        yield return new TreeSenseItem("Syntax", "doc DocumentationName;", "Create a documentation/logical section.", "RU: DocumentationNode. EN: documentation node.");
+        yield return new TreeSenseItem("Syntax", "if Condition", "Start a DecisionNode branch.", "RU: условная ветка. EN: conditional branch.");
+        yield return new TreeSenseItem("Syntax", "elif group(group_name)", "Faction-group branch condition.", "RU: ветка по группе фракций. EN: faction group branch.");
+        yield return new TreeSenseItem("Syntax", "else", "Fallback branch.", "RU: ветка иначе. EN: fallback branch.");
+        yield return new TreeSenseItem("Syntax", "end", "Close if/sub block.", "RU: закрывает блок. EN: closes a block.");
+        yield return new TreeSenseItem("Syntax", "sub node_123", "Reusable branch body.", "RU: переиспользуемая ветка. EN: reusable branch.");
+        yield return new TreeSenseItem("Syntax", "call node_123;", "Call a reusable branch.", "RU: переход к sub. EN: call a sub branch.");
+        yield return new TreeSenseItem("Syntax", "offer_group group_name;", "Set offer factions.", "RU: фракции оффера. EN: offer factions.");
+        yield return new TreeSenseItem("Syntax", "hostile_group group_name;", "Set hostile factions.", "RU: враждебные фракции. EN: hostile factions.");
+        yield return new TreeSenseItem("Syntax", "offer_text (...);", "Mission offer text sequence.", "RU: текст оффера. EN: offer text.");
+        yield return new TreeSenseItem("Syntax", "objective_text template_name, IDS_NAME;", "Objective text template.", "RU: текст цели. EN: objective text.");
+        yield return new TreeSenseItem("Syntax", "comm_sequence EVENT, TARGET, 0, 0, 0, SOURCE, MESSAGE;", "Communication event.", "RU: реплика/событие. EN: comm event.");
+        yield return new TreeSenseItem("Syntax", "noop;", "Empty branch placeholder.", "RU: пустая ветка, которой не было в исходном INI. EN: empty branch missing from the original INI.");
+    }
+
+    private IEnumerable<int> TreeIds()
+    {
+        var seen = new HashSet<int>();
+        foreach (var line in treeLines)
+        {
+            foreach (var id in SplitIdsFromCodeLine(line))
+            {
+                if (seen.Add(id))
+                    yield return id;
+            }
+        }
+    }
+
+    private readonly record struct TreeSenseItem(string Kind, string InsertText, string Hint, string Details);
+
+    private void DrawProperties()
+    {
+        if (!ImGui.BeginTable("##vignetteProperties", 3,
+                ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg | ImGuiTableFlags.Resizable))
+            return;
+        ImGui.TableSetupColumn("Name", ImGuiTableColumnFlags.WidthStretch, 0.8f);
+        ImGui.TableSetupColumn("Value", ImGuiTableColumnFlags.WidthStretch, 2.2f);
+        ImGui.TableSetupColumn("Line", ImGuiTableColumnFlags.WidthFixed, 60 * ImGuiHelper.Scale);
+        ImGui.TableHeadersRow();
+        foreach (var property in selected!.Properties)
+        {
+            ImGui.TableNextRow();
+            ImGui.TableNextColumn();
+            ImGui.Text(property.Name);
+            ImGui.TableNextColumn();
+            ImGui.TextWrapped(property.Value);
+            ImGui.TableNextColumn();
+            ImGui.Text(property.Line.ToString());
+        }
+        ImGui.EndTable();
+    }
+
+    private void DrawConnections()
+    {
+        ImGui.Text("Incoming");
+        DrawEdgeList(selected!.Incoming, true);
+        ImGui.Separator();
+        ImGui.Text("Outgoing");
+        DrawEdgeList(selected.Outgoing, false);
+    }
+
+    private void DrawEdgeList(IEnumerable<VignetteGraphEdge> edges, bool incoming)
+    {
+        var any = false;
+        foreach (var edge in edges)
+        {
+            any = true;
+            var otherId = incoming ? edge.SourceNodeId : edge.TargetNodeId;
+            var label = incoming
+                ? $"{edge.SourceNodeId} -> {edge.TargetNodeId} ({edge.Relation})"
+                : $"{edge.SourceNodeId} -> {edge.TargetNodeId} ({edge.Relation})";
+            if (edge.Broken)
+                ImGui.TextColored(new Vector4(0.95f, 0.35f, 0.28f, 1), label + " broken");
+            else if (ImGui.Selectable(label))
+            {
+                selected = graph.NodeById(otherId);
+                graphNavigateToSelected = true;
+            }
+        }
+        if (!any)
+            ImGui.TextDisabled("None");
+    }
+
+    private void DrawRawIni()
+    {
+        if (ImGui.Button($"{Icons.Copy} Copy raw section"))
+            win.SetClipboardText(selected!.RawIni);
+        ImGui.PushFont(ImGuiHelper.SystemMonospace, 0);
+        var raw = selected!.RawIni;
+        ImGui.InputTextMultiline("##rawVignetteNode", ref raw, (uint)Encoding.UTF8.GetByteCount(raw) + 1,
+            ImGui.GetContentRegionAvail(), ImGuiInputTextFlags.ReadOnly);
+        ImGui.PopFont();
+    }
+
+    private void DrawDiagnostics()
+    {
+        if (selected!.Diagnostics.Count == 0 && graph.Diagnostics.Count == 0)
+        {
+            ImGui.TextDisabled("No diagnostics.");
+            return;
+        }
+        foreach (var diagnostic in graph.Diagnostics.Where(x => x.NodeId == null || x.NodeId == selected.Id))
+        {
+            var color = diagnostic.Severity switch
+            {
+                VignetteDiagnosticSeverity.Error => new Vector4(0.95f, 0.35f, 0.28f, 1),
+                VignetteDiagnosticSeverity.Warning => new Vector4(1f, 0.72f, 0.25f, 1),
+                _ => new Vector4(0.65f, 0.75f, 0.95f, 1)
+            };
+            ImGui.TextColored(color, $"{diagnostic.Severity}: {diagnostic.Message}");
+        }
+    }
+
+    private void DrawGraph()
+    {
+        if (ImGui.Button($"{Icons.Sitemap} Fit graph"))
+            graphNeedsLayout = true;
+        ImGui.SameLine();
+        if (ImGui.Button($"{Icons.Bullseye} Center selected"))
+            graphNavigateToSelected = true;
+        ImGui.SameLine();
+        ImGui.TextDisabled("Read-only graph canvas. Pan and zoom like Mission Script Editor.");
+
+        NodeEditor.SetCurrentEditor(graphContext);
+        NodeEditor.Begin("Vignette Node Graph", ImGui.GetContentRegionAvail());
+
+        if (graphNeedsLayout)
+        {
+            QueueGraphLayout();
+            graphNeedsLayout = false;
+        }
+
+        while (graphPositions.Count > 0)
+        {
+            var item = graphPositions.Dequeue();
+            NodeEditor.SetNodePosition(item.Id, item.Pos);
+        }
+
+        foreach (var node in graph.Nodes)
+            DrawGraphCanvasNode(node);
+
+        for (int i = 0; i < graph.Edges.Count; i++)
+        {
+            var edge = graph.Edges[i];
+            if (edge.Broken)
+                continue;
+            var source = graph.NodeById(edge.SourceNodeId);
+            var target = graph.NodeById(edge.TargetNodeId);
+            if (source == null || target == null)
+                continue;
+            NodeEditor.Link(GraphLinkId(i), GraphOutputPin(source), GraphInputPin(target), EdgeColor(edge), 2.0f);
+        }
+
+        SyncGraphSelection();
+
+        if (graphNavigateToSelected && selected != null)
+        {
+            NodeEditor.ClearSelection();
+            NodeEditor.SelectNode(GraphNodeId(selected));
+            NodeEditor.NavigateToSelection(true);
+            graphNavigateToSelected = false;
+        }
+
+        NodeEditor.End();
+        NodeEditor.SetCurrentEditor(null);
+    }
+
+    private void DrawGraphCanvasNode(VignetteGraphNode node)
+    {
+        var dim = search is not "" && !MatchesSearch(node);
+        if (dim)
+            ImGui.PushStyleVar(ImGuiStyleVar.Alpha, 0.25f);
+
+        NodeEditor.PushStyleVar(StyleVar.NodePadding, new Vector4(8, 4, 8, 8));
+        NodeEditor.BeginNode(GraphNodeId(node));
+        ImGui.PushID(node.Index);
+
+        var headerColor = NodeColor(node);
+        ImGui.PushStyleColor(ImGuiCol.Text, headerColor);
+        ImGui.BeginGroup();
+        ImGui.Text($"{node.DisplayName}");
+        ImGui.SameLine();
+        ImGui.TextDisabled(StatusFlags(node));
+        ImGui.EndGroup();
+        ImGui.PopStyleColor();
+
+        ImGui.BeginTable("##nodePins", 3, ImGuiTableFlags.PreciseWidths, new Vector2(420, 0));
+        ImGui.TableSetupColumn("Input", ImGuiTableColumnFlags.WidthFixed, 70);
+        ImGui.TableSetupColumn("Summary", ImGuiTableColumnFlags.WidthFixed, 280);
+        ImGui.TableSetupColumn("Output", ImGuiTableColumnFlags.WidthFixed, 70);
+        ImGui.TableNextRow();
+
+        ImGui.TableNextColumn();
+        NodeEditor.BeginPin(GraphInputPin(node), PinKind.Input);
+        NodeEditor.PinPivotAlignment(new Vector2(0f, 0.5f));
+        NodeEditor.PinPivotSize(new Vector2(0, 0));
+        VectorIcons.Icon(new Vector2(14), VectorIcon.Diamond, false, Color4.Green);
+        ImGui.SameLine();
+        ImGui.Text("In");
+        NodeEditor.EndPin();
+
+        ImGui.TableNextColumn();
+        ImGui.TextWrapped(Shorten(GraphHeadline(node), 92));
+        ImGui.TextDisabled($"line {node.Line}");
+        foreach (var line in GraphCardLines(node).Take(5))
+            ImGui.TextDisabled(Shorten(line, 86));
+
+        ImGui.TableNextColumn();
+        NodeEditor.BeginPin(GraphOutputPin(node), PinKind.Output);
+        NodeEditor.PinPivotAlignment(new Vector2(1f, 0.5f));
+        NodeEditor.PinPivotSize(new Vector2(0, 0));
+        ImGui.Text("Out");
+        ImGui.SameLine();
+        VectorIcons.Icon(new Vector2(14), VectorIcon.Diamond, false, Color4.Green);
+        NodeEditor.EndPin();
+        ImGui.EndTable();
+
+        DrawNodeBadges(node);
+
+        ImGui.PopID();
+        NodeEditor.EndNode();
+        NodeEditor.PopStyleVar();
+
+        if (dim)
+            ImGui.PopStyleVar();
+    }
+
+    private void DrawNodeBadges(VignetteGraphNode node)
+    {
+        var broken = node.Outgoing.Count(x => x.Broken);
+        if (broken == 0 && node.Diagnostics.Count == 0)
+            return;
+        ImGui.Separator();
+        if (broken > 0)
+            ImGui.TextColored(new Vector4(0.95f, 0.35f, 0.28f, 1), $"{broken} broken ref(s)");
+        if (node.Diagnostics.Count > 0)
+            ImGui.TextColored(new Vector4(1f, 0.72f, 0.25f, 1), $"{node.Diagnostics.Count} diagnostic(s)");
+    }
+
+    private void SyncGraphSelection()
+    {
+        if (NodeEditor.HasSelectionChanged())
+        {
+            Span<NodeId> nodes = stackalloc NodeId[Math.Max(1, graph.Nodes.Count)];
+            var count = NodeEditor.GetSelectedNodes(nodes);
+            if (count > 0)
+            {
+                var selectedId = nodes[0];
+                var node = graph.Nodes.FirstOrDefault(x => GraphNodeId(x) == selectedId);
+                if (node != null)
+                    selected = node;
+            }
+        }
+
+        var doubleClicked = NodeEditor.GetDoubleClickedNode();
+        if (doubleClicked != 0)
+        {
+            var node = graph.Nodes.FirstOrDefault(x => GraphNodeId(x) == doubleClicked);
+            if (node != null)
+                selected = node;
+        }
+    }
+
+    private void QueueGraphLayout()
+    {
+        graphPositions.Clear();
+        var byId = graph.Nodes.ToDictionary(x => x.Id);
+        var depth = new Dictionary<int, int>();
+        var queue = new Queue<VignetteGraphNode>();
+
+        foreach (var root in graph.Nodes.Where(x => x.IsRoot).OrderBy(x => x.Id))
+        {
+            depth[root.Id] = 0;
+            queue.Enqueue(root);
+        }
+        if (queue.Count == 0 && graph.Nodes.FirstOrDefault() is { } first)
+        {
+            depth[first.Id] = 0;
+            queue.Enqueue(first);
+        }
+
+        while (queue.Count > 0)
+        {
+            var node = queue.Dequeue();
+            var nextDepth = depth[node.Id] + 1;
+            foreach (var edge in node.Outgoing)
+            {
+                if (!byId.TryGetValue(edge.TargetNodeId, out var child))
+                    continue;
+                if (depth.TryGetValue(child.Id, out var existing) && existing <= nextDepth)
+                    continue;
+                depth[child.Id] = nextDepth;
+                queue.Enqueue(child);
+            }
+        }
+
+        var maxDepth = depth.Count == 0 ? 0 : depth.Values.Max();
+        foreach (var node in graph.Nodes.Where(x => !depth.ContainsKey(x.Id)).OrderBy(x => x.Id))
+            depth[node.Id] = ++maxDepth;
+
+        var orderedLayers = BuildOrderedLayoutLayers(depth);
+        foreach (var group in orderedLayers.OrderBy(x => x.Key))
+        {
+            var ordered = group.Value;
+            var totalHeight = (ordered.Length - 1) * 190f;
+            for (int i = 0; i < ordered.Length; i++)
+            {
+                var pos = new Vector2(group.Key * 460f, i * 190f - totalHeight * 0.5f);
+                graphPositions.Enqueue((GraphNodeId(ordered[i]), pos));
+            }
+        }
+        graphNavigateToSelected = true;
+    }
+
+    private Dictionary<int, VignetteGraphNode[]> BuildOrderedLayoutLayers(Dictionary<int, int> depth)
+    {
+        var layers = graph.Nodes
+            .GroupBy(x => depth[x.Id])
+            .ToDictionary(
+                x => x.Key,
+                x => x.OrderBy(n => n.Line).ThenBy(n => n.Index).ToArray());
+        var maxDepth = layers.Count == 0 ? 0 : layers.Keys.Max();
+        var previousOrder = new Dictionary<int, float>();
+
+        for (var layer = 0; layer <= maxDepth; layer++)
+        {
+            if (!layers.TryGetValue(layer, out var nodes))
+                continue;
+            if (layer > 0)
+            {
+                nodes = nodes
+                    .OrderBy(n => ParentMedian(n, previousOrder))
+                    .ThenBy(n => n.Line)
+                    .ThenBy(n => n.Index)
+                    .ToArray();
+                layers[layer] = nodes;
+            }
+            previousOrder = nodes
+                .Select((node, index) => (node, index))
+                .ToDictionary(x => x.node.Id, x => (float)x.index);
+        }
+
+        for (var layer = maxDepth - 1; layer >= 0; layer--)
+        {
+            if (!layers.TryGetValue(layer, out var nodes))
+                continue;
+            var childOrder = layers.TryGetValue(layer + 1, out var next)
+                ? next.Select((node, index) => (node, index)).ToDictionary(x => x.node.Id, x => (float)x.index)
+                : new Dictionary<int, float>();
+            nodes = nodes
+                .OrderBy(n => ChildMedian(n, childOrder))
+                .ThenBy(n => n.Line)
+                .ThenBy(n => n.Index)
+                .ToArray();
+            layers[layer] = nodes;
+        }
+
+        return layers;
+    }
+
+    private static float ParentMedian(VignetteGraphNode node, Dictionary<int, float> previousOrder)
+    {
+        var positions = node.Incoming
+            .Where(x => previousOrder.ContainsKey(x.SourceNodeId))
+            .Select(x => previousOrder[x.SourceNodeId])
+            .OrderBy(x => x)
+            .ToArray();
+        return MedianOrMax(positions);
+    }
+
+    private static float ChildMedian(VignetteGraphNode node, Dictionary<int, float> childOrder)
+    {
+        var positions = node.Outgoing
+            .Where(x => !x.Broken && childOrder.ContainsKey(x.TargetNodeId))
+            .Select(x => childOrder[x.TargetNodeId])
+            .OrderBy(x => x)
+            .ToArray();
+        return MedianOrMax(positions);
+    }
+
+    private static float MedianOrMax(float[] values)
+    {
+        if (values.Length == 0)
+            return float.MaxValue;
+        return values[values.Length / 2];
+    }
+
+    private static NodeId GraphNodeId(VignetteGraphNode node) => 100000 + node.Index + 1;
+    private static PinId GraphInputPin(VignetteGraphNode node) => 200000 + node.Index + 1;
+    private static PinId GraphOutputPin(VignetteGraphNode node) => 300000 + node.Index + 1;
+    private static LinkId GraphLinkId(int edgeIndex) => 400000 + edgeIndex + 1;
+
+    private static Color4 NodeColor(VignetteGraphNode node) =>
+        node.Outgoing.Any(x => x.Broken) ? new Color4(150, 50, 42, 255) :
+        node.IsUnreachable ? new Color4(94, 90, 105, 255) :
+        node.Kind switch
+        {
+            VignetteNodeKind.Decision => new Color4(45, 105, 158, 255),
+            VignetteNodeKind.Data => new Color4(55, 125, 70, 255),
+            VignetteNodeKind.Documentation => new Color4(120, 95, 45, 255),
+            _ => new Color4(110, 65, 110, 255)
+        };
+
+    private static VertexDiffuse EdgeColor(VignetteGraphEdge edge) =>
+        edge.Relation.StartsWith("true", StringComparison.OrdinalIgnoreCase)
+            ? (VertexDiffuse)new Color4(70, 170, 250, 255)
+            : edge.Relation.StartsWith("false", StringComparison.OrdinalIgnoreCase)
+                ? (VertexDiffuse)new Color4(245, 170, 70, 255)
+                : edge.Relation.StartsWith("branch", StringComparison.OrdinalIgnoreCase)
+                    ? (VertexDiffuse)new Color4(185, 130, 245, 255)
+                    : (VertexDiffuse)new Color4(80, 190, 115, 255);
+
+    private static string Shorten(string text, int max) =>
+        text.Length <= max ? text : text[..Math.Max(0, max - 3)] + "...";
+
+    private string GraphHeadline(VignetteGraphNode node)
+    {
+        if (showFactionNames)
+        {
+            var groupHeadline = GroupHeadline(node);
+            if (groupHeadline != null)
+                return groupHeadline;
+        }
+
+        var resolved = showIdsText ? ResolvedTextLines(node).FirstOrDefault() : null;
+        if (resolved == null)
+            return node.Summary;
+        var colon = resolved.IndexOf(':');
+        return colon >= 0 && colon + 1 < resolved.Length
+            ? $"{node.Summary} -> {resolved[(colon + 1)..].Trim()}"
+            : $"{node.Summary} -> {resolved}";
+    }
+
+    private IEnumerable<string> GraphCardLines(VignetteGraphNode node)
+    {
+        if (showFlowHints)
+        {
+            foreach (var line in FlowLines(node).Take(2))
+                yield return line;
+        }
+        foreach (var line in HumanSemanticLines(node).Where(IsFactionSemanticLine).Take(2))
+            yield return line;
+        if (showIdsText)
+        {
+            foreach (var line in ResolvedTextLines(node).Take(2))
+                yield return line;
+        }
+        foreach (var line in HumanSemanticLines(node).Where(x => !IsFlowSemanticLine(x) && !IsFactionSemanticLine(x)).Take(3))
+            yield return line;
+    }
+
+    private static bool IsFlowSemanticLine(string line) =>
+        line.StartsWith("branch match ->", StringComparison.OrdinalIgnoreCase) ||
+        line.StartsWith("true/left:", StringComparison.OrdinalIgnoreCase) ||
+        line.StartsWith("next:", StringComparison.OrdinalIgnoreCase) ||
+        line.StartsWith("children:", StringComparison.OrdinalIgnoreCase) ||
+        line.StartsWith("no child nodes", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsFactionSemanticLine(string line) =>
+        line.StartsWith("offer groups:", StringComparison.OrdinalIgnoreCase) ||
+        line.StartsWith("hostile groups:", StringComparison.OrdinalIgnoreCase);
+
+    private string? GroupHeadline(VignetteGraphNode node)
+    {
+        if (node.FirstValue("offer_group") is { } offer)
+            return $"offer groups: {HumanizeFactionList(offer)}";
+        if (node.FirstValue("hostile_group") is { } hostile)
+            return $"hostile groups: {HumanizeFactionList(hostile)}";
+        return null;
+    }
+
+    private IEnumerable<string> FlowLines(VignetteGraphNode node)
+    {
+        if (node.IsRoot)
+            yield return "entry point: no incoming child_node";
+        foreach (var incoming in node.Incoming.OrderBy(x => x.SourceNodeId).Take(4))
+            yield return $"called by #{incoming.SourceNodeId} via {incoming.Relation}";
+        if (node.Incoming.Count > 4)
+            yield return $"called by {node.Incoming.Count - 4} more node(s)";
+
+        if (node.IsTerminal)
+            yield return "terminal: no outgoing child_node";
+        foreach (var outgoing in node.Outgoing.OrderBy(x => x.TargetNodeId).Take(4))
+        {
+            var target = graph.NodeById(outgoing.TargetNodeId);
+            var targetName = target == null ? "missing node" : target.DisplayName;
+            var suffix = outgoing.Broken ? " broken" : "";
+            yield return $"{outgoing.Relation}: #{outgoing.TargetNodeId} {targetName}{suffix}";
+        }
+        if (node.Outgoing.Count > 4)
+            yield return $"{node.Outgoing.Count - 4} more outgoing child_node link(s)";
+    }
+
+    private IEnumerable<string> ResolvedTextLines(VignetteGraphNode node)
+    {
+        foreach (var property in node.Properties)
+        {
+            if (!IsIdsTextProperty(property.Name))
+                continue;
+            foreach (var part in SplitCsv(property.Value))
+            {
+                if (!int.TryParse(part, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))
+                    continue;
+                var text = ResolveStringId(id);
+                if (string.IsNullOrWhiteSpace(text))
+                    continue;
+                yield return $"{property.Name} IDS_NAME {id}: {Shorten(NormalizeResolvedText(text), 180)}";
+            }
+        }
+    }
+
+    private IEnumerable<string> HumanSemanticLines(VignetteGraphNode node)
+    {
+        foreach (var line in node.SemanticLines())
+            yield return HumanizeSemanticLine(line);
+    }
+
+    private string HumanizeSemanticLine(string line)
+    {
+        if (!showFactionNames)
+            return line;
+
+        const string offerGroups = "offer groups:";
+        const string hostileGroups = "hostile groups:";
+        if (line.StartsWith(offerGroups, StringComparison.OrdinalIgnoreCase))
+            return $"{offerGroups} {HumanizeFactionList(line[offerGroups.Length..])}";
+        if (line.StartsWith(hostileGroups, StringComparison.OrdinalIgnoreCase))
+            return $"{hostileGroups} {HumanizeFactionList(line[hostileGroups.Length..])}";
+        return line;
+    }
+
+    private string HumanizeFactionList(string value)
+    {
+        return string.Join(", ", SplitCsv(value).Select(HumanizeFactionNickname));
+    }
+
+    private string HumanizeFactionNickname(string nickname)
+    {
+        if (nickname.Equals("all", StringComparison.OrdinalIgnoreCase))
+            return "all";
+        var faction = context.GameData.Items.Factions.Get(nickname);
+        if (faction == null)
+            return nickname;
+        var name = context.GameData.GetString(faction.IdsName);
+        if (string.IsNullOrWhiteSpace(name))
+            return nickname;
+        return $"{nickname} ({NormalizeResolvedText(name)})";
+    }
+
+    private string BuildTreeText()
+    {
+        try
+        {
+            var vparams = new VignetteParamsIni();
+            vparams.AddFile(sourcePath, context.GameData.VFS);
+            return AnnotateTreeText(VignetteParamsDecompiler.Decompile(vparams));
+        }
+        catch (Exception ex)
+        {
+            return BuildGraphTreeText(ex);
+        }
+    }
+
+    private string AnnotateTreeText(string text)
+    {
+        var lines = text.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var groups = ExtractGroupDefinitions(lines);
+        var sb = new StringBuilder();
+        foreach (var line in lines)
+        {
+            sb.AppendLine(line);
+            var hint = TreeHintForLine(line.Trim(), groups);
+            if (hint == null)
+                continue;
+            var indent = line.Length - line.TrimStart().Length;
+            sb.Append(' ', indent);
+            sb.Append("# ");
+            sb.AppendLine(hint);
+        }
+        return sb.ToString();
+    }
+
+    private static Dictionary<string, string> ExtractGroupDefinitions(IEnumerable<string> lines)
+    {
+        var groups = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var line in lines.Select(x => x.Trim()))
+        {
+            if (!line.StartsWith("group ", StringComparison.OrdinalIgnoreCase))
+                continue;
+            var body = line["group ".Length..].TrimEnd(';').Trim();
+            var nameEnd = body.IndexOf(' ');
+            if (nameEnd <= 0)
+                continue;
+            groups[body[..nameEnd]] = body[(nameEnd + 1)..].Trim();
+        }
+        return groups;
+    }
+
+    private string? TreeHintForLine(string line, Dictionary<string, string> groups)
+    {
+        if (line.Length == 0 || line.StartsWith("#", StringComparison.Ordinal))
+            return null;
+        if (line.StartsWith("group ", StringComparison.OrdinalIgnoreCase))
+        {
+            var body = line["group ".Length..].TrimEnd(';').Trim();
+            var nameEnd = body.IndexOf(' ');
+            if (nameEnd <= 0)
+                return null;
+            return $"defines {body[..nameEnd]}: {HumanizeFactionGroup(body[(nameEnd + 1)..])}";
+        }
+        if (line.StartsWith("offer_group ", StringComparison.OrdinalIgnoreCase))
+            return GroupReferenceHint("offer factions", line["offer_group ".Length..], groups);
+        if (line.StartsWith("hostile_group ", StringComparison.OrdinalIgnoreCase))
+            return GroupReferenceHint("hostile factions", line["hostile_group ".Length..], groups);
+        if (line.StartsWith("if group", StringComparison.OrdinalIgnoreCase) ||
+            line.StartsWith("elif group", StringComparison.OrdinalIgnoreCase))
+        {
+            var start = line.IndexOf('(');
+            var end = line.IndexOf(')');
+            if (start >= 0 && end > start)
+                return GroupReferenceHint("condition factions", line[(start + 1)..end], groups);
+        }
+        if (line.StartsWith("objective_text ", StringComparison.OrdinalIgnoreCase))
+            return IdTextHint("objective_text", line);
+        if (line.StartsWith("reward_text ", StringComparison.OrdinalIgnoreCase))
+            return IdTextHint("reward_text", line);
+        if (line.StartsWith("failure_text ", StringComparison.OrdinalIgnoreCase))
+            return IdTextHint("failure_text", line);
+        if (line.Contains('(') && line.Contains(')') &&
+            (line.StartsWith("append", StringComparison.OrdinalIgnoreCase) ||
+             line.StartsWith("replace", StringComparison.OrdinalIgnoreCase)))
+        {
+            return IdTextHint("offer_text", line);
+        }
+        return null;
+    }
+
+    private string? GroupReferenceHint(string prefix, string groupNameText, Dictionary<string, string> groups)
+    {
+        var groupName = groupNameText.Trim().TrimEnd(';').Trim();
+        if (!groups.TryGetValue(groupName, out var factions))
+            return null;
+        return $"{prefix}: {HumanizeFactionGroup(factions)}";
+    }
+
+    private string HumanizeFactionGroup(string factions)
+    {
+        var parts = SplitCsv(factions);
+        if (parts.Length == 0)
+            return "empty group";
+        var rendered = parts.Select(HumanizeFactionNickname).Take(10).ToArray();
+        var suffix = parts.Length > rendered.Length ? $" ... +{parts.Length - rendered.Length} more" : "";
+        return string.Join(", ", rendered) + suffix;
+    }
+
+    private string? IdTextHint(string label, string line)
+    {
+        var ids = SplitIdsFromCodeLine(line);
+        if (ids.Length == 0)
+            return null;
+        var texts = ids
+            .Select(id => (id, text: ResolveStringId(id)))
+            .Where(x => !string.IsNullOrWhiteSpace(x.text))
+            .Take(3)
+            .Select(x => $"IDS_NAME {x.id}: {Shorten(NormalizeResolvedText(x.text!), 120)}")
+            .ToArray();
+        return texts.Length == 0 ? null : $"{label}: {string.Join("; ", texts)}";
+    }
+
+    private static int[] SplitIdsFromCodeLine(string line)
+    {
+        var ids = new List<int>();
+        var current = new StringBuilder();
+        foreach (var ch in line)
+        {
+            if (char.IsDigit(ch))
+            {
+                current.Append(ch);
+                continue;
+            }
+            Flush();
+        }
+        Flush();
+        return ids.ToArray();
+
+        void Flush()
+        {
+            if (current.Length == 0)
+                return;
+            if (int.TryParse(current.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))
+                ids.Add(id);
+            current.Clear();
+        }
+    }
+
+    private void CompileTreePreview()
+    {
+        try
+        {
+            var sections = VignetteParamsCompiler.Compile(treeText, "Vignette Tree");
+            var ini = SerializeIniSections(sections);
+            treeCompileStatus = $"Compiled {sections.Count} section(s).";
+            win.TextWindows.Add(new TextDisplayWindow(ini, "vignetteparams.compiled.ini", win));
+        }
+        catch (Exception ex)
+        {
+            treeCompileStatus = $"Compile error: {ex.Message}";
+        }
+    }
+
+    private static string SerializeIniSections(IEnumerable<Section> sections)
+    {
+        using var stream = new MemoryStream();
+        IniWriter.WriteIni(stream, sections);
+        return Encoding.GetEncoding(1252).GetString(stream.ToArray());
+    }
+
+    private string BuildGraphTreeText(Exception? decompileError)
+    {
+        var sb = new StringBuilder();
+        if (decompileError != null)
+        {
+            sb.AppendLine("Decompiler could not build the high-level if/elif/else view.");
+            sb.AppendLine($"Fallback structural tree is shown from raw child_node links. {decompileError.GetType().Name}: {decompileError.Message}");
+            sb.AppendLine();
+        }
+
+        sb.AppendLine(sourcePath);
+        sb.AppendLine();
+        var emitted = new HashSet<int>();
+        var roots = graph.Nodes.Where(x => x.IsRoot).OrderBy(x => x.Line).ThenBy(x => x.Id).ToArray();
+        if (roots.Length == 0)
+            roots = graph.Nodes.OrderBy(x => x.Line).ThenBy(x => x.Id).Take(1).ToArray();
+
+        foreach (var root in roots)
+            AppendTreeNode(sb, root, 0, emitted, []);
+
+        var remaining = graph.Nodes
+            .Where(x => !emitted.Contains(x.Id))
+            .OrderBy(x => x.Line)
+            .ThenBy(x => x.Id)
+            .ToArray();
+        if (remaining.Length == 0)
+            return sb.ToString();
+
+        sb.AppendLine();
+        sb.AppendLine("Detached or shared nodes:");
+        foreach (var node in remaining)
+            AppendTreeNode(sb, node, 0, emitted, []);
+        return sb.ToString();
+    }
+
+    private void AppendTreeNode(StringBuilder sb, VignetteGraphNode node, int indent, HashSet<int> emitted, HashSet<int> path)
+    {
+        AppendIndent(sb, indent);
+        sb.Append(node.DisplayName);
+        sb.Append("  ");
+        sb.Append(GraphHeadline(node));
+        sb.Append("  line ");
+        sb.Append(node.Line);
+        if (node.IsTerminal)
+            sb.Append("  terminal");
+        if (node.IsUnreachable)
+            sb.Append("  unreachable");
+        sb.AppendLine();
+
+        if (!path.Add(node.Id))
+        {
+            AppendIndent(sb, indent + 1);
+            sb.AppendLine("cycle: node is already in this path");
+            return;
+        }
+
+        emitted.Add(node.Id);
+        foreach (var line in HumanSemanticLines(node).Where(x => !IsFlowSemanticLine(x)).Take(6))
+        {
+            AppendIndent(sb, indent + 1);
+            sb.Append("- ");
+            sb.AppendLine(line);
+        }
+        if (showIdsText)
+        {
+            foreach (var line in ResolvedTextLines(node).Take(4))
+            {
+                AppendIndent(sb, indent + 1);
+                sb.Append("- ");
+                sb.AppendLine(line);
+            }
+        }
+
+        foreach (var edge in OrderedOutgoing(node))
+        {
+            AppendIndent(sb, indent + 1);
+            sb.Append("-> ");
+            sb.Append(edge.Relation);
+            sb.Append(": #");
+            sb.Append(edge.TargetNodeId);
+            if (edge.Broken)
+            {
+                sb.AppendLine(" missing");
+                continue;
+            }
+            var target = graph.NodeById(edge.TargetNodeId);
+            if (target == null)
+            {
+                sb.AppendLine(" missing");
+                continue;
+            }
+            if (path.Contains(target.Id))
+            {
+                sb.AppendLine(" cycle");
+                continue;
+            }
+            if (emitted.Contains(target.Id))
+            {
+                sb.Append(" ref ");
+                sb.Append(target.DisplayName);
+                sb.Append(" line ");
+                sb.AppendLine(target.Line.ToString(CultureInfo.InvariantCulture));
+                continue;
+            }
+
+            sb.AppendLine();
+            AppendTreeNode(sb, target, indent + 2, emitted, new HashSet<int>(path));
+        }
+    }
+
+    private static IEnumerable<VignetteGraphEdge> OrderedOutgoing(VignetteGraphNode node) =>
+        node.Outgoing
+            .Select((edge, index) => (edge, index, childIndex: ChildIndex(node, edge.TargetNodeId)))
+            .OrderBy(x => x.childIndex < 0 ? int.MaxValue : x.childIndex)
+            .ThenBy(x => x.index)
+            .Select(x => x.edge);
+
+    private static int ChildIndex(VignetteGraphNode node, int childId)
+    {
+        for (var i = 0; i < node.ChildIds.Count; i++)
+        {
+            if (node.ChildIds[i] == childId)
+                return i;
+        }
+        return -1;
+    }
+
+    private static void AppendIndent(StringBuilder sb, int indent) =>
+        sb.Append(' ', indent * 2);
+
+    private string? ResolveStringId(int id)
+    {
+        try
+        {
+            return context.Infocards.GetStringResource(id);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool IsIdsTextProperty(string name) =>
+        name.Equals("offer_text", StringComparison.OrdinalIgnoreCase) ||
+        name.Equals("objective_text", StringComparison.OrdinalIgnoreCase) ||
+        name.Equals("Reward_text", StringComparison.OrdinalIgnoreCase) ||
+        name.Equals("Failure_text", StringComparison.OrdinalIgnoreCase);
+
+    private static string[] SplitCsv(string value) =>
+        value.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+    private static string NormalizeResolvedText(string value) =>
+        value.Replace("\r", "\\r", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Trim();
+
+    private string BuildDiagnosticExport()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(graph.SourcePath);
+        if (!string.IsNullOrWhiteSpace(graph.BackingPath))
+            sb.AppendLine(graph.BackingPath);
+        sb.AppendLine($"Nodes: {graph.Nodes.Count}");
+        sb.AppendLine($"Edges: {graph.Edges.Count}");
+        sb.AppendLine();
+        foreach (var diagnostic in graph.Diagnostics)
+            sb.AppendLine($"{diagnostic.Severity} {(diagnostic.NodeId is { } id ? $"node {id}" : "global")}: {diagnostic.Message}");
+        return sb.ToString();
+    }
+
+    public override void Dispose()
+    {
+        treeEditor.Dispose();
+        graphContext.Dispose();
+        graphConfig.Dispose();
+        base.Dispose();
+    }
+}

--- a/src/Editor/LancerEdit/GameContent/VoiceBrowserTab.cs
+++ b/src/Editor/LancerEdit/GameContent/VoiceBrowserTab.cs
@@ -1,0 +1,719 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using ImGuiNET;
+using LibreLancer;
+using LibreLancer.Data;
+using LibreLancer.Data.Ini;
+using LibreLancer.Dialogs;
+using LibreLancer.ImUI;
+using LibreLancer.Media;
+using LibreLancer.Utf;
+
+namespace LancerEdit.GameContent;
+
+public class VoiceBrowserTab : EditorTab
+{
+    private readonly MainWindow win;
+    private readonly GameDataContext context;
+    private readonly VoiceEntry[] voices;
+    private readonly Dictionary<string, VoiceUtfIndex> utfIndexes = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<uint, List<VoiceUtfNode>> nodesByHash = new();
+    private readonly Dictionary<uint, List<string>> messagesByHash = new();
+    private readonly Dictionary<string, VoiceSourceInfo> voiceSources;
+    private readonly Dictionary<string, List<PermutationSourceInfo>> permutationSources;
+    private readonly FileDialogFilters wavFilters = new(new FileFilter("WAV Files", "wav"));
+
+    private VoiceEntry selectedVoice;
+    private VoiceLineRow[] rows = [];
+    private SoundInstance currentInstance;
+    private string currentPlaybackId;
+    private string search = "";
+    private int statusFilter;
+    private int sourceFilter;
+
+    private static readonly string[] StatusFilters =
+    [
+        "All",
+        "Problems",
+        "Linked",
+        "INI missing",
+        "UTF missing"
+    ];
+
+    private static readonly string[] SourceFilters =
+    [
+        "All",
+        "Base",
+        "Space",
+        "Mission",
+        "Recognizable",
+        "Mixed",
+        "Other"
+    ];
+
+    public VoiceBrowserTab(MainWindow win, GameDataContext context)
+    {
+        this.win = win;
+        this.context = context;
+        Title = "Voice Browser";
+
+        BuildUtfIndexes();
+        voiceSources = BuildVoiceSources();
+        permutationSources = BuildPermutationSources();
+        var voiceNames = context.GameData.Items.Ini.Voices.Voices.Keys
+            .Concat(context.GameData.Items.Ini.MsnVoiceProps.VoiceProps.Select(x => x.Voice))
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+        voices = voiceNames
+            .Select(nickname =>
+            {
+                var source = voiceSources.GetValueOrDefault(nickname) ?? VoiceSourceInfo.Empty;
+                return new VoiceEntry(nickname, context.GameData.GetVoicePath(nickname), source);
+            })
+            .OrderBy(x => x.Nickname, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        foreach (var voice in voices)
+        {
+            if (!context.GameData.Items.Ini.Voices.Voices.TryGetValue(voice.Nickname, out var data))
+                continue;
+            foreach (var line in data.Messages)
+            {
+                var hash = FLHash.CreateID(line.Message);
+                if (!messagesByHash.TryGetValue(hash, out var messages))
+                    messagesByHash[hash] = messages = [];
+                if (!messages.Contains(line.Message, StringComparer.OrdinalIgnoreCase))
+                    messages.Add(line.Message);
+            }
+        }
+        selectedVoice = voices.FirstOrDefault();
+        RebuildRows();
+    }
+
+    public override void Draw(double elapsed)
+    {
+        DrawToolbar();
+        ImGui.Separator();
+
+        var avail = ImGui.GetContentRegionAvail();
+        var leftWidth = Math.Clamp(avail.X * 0.24f, 210 * ImGuiHelper.Scale, 340 * ImGuiHelper.Scale);
+        ImGui.BeginChild("##voiceList", new Vector2(leftWidth, 0), ImGuiChildFlags.Borders);
+        DrawVoiceList();
+        ImGui.EndChild();
+
+        ImGui.SameLine();
+        ImGui.BeginChild("##voiceLines", new Vector2(0, 0), ImGuiChildFlags.Borders);
+        DrawSelectedVoice();
+        ImGui.EndChild();
+    }
+
+    private void DrawToolbar()
+    {
+        ImGui.SetNextItemWidth(300 * ImGuiHelper.Scale);
+        if (ImGui.InputTextWithHint("##voiceSearch", "Search voice or line", ref search, 256))
+            RebuildRows();
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(140 * ImGuiHelper.Scale);
+        if (ImGui.Combo("Status", ref statusFilter, StatusFilters, StatusFilters.Length))
+            RebuildRows();
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(150 * ImGuiHelper.Scale);
+        if (ImGui.Combo("Source", ref sourceFilter, SourceFilters, SourceFilters.Length) &&
+            selectedVoice != null &&
+            !MatchesSourceFilter(selectedVoice))
+        {
+            selectedVoice = voices.FirstOrDefault(MatchesSourceFilter);
+            RebuildRows();
+        }
+        if (ImGui.IsItemHovered())
+            ImGui.SetTooltip("Filter voices by the voice_*.ini files that define or extend them.");
+        ImGui.SameLine();
+        ImGui.TextDisabled($"{rows.Length} lines");
+    }
+
+    private bool MatchesSourceFilter(VoiceEntry voice)
+    {
+        if (sourceFilter == 0)
+            return true;
+        return voice.Source.KindLabel.Equals(SourceFilters[sourceFilter], StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void DrawVoiceList()
+    {
+        foreach (var voice in voices.Where(MatchesSourceFilter))
+        {
+            var isSelected = selectedVoice == voice;
+            var label = $"{voice.Nickname}##voice_{voice.Nickname}";
+            if (ImGui.Selectable(label, isSelected))
+            {
+                StopPlayback();
+                selectedVoice = voice;
+                RebuildRows();
+            }
+            if (ImGui.IsItemHovered())
+                ImGui.SetTooltip($"{voice.UtfPath ?? "(no UTF path)"}\n{voice.Source.Tooltip}");
+        }
+    }
+
+    private void DrawSelectedVoice()
+    {
+        if (selectedVoice == null)
+        {
+            ImGui.TextDisabled("No voices loaded");
+            return;
+        }
+
+        ImGui.Text($"Voice: {selectedVoice.Nickname}");
+        ImGui.Text($"UTF: {selectedVoice.UtfPath ?? "(none)"}");
+        ImGui.TextDisabled($"Source: {selectedVoice.Source.KindLabel} ({selectedVoice.Source.Files.Count} file(s))");
+        if (ImGui.IsItemHovered())
+            ImGui.SetTooltip(selectedVoice.Source.Tooltip);
+        DrawPermutationIssues();
+        ImGui.Separator();
+        DrawRows();
+    }
+
+    private void DrawRows()
+    {
+        var flags = ImGuiTableFlags.BordersInnerV | ImGuiTableFlags.RowBg | ImGuiTableFlags.Resizable |
+                    ImGuiTableFlags.ScrollY | ImGuiTableFlags.SizingStretchProp;
+        if (!ImGui.BeginTable("##voiceRows", 7, flags, ImGui.GetContentRegionAvail()))
+            return;
+
+        ImGui.TableSetupColumn("Status", ImGuiTableColumnFlags.WidthFixed, 70 * ImGuiHelper.Scale);
+        ImGui.TableSetupColumn("Message", ImGuiTableColumnFlags.WidthStretch, 2.3f);
+        ImGui.TableSetupColumn("CRC", ImGuiTableColumnFlags.WidthFixed, 96 * ImGuiHelper.Scale);
+        ImGui.TableSetupColumn("INI", ImGuiTableColumnFlags.WidthFixed, 42 * ImGuiHelper.Scale);
+        ImGui.TableSetupColumn("UTF", ImGuiTableColumnFlags.WidthStretch, 1.2f);
+        ImGui.TableSetupColumn("Issue", ImGuiTableColumnFlags.WidthStretch, 1.3f);
+        ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.WidthFixed, 120 * ImGuiHelper.Scale);
+        ImGui.TableHeadersRow();
+
+        var clipper = new ImGuiListClipper();
+        clipper.Begin(rows.Length);
+        while (clipper.Step())
+        {
+            for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
+                DrawRow(rows[i], i);
+        }
+        ImGui.EndTable();
+    }
+
+    private void DrawRow(VoiceLineRow row, int index)
+    {
+        ImGui.TableNextRow();
+        ImGui.PushID(index);
+
+        ImGui.TableNextColumn();
+        ImGui.TextColored(row.Ok ? new Vector4(0.35f, 0.85f, 0.45f, 1) : new Vector4(0.95f, 0.45f, 0.35f, 1),
+            row.Ok ? $"{Icons.Check} OK" : $"{Icons.X} Bad");
+        ImGui.TableNextColumn();
+        ImGui.Text(row.Message);
+        ImGui.TableNextColumn();
+        ImGui.Text($"0x{row.Hash:X8}");
+        ImGui.TableNextColumn();
+        ImGui.Text(row.HasIni ? "yes" : "no");
+        ImGui.TableNextColumn();
+        ImGui.Text(row.UtfSummary);
+        if (ImGui.IsItemHovered() && !string.IsNullOrEmpty(row.UtfTooltip))
+            ImGui.SetTooltip(row.UtfTooltip);
+        ImGui.TableNextColumn();
+        ImGui.TextWrapped(row.Issue);
+        ImGui.TableNextColumn();
+        var isPlaying = IsPlaying(row);
+        if (ImGui.Button($"{(isPlaying ? Icons.Stop : Icons.Play)}##play", new Vector2(34 * ImGuiHelper.Scale, 0)))
+        {
+            if (isPlaying)
+                StopPlayback();
+            else
+                Play(row);
+        }
+        if (ImGui.IsItemHovered())
+            ImGui.SetTooltip(isPlaying ? "Stop this voice line." : "Play this voice line through Librelancer audio.");
+        ImGui.SameLine();
+        ImGui.BeginDisabled(row.FirstNode == null);
+        if (ImGui.Button($"{Icons.Export}##export", new Vector2(34 * ImGuiHelper.Scale, 0)))
+            Export(row);
+        if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+            ImGui.SetTooltip(row.FirstNode == null
+                ? "No UTF audio node is linked, so there is nothing to export."
+                : "Export the linked UTF audio node as a WAV file.");
+        ImGui.EndDisabled();
+
+        ImGui.PopID();
+    }
+
+    private void DrawPermutationIssues()
+    {
+        var props = context.GameData.Items.Ini.MsnVoiceProps.VoiceProps
+            .FirstOrDefault(x => x.Voice.Equals(selectedVoice.Nickname, StringComparison.OrdinalIgnoreCase));
+        if (props == null || props.PermutationCounts.Count == 0)
+            return;
+        context.GameData.Items.Ini.Voices.Voices.TryGetValue(selectedVoice.Nickname, out var voiceData);
+
+        foreach (var (line, expected) in props.PermutationCounts)
+        {
+            if (!MatchesPermutationSearch(line, expected))
+                continue;
+            var probeLimit = ProbePermutationLimit(expected);
+            var ini = GetPermutationNumbers(line, probeLimit, h =>
+                voiceData?.Messages.Any(m => FLHash.CreateID(m.Message) == h) == true);
+            var utf = GetPermutationNumbers(line, probeLimit, h => GetNodesForSelectedUtf(h).Count > 0);
+            var utfMax = utf.Count == 0 ? 0 : utf.Max();
+            var countExceedsUtf = utfMax == 0 || expected > utfMax;
+            var iniMissingUtf = NumbersMissingFrom(ini, utf);
+            if (!countExceedsUtf && iniMissingUtf.Count == 0)
+                continue;
+            if (statusFilter == 2 ||
+                statusFilter == 3 ||
+                (statusFilter == 4 && !countExceedsUtf && iniMissingUtf.Count == 0))
+                continue;
+
+            ImGui.TextColored(new Vector4(1f, 0.72f, 0.25f, 1f),
+                $"{Icons.Warning} {line} permutation_count warning");
+            ImGui.SameLine();
+            ImGui.TextDisabled(
+                $"Count: {expected}  INI: {FormatNumbers(ini)}  UTF: {FormatNumbers(utf)}  UTF max: {FormatMax(utfMax)}  INI missing UTF: {FormatNumbers(iniMissingUtf)}");
+            if (ImGui.IsItemHovered())
+                ImGui.SetTooltip(PermutationTooltip(line, expected, utfMax, iniMissingUtf));
+        }
+    }
+
+    private void RebuildRows()
+    {
+        if (selectedVoice == null)
+        {
+            rows = [];
+            return;
+        }
+
+        var voiceData = context.GameData.Items.Ini.Voices.Voices.GetValueOrDefault(selectedVoice.Nickname);
+        var byHash = new Dictionary<uint, VoiceLineRow>();
+        if (voiceData != null)
+        {
+            foreach (var msg in voiceData.Messages)
+            {
+                var hash = FLHash.CreateID(msg.Message);
+                var nodes = GetNodesForSelectedUtf(hash);
+                byHash[hash] = CreateRow(msg.Message, hash, true, nodes);
+            }
+        }
+
+        if (selectedVoice.UtfPath != null && TryGetUtfIndex(selectedVoice.UtfPath, out var index))
+        {
+            foreach (var node in index.Nodes)
+            {
+                if (byHash.ContainsKey(node.Hash))
+                    continue;
+                byHash[node.Hash] = CreateRow(node.NodeName, node.Hash, false, [node]);
+            }
+        }
+
+        IEnumerable<VoiceLineRow> filtered = byHash.Values;
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            filtered = filtered.Where(x =>
+                selectedVoice.Nickname.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                x.Message.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                x.Hash.ToString("X8").Contains(search, StringComparison.OrdinalIgnoreCase));
+        }
+        filtered = statusFilter switch
+        {
+            1 => filtered.Where(x => !x.Ok),
+            2 => filtered.Where(x => x.Ok),
+            3 => filtered.Where(x => !x.HasIni),
+            4 => filtered.Where(x => x.HasIni && x.FirstNode == null),
+            _ => filtered
+        };
+        rows = filtered.OrderBy(x => x.Message, StringComparer.OrdinalIgnoreCase).ToArray();
+    }
+
+    private VoiceLineRow CreateRow(string message, uint hash, bool hasIni, List<VoiceUtfNode> nodes)
+    {
+        var allNodes = nodesByHash.GetValueOrDefault(hash) ?? [];
+        var issues = new List<string>();
+        if (!hasIni)
+            issues.Add("Missing [Sound]");
+        if (nodes.Count == 0)
+            issues.Add("Missing UTF node");
+        if (messagesByHash.TryGetValue(hash, out var messages) && messages.Count > 1)
+            issues.Add("CRC collision");
+        if (nodes.Count > 1)
+            issues.Add("Duplicate UTF node");
+        var otherUtfs = allNodes
+            .Select(x => x.UtfPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        return new VoiceLineRow(
+            message,
+            hash,
+            hasIni,
+            nodes.FirstOrDefault(),
+            nodes.Count == 0 ? "-" : string.Join(", ", nodes.Select(x => x.NodeName)),
+            otherUtfs.Length > 1 ? "Same hash also exists in:\n" + string.Join("\n", otherUtfs) : "",
+            issues.Count == 0 ? "Linked" : string.Join("; ", issues),
+            issues.Count == 0);
+    }
+
+    private List<VoiceUtfNode> GetNodesForSelectedUtf(uint hash)
+    {
+        if (selectedVoice == null ||
+            selectedVoice.UtfPath == null ||
+            !TryGetUtfIndex(selectedVoice.UtfPath, out var index))
+            return [];
+        return index.ByHash.GetValueOrDefault(hash) ?? [];
+    }
+
+    private Dictionary<string, VoiceSourceInfo> BuildVoiceSources()
+    {
+        var sources = new Dictionary<string, VoiceSourceBuilder>(StringComparer.OrdinalIgnoreCase);
+        foreach (var path in context.GameData.Items.Ini.Freelancer.VoicePaths)
+        {
+            foreach (var section in IniFile.ParseFile(path, context.GameData.VFS))
+            {
+                if (!section.Name.Equals("voice", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                var voice = EntryString(section, "extend") ?? EntryString(section, "nickname");
+                if (string.IsNullOrWhiteSpace(voice))
+                    continue;
+                if (!sources.TryGetValue(voice, out var builder))
+                    sources[voice] = builder = new VoiceSourceBuilder();
+                builder.Add(path, section.Line, SourceKind(path));
+            }
+        }
+        return sources.ToDictionary(x => x.Key, x => x.Value.Build(), StringComparer.OrdinalIgnoreCase);
+    }
+
+    private Dictionary<string, List<PermutationSourceInfo>> BuildPermutationSources()
+    {
+        var result = new Dictionary<string, List<PermutationSourceInfo>>(StringComparer.OrdinalIgnoreCase);
+        var path = context.GameData.Items.Ini.Freelancer.DataPath + "MISSIONS\\voice_properties.ini";
+        if (!context.GameData.VFS.FileExists(path))
+            return result;
+
+        foreach (var section in IniFile.ParseFile(path, context.GameData.VFS))
+        {
+            if (!section.Name.Equals("mVoiceProp", StringComparison.OrdinalIgnoreCase))
+                continue;
+            var voice = EntryString(section, "voice");
+            if (string.IsNullOrWhiteSpace(voice))
+                continue;
+            foreach (var entry in section)
+            {
+                if (!entry.Name.Equals("permutation_count", StringComparison.OrdinalIgnoreCase) || entry.Count < 2)
+                    continue;
+                var line = entry[0].ToString();
+                var expected = entry[1].ToInt32();
+                var key = PermutationKey(voice, line);
+                if (!result.TryGetValue(key, out var sources))
+                    result[key] = sources = [];
+                sources.Add(new PermutationSourceInfo(path, section.Line, entry.Line, expected));
+            }
+        }
+        return result;
+    }
+
+    private string PermutationTooltip(string line, int expected, int utfMax, List<int> iniMissingUtf)
+    {
+        var tooltip =
+            "Declared in DATA\\MISSIONS\\voice_properties.ini.\n" +
+            "Count is permutation_count: the highest random variant the engine may try for this group.\n" +
+            "INI is matching [Sound] msg variants in the merged voice. UTF is matching audio nodes in the selected voice UTF.\n" +
+            "The numbered set may be sparse. This warns when permutation_count is higher than the highest UTF variant, or when a [Sound] variant has no UTF audio.";
+        if (utfMax == 0)
+            tooltip += "\nNo matching UTF variants were found for this group.";
+        else if (expected > utfMax)
+            tooltip += $"\npermutation_count {expected} is higher than UTF max {utfMax:D2}.";
+        if (iniMissingUtf.Count > 0)
+            tooltip += $"\n[Sound] variants without UTF audio: {FormatNumbers(iniMissingUtf)}";
+        var key = PermutationKey(selectedVoice.Nickname, line);
+        if (permutationSources.TryGetValue(key, out var sources))
+        {
+            tooltip += "\n";
+            tooltip += string.Join("\n", sources.Select(x =>
+                $"{x.Path}:{x.EntryLine}  expected {x.Expected}  [mVoiceProp] line {x.SectionLine}"));
+        }
+        else
+        {
+            tooltip += $"\nExpected {expected}. Source line was not found in the raw ini scan.";
+        }
+        return tooltip;
+    }
+
+    private bool MatchesPermutationSearch(string line, int expected)
+    {
+        if (string.IsNullOrWhiteSpace(search))
+            return true;
+        if (selectedVoice.Nickname.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+            line.Contains(search, StringComparison.OrdinalIgnoreCase))
+            return true;
+        for (int i = 1; i <= ProbePermutationLimit(expected); i++)
+        {
+            var hash = FLHash.CreateID($"{line}_{i:D2}-");
+            if (hash.ToString("X8").Contains(search, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    private static string EntryString(Section section, string name)
+    {
+        var entry = section.FirstOrDefault(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+        return entry is { Count: > 0 } ? entry[0].ToString() : null;
+    }
+
+    private static string SourceKind(string path)
+    {
+        var file = Path.GetFileName(path);
+        if (file.Contains("voices_base", StringComparison.OrdinalIgnoreCase))
+            return "Base";
+        if (file.Contains("voices_space", StringComparison.OrdinalIgnoreCase))
+            return "Space";
+        if (file.Contains("voices_mission", StringComparison.OrdinalIgnoreCase))
+            return "Mission";
+        if (file.Contains("voices_recognizable", StringComparison.OrdinalIgnoreCase))
+            return "Recognizable";
+        return "Other";
+    }
+
+    private static string PermutationKey(string voice, string line) =>
+        voice + "\0" + line;
+
+    private void BuildUtfIndexes()
+    {
+        foreach (var utf in GetUtfFiles(@"DATA\AUDIO"))
+        {
+            try
+            {
+                using var stream = context.GameData.VFS.Open(utf);
+                var index = AddUtfIndex(utf, stream);
+                foreach (var node in index.Nodes)
+                {
+                    if (!nodesByHash.TryGetValue(node.Hash, out var nodes))
+                        nodesByHash[node.Hash] = nodes = [];
+                    nodes.Add(node);
+                }
+            }
+            catch (Exception ex)
+            {
+                FLLog.Error("Voice Browser", $"{utf}: {ex.Message}");
+            }
+        }
+    }
+
+    private VoiceUtfIndex AddUtfIndex(string utf, Stream stream)
+    {
+        var index = new VoiceUtfIndex(utf, stream);
+        utfIndexes[utf] = index;
+        utfIndexes[CanonicalUtfPath(utf)] = index;
+        return index;
+    }
+
+    private bool TryGetUtfIndex(string utf, out VoiceUtfIndex index)
+    {
+        if (utfIndexes.TryGetValue(utf, out index) ||
+            utfIndexes.TryGetValue(CanonicalUtfPath(utf), out index))
+            return true;
+
+        try
+        {
+            if (!context.GameData.VFS.FileExists(utf))
+                return false;
+            using var stream = context.GameData.VFS.Open(utf);
+            index = AddUtfIndex(utf, stream);
+            foreach (var node in index.Nodes)
+            {
+                if (!nodesByHash.TryGetValue(node.Hash, out var nodes))
+                    nodesByHash[node.Hash] = nodes = [];
+                nodes.Add(node);
+            }
+            return true;
+        }
+        catch (Exception ex)
+        {
+            FLLog.Error("Voice Browser", $"{utf}: {ex.Message}");
+            index = null;
+            return false;
+        }
+    }
+
+    private IEnumerable<string> GetUtfFiles(string path)
+    {
+        foreach (var file in context.GameData.VFS.GetFiles(path))
+        {
+            if (file.EndsWith(".utf", StringComparison.OrdinalIgnoreCase))
+                yield return CombineVfs(path, file);
+        }
+        foreach (var dir in context.GameData.VFS.GetDirectories(path))
+        {
+            foreach (var file in GetUtfFiles(CombineVfs(path, dir)))
+                yield return file;
+        }
+    }
+
+    private void Play(VoiceLineRow row)
+    {
+        StopPlayback();
+        currentPlaybackId = PlaybackId(row);
+        if (row.HasIni)
+        {
+            currentInstance = context.Sounds.GetInstance(selectedVoice.Nickname, row.Hash);
+            currentInstance?.Play();
+        }
+        else if (row.FirstNode != null)
+        {
+            win.PlayBuffer(row.FirstNode.Data);
+        }
+    }
+
+    private void StopPlayback()
+    {
+        currentInstance?.Stop();
+        currentInstance = null;
+        currentPlaybackId = null;
+        win.StopBuffer();
+    }
+
+    private bool IsPlaying(VoiceLineRow row) =>
+        currentPlaybackId == PlaybackId(row) &&
+        (currentInstance is { Playing: true } || win.PlayingBuffer);
+
+    private string PlaybackId(VoiceLineRow row) =>
+        $"{selectedVoice?.Nickname}:{row.Hash:X8}:{row.HasIni}";
+
+    private void Export(VoiceLineRow row)
+    {
+        if (row.FirstNode == null)
+            return;
+        FileDialog.Save(path => File.WriteAllBytes(path, row.FirstNode.Data), wavFilters);
+    }
+
+    private static List<int> GetPermutationNumbers(string line, int max, Func<uint, bool> exists)
+    {
+        var result = new List<int>();
+        for (int i = 1; i <= max; i++)
+        {
+            var hash = FLHash.CreateID($"{line}_{i:D2}-");
+            if (exists(hash))
+                result.Add(i);
+        }
+        return result;
+    }
+
+    private static int ProbePermutationLimit(int expected) =>
+        Math.Clamp(expected + 16, 64, 999);
+
+    private static List<int> NumbersMissingFrom(List<int> required, List<int> available) =>
+        required.Where(x => !available.Contains(x)).ToList();
+
+    private static string FormatNumbers(List<int> numbers) =>
+        numbers.Count == 0 ? "-" : string.Join(", ", FormatNumberRanges(numbers));
+
+    private static string FormatMax(int value) =>
+        value <= 0 ? "-" : value.ToString("D2");
+
+    private static IEnumerable<string> FormatNumberRanges(List<int> numbers)
+    {
+        var ordered = numbers.OrderBy(x => x).Distinct().ToArray();
+        for (int i = 0; i < ordered.Length; i++)
+        {
+            var start = ordered[i];
+            var end = start;
+            while (i + 1 < ordered.Length && ordered[i + 1] == end + 1)
+            {
+                end = ordered[++i];
+            }
+            yield return start == end ? start.ToString("D2") : $"{start:D2}-{end:D2}";
+        }
+    }
+
+
+    private static string CombineVfs(string path, string file) =>
+        path.TrimEnd('\\', '/') + "\\" + file.TrimStart('\\', '/');
+
+    private static string CanonicalUtfPath(string path)
+    {
+        path = path.Replace('/', '\\');
+        var marker = "\\AUDIO\\";
+        var index = path.LastIndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (index >= 0)
+            return path[(index + 1)..].ToLowerInvariant();
+        if (path.StartsWith("AUDIO\\", StringComparison.OrdinalIgnoreCase))
+            return path.ToLowerInvariant();
+        return path.ToLowerInvariant();
+    }
+
+    private record VoiceEntry(string Nickname, string UtfPath, VoiceSourceInfo Source);
+
+    private record VoiceLineRow(
+        string Message,
+        uint Hash,
+        bool HasIni,
+        VoiceUtfNode FirstNode,
+        string UtfSummary,
+        string UtfTooltip,
+        string Issue,
+        bool Ok);
+
+    private record VoiceUtfNode(string UtfPath, string NodeName, uint Hash, byte[] Data);
+
+    private record VoiceSourceInfo(string KindLabel, List<string> Files, string Tooltip)
+    {
+        public static readonly VoiceSourceInfo Empty = new("Other", [], "No voice source file was found.");
+    }
+
+    private record PermutationSourceInfo(string Path, int SectionLine, int EntryLine, int Expected);
+
+    private class VoiceSourceBuilder
+    {
+        private readonly List<string> declarations = [];
+        private readonly HashSet<string> files = new(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> kinds = new(StringComparer.OrdinalIgnoreCase);
+
+        public void Add(string path, int line, string kind)
+        {
+            files.Add(path);
+            kinds.Add(kind);
+            declarations.Add($"{path}:{line}");
+        }
+
+        public VoiceSourceInfo Build()
+        {
+            var kind = kinds.Count == 1 ? kinds.First() : "Mixed";
+            var fileList = files.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToList();
+            return new VoiceSourceInfo(kind, fileList, string.Join("\n", declarations));
+        }
+    }
+
+    private class VoiceUtfIndex : UtfFile
+    {
+        public List<VoiceUtfNode> Nodes = [];
+        public Dictionary<uint, List<VoiceUtfNode>> ByHash = new();
+
+        public VoiceUtfIndex(string path, Stream stream)
+        {
+            foreach (var child in parseFile(path, stream).Children)
+            {
+                if (child is not LeafNode leaf)
+                    continue;
+                var hash = ParseHash(child.Name);
+                var node = new VoiceUtfNode(path, child.Name, hash, leaf.ByteArrayData);
+                Nodes.Add(node);
+                if (!ByHash.TryGetValue(hash, out var nodes))
+                    ByHash[hash] = nodes = [];
+                nodes.Add(node);
+            }
+        }
+
+        private static uint ParseHash(string name)
+        {
+            if (name.StartsWith("0x", StringComparison.OrdinalIgnoreCase) &&
+                uint.TryParse(name[2..], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var hash))
+                return hash;
+            return FLHash.CreateID(name);
+        }
+    }
+}

--- a/src/Editor/LancerEdit/MainWindow.cs
+++ b/src/Editor/LancerEdit/MainWindow.cs
@@ -663,6 +663,14 @@ namespace LancerEdit
                         AddTab(new MissionScriptEditorTab(OpenDataContext, this, x));
                     }, AppFilters.IniFilters, GetDataPath());
                 }
+                if (Theme.IconMenuItem(Icons.Images, "3DB Icon Browser", OpenDataContext != null))
+                {
+                    var fd = TabControl.Tabs.FirstOrDefault(x => x is ThreeDbIconBrowserTab);
+                    if (fd != null)
+                        TabControl.SetSelected(fd);
+                    else
+                        AddTab(new ThreeDbIconBrowserTab(this, OpenDataContext));
+                }
                 ImGui.Separator();
                 if (Theme.IconMenuItem(Icons.Fire, "Projectile Viewer", OpenDataContext != null))
                     AddTab(new ProjectileViewerTab(this, OpenDataContext));
@@ -1256,9 +1264,14 @@ namespace LancerEdit
                                 Type = ResourceUsageType.Material,
                                 MaterialId = matId,
                                 Name = ResolveMaterialName(matId),
-                                Missing = true
+                                Missing = true,
+                                Hint = miss.Hint
                             };
                             ResourceIndex[key] = usage;
+                        }
+                        else if (string.IsNullOrEmpty(usage.Hint))
+                        {
+                            usage.Hint = miss.Hint;
                         }
 
                         if (!string.IsNullOrEmpty(miss.Reference))
@@ -1342,6 +1355,7 @@ namespace LancerEdit
         public string Name; // texture name OR material display name
         public uint? MaterialId; // only for materials
         public bool Missing;
+        public string Hint;
 
         public HashSet<string> UsedBy = new(); // model / drawable names
         public HashSet<string> ProvidedBy = new(); // utf filenames (optional, can be empty)

--- a/src/Editor/LancerEdit/MainWindow.cs
+++ b/src/Editor/LancerEdit/MainWindow.cs
@@ -630,6 +630,14 @@ namespace LancerEdit
                 ImGui.Separator();
                 if (Theme.IconMenuItem(Icons.BookOpen, "Infocard Browser", OpenDataContext != null))
                     AddTab(new InfocardBrowserTab(OpenDataContext, this));
+                if (Theme.IconMenuItem(Icons.Video, "Voice Browser", OpenDataContext != null))
+                {
+                    var fd = TabControl.Tabs.FirstOrDefault(x => x is VoiceBrowserTab);
+                    if (fd != null)
+                        TabControl.SetSelected(fd);
+                    else
+                        AddTab(new VoiceBrowserTab(this, OpenDataContext));
+                }
                 if (Theme.IconMenuItem(Icons.Globe, "Universe Editor", OpenDataContext != null))
                 {
                     var fd = TabControl.Tabs.FirstOrDefault(x => x is UniverseEditorTab);
@@ -670,6 +678,22 @@ namespace LancerEdit
                         TabControl.SetSelected(fd);
                     else
                         AddTab(new ThreeDbIconBrowserTab(this, OpenDataContext));
+                }
+                if (Theme.IconMenuItem(Icons.Star, "Stars Browser", OpenDataContext != null))
+                {
+                    var fd = TabControl.Tabs.FirstOrDefault(x => x is StarsBrowserTab);
+                    if (fd != null)
+                        TabControl.SetSelected(fd);
+                    else
+                        AddTab(new StarsBrowserTab(this, OpenDataContext));
+                }
+                if (Theme.IconMenuItem(Icons.Sitemap, "Vignette Nodes Browser", OpenDataContext != null))
+                {
+                    var fd = TabControl.Tabs.FirstOrDefault(x => x is VignetteNodesBrowserTab);
+                    if (fd != null)
+                        TabControl.SetSelected(fd);
+                    else
+                        AddTab(new VignetteNodesBrowserTab(this, OpenDataContext));
                 }
                 ImGui.Separator();
                 if (Theme.IconMenuItem(Icons.Fire, "Projectile Viewer", OpenDataContext != null))

--- a/src/Editor/LancerEdit/Model/ModelViewer.cs
+++ b/src/Editor/LancerEdit/Model/ModelViewer.cs
@@ -105,6 +105,11 @@ namespace LancerEdit
         private VerticalTabLayout layout;
 
         public ModelViewer(string name, IDrawable drawable, MainWindow win, UtfTab parent, ModelNodes hprefs)
+            : this(name, drawable, win, parent, hprefs, null)
+        {
+        }
+
+        public ModelViewer(string name, IDrawable drawable, MainWindow win, UtfTab parent, ModelNodes hprefs, ResourceManager resources)
         {
             blenderEnabled = Blender.BlenderPathValid(win.Config.BlenderPath);
             selectedCam = win.Config.DefaultCameraMode;
@@ -116,7 +121,7 @@ namespace LancerEdit
             this.TabColor = parent.TabColor;
             this.hprefs = hprefs;
             rstate = win.RenderContext;
-            res = parent.DetachedResources ?? win.Resources;
+            res = resources ?? parent.DetachedResources ?? win.Resources;
             buffer = win.Commands;
             _window = win;
             SaveStrategy = parent.SaveStrategy;
@@ -1254,7 +1259,7 @@ namespace LancerEdit
 
         public override void DetectResources(List<MissingReference> missing, List<uint> matrefs, List<TextureReference> texrefs)
         {
-            ResourceDetection.DetectDrawable(Name, drawable, res, missing, matrefs, texrefs);
+            ResourceDetection.DetectDrawable(Name, drawable, res, missing, matrefs, texrefs, parent?.FilePath);
         }
 
 

--- a/src/Editor/LancerEdit/Resource/MissingReference.cs
+++ b/src/Editor/LancerEdit/Resource/MissingReference.cs
@@ -9,10 +9,19 @@ namespace LancerEdit
 	{
 		public string Missing;
 		public string Reference;
+		public string Hint;
 		public MissingReference(string m, string r)
 		{
 			Missing = m;
 			Reference = r;
+			Hint = null;
+		}
+
+		public MissingReference(string m, string r, string hint)
+		{
+			Missing = m;
+			Reference = r;
+			Hint = hint;
 		}
 	}
 }

--- a/src/Editor/LancerEdit/Resource/ResourceDetection.cs
+++ b/src/Editor/LancerEdit/Resource/ResourceDetection.cs
@@ -4,12 +4,15 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
+using LibreLancer.ContentEdit;
 using LibreLancer;
 using LibreLancer.Data;
 using LibreLancer.Graphics;
 using LibreLancer.Render.Materials;
 using LibreLancer.Resources;
+using LibreLancer.Utf;
 using LibreLancer.Utf.Cmp;
 using LibreLancer.Utf.Mat;
 namespace LancerEdit
@@ -46,16 +49,18 @@ namespace LancerEdit
     }
 	static class ResourceDetection
 	{
-		public static void DetectDrawable(string name, IDrawable drawable, ResourceManager res, List<MissingReference> missing, List<uint> matrefs, List<TextureReference> texrefs)
+		static readonly Dictionary<string, string> materialLibraryHints = new(StringComparer.OrdinalIgnoreCase);
+
+		public static void DetectDrawable(string name, IDrawable drawable, ResourceManager res, List<MissingReference> missing, List<uint> matrefs, List<TextureReference> texrefs, string sourcePath = null)
 		{
 			if (drawable is CmpFile)
 			{
 				var cmp = (CmpFile)drawable;
-				foreach (var part in cmp.ModelParts()) DetectResourcesModel(part.Model, name + ", " + part.Model.Path, res, missing, matrefs, texrefs);
+				foreach (var part in cmp.ModelParts()) DetectResourcesModel(part.Model, name + ", " + part.Model.Path, res, missing, matrefs, texrefs, sourcePath);
 			}
 			if (drawable is ModelFile)
 			{
-				DetectResourcesModel((ModelFile)drawable, name, res, missing, matrefs, texrefs);
+				DetectResourcesModel((ModelFile)drawable, name, res, missing, matrefs, texrefs, sourcePath);
 			}
 			if (drawable is SphFile)
 			{
@@ -77,26 +82,103 @@ namespace LancerEdit
 				}
 			}
 		}
-		static void DetectResourcesModel(ModelFile mdl, string mdlname, ResourceManager res, List<MissingReference> missing, List<uint> matrefs, List<TextureReference> texrefs)
+		static void DetectResourcesModel(ModelFile mdl, string mdlname, ResourceManager res, List<MissingReference> missing, List<uint> matrefs, List<TextureReference> texrefs, string sourcePath)
         {
             if (mdl.Levels.Length <= 0) return;
 			var lvl = mdl.Levels[0];
             var msh = res.FindMesh(lvl.MeshCrc);
-            if (msh == null) return;
+			if (msh == null) return;
 			for (int i = lvl.StartMesh; i < (lvl.StartMesh + lvl.MeshCount); i++)
             {
-                var mat = res.FindMaterial(msh.Meshes[i].MaterialCrc);
+                var materialCrc = msh.Meshes[i].MaterialCrc;
+                if (materialCrc == 0)
+                    continue;
+                var mat = res.FindMaterial(materialCrc);
 				if (mat == null)
 				{
-					var str = "Material: 0x" + msh.Meshes[i].MaterialCrc.ToString("X");
-					if (!HasMissing(missing, str)) missing.Add(new MissingReference(str, string.Format("{0}, VMesh(0x{1:X}) #{2}", mdlname, lvl.MeshCrc, i)));
+					var str = "Material: 0x" + materialCrc.ToString("X");
+					if (!HasMissing(missing, str)) missing.Add(new MissingReference(
+						str,
+						string.Format("{0}, VMesh(0x{1:X}) #{2}", mdlname, lvl.MeshCrc, i),
+						FindMaterialLibraryHint(sourcePath, materialCrc)));
 				}
 				else
 				{
-					if (!matrefs.Contains(msh.Meshes[i].MaterialCrc)) matrefs.Add(msh.Meshes[i].MaterialCrc);
+					if (!matrefs.Contains(materialCrc)) matrefs.Add(materialCrc);
 					DoMaterialRefs(mat, res, missing, texrefs, string.Format(" - {0} VMesh(0x{1:X}) #{2}", mdlname, lvl.MeshCrc, i));
 				}
 			}
+		}
+
+		static string FindMaterialLibraryHint(string sourcePath, uint materialCrc)
+		{
+			if (string.IsNullOrWhiteSpace(sourcePath))
+				return null;
+
+			var cacheKey = $"{sourcePath}|{materialCrc:X}";
+			if (materialLibraryHints.TryGetValue(cacheKey, out var cached))
+				return cached;
+
+			var hint = BuildMaterialLibraryHint(sourcePath, materialCrc);
+			materialLibraryHints[cacheKey] = hint;
+			return hint;
+		}
+
+		static string BuildMaterialLibraryHint(string sourcePath, uint materialCrc)
+		{
+			try
+			{
+				if (!File.Exists(sourcePath))
+					return null;
+
+				var directory = Path.GetDirectoryName(sourcePath);
+				if (string.IsNullOrEmpty(directory))
+					return null;
+
+				foreach (var matPath in Directory.EnumerateFiles(directory, "*.mat"))
+				{
+					if (MatFileContainsMaterial(matPath, materialCrc))
+					{
+						var rel = ToDataRelativePath(matPath);
+						return $"Recommended fix: add material_library = {rel}";
+					}
+				}
+
+				var expected = Path.ChangeExtension(sourcePath, ".mat");
+				var expectedRel = ToDataRelativePath(expected);
+				var existsText = File.Exists(expected)
+					? "The same-name MAT exists but does not contain this CRC."
+					: "No adjacent MAT containing this CRC was found.";
+				return $"{existsText} Check material_library. Candidate: material_library = {expectedRel}";
+			}
+			catch (Exception ex)
+			{
+				return $"Could not inspect adjacent MAT files: {ex.Message}";
+			}
+		}
+
+		static bool MatFileContainsMaterial(string matPath, uint materialCrc)
+		{
+			try
+			{
+				var utf = new EditableUtf(matPath);
+				UtfLoader.LoadResourceNode(utf.Export(), null, out var mat, out _, out _);
+				return mat?.Materials.ContainsKey(materialCrc) == true;
+			}
+			catch
+			{
+				return false;
+			}
+		}
+
+		static string ToDataRelativePath(string path)
+		{
+			var normalized = path.Replace('/', '\\');
+			var marker = "\\DATA\\";
+			var idx = normalized.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+			if (idx >= 0)
+				return normalized.Substring(idx + marker.Length);
+			return Path.GetFileName(path);
 		}
 
 		static void DoMaterialRefs(Material m, ResourceManager res, List<MissingReference> missing, List<TextureReference> texrefs, string refstr)

--- a/src/Editor/LancerEdit/Resource/ResourcesTab.cs
+++ b/src/Editor/LancerEdit/Resource/ResourcesTab.cs
@@ -155,6 +155,14 @@ namespace LancerEdit
                     return false;
             }
 
+            if (!string.IsNullOrEmpty(sourceFilter))
+            {
+                if (!u.ProvidedBy.Any(x =>
+                        x.Contains(sourceFilter, StringComparison.OrdinalIgnoreCase)) &&
+                    (u.Hint == null || !u.Hint.Contains(sourceFilter, StringComparison.OrdinalIgnoreCase)))
+                    return false;
+            }
+
             return true;
         }
 
@@ -211,7 +219,16 @@ namespace LancerEdit
 
             if (u.ProvidedBy.Count == 0)
             {
-                ImGui.TextDisabled("-");
+                if (!string.IsNullOrEmpty(u.Hint))
+                {
+                    ImGui.TextColored(color, u.Hint);
+                    if (ImGui.IsItemHovered())
+                        ImGui.SetTooltip(u.Hint);
+                }
+                else
+                {
+                    ImGui.TextDisabled("-");
+                }
                 return;
             }
 
@@ -255,6 +272,8 @@ namespace LancerEdit
             {
                 if (ImGui.MenuItem("Copy Material CRC"))
                     win.SetClipboardText($"0x{u.MaterialId.Value:X}");
+                if (!string.IsNullOrEmpty(u.Hint) && ImGui.MenuItem("Copy Recommendation"))
+                    win.SetClipboardText(u.Hint);
             }
 
             ImGui.EndPopup();

--- a/src/Editor/LancerEdit/Resource/ThreeDbIconBrowserTab.cs
+++ b/src/Editor/LancerEdit/Resource/ThreeDbIconBrowserTab.cs
@@ -1,0 +1,343 @@
+// MIT License - Copyright (c) Callum McGing
+// This file is subject to the terms and conditions defined in
+// LICENSE, which is part of this source code package
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using ImGuiNET;
+using LibreLancer.Graphics;
+using LibreLancer.ImUI;
+using LibreLancer.Resources;
+using LibreLancer.Utf;
+
+namespace LancerEdit;
+
+public class ThreeDbIconBrowserTab : EditorTab
+{
+    const int LoadsPerFrame = 4;
+
+    static readonly ThreeDbIconCollectionDefinition[] CollectionDefinitions =
+    [
+        new(
+            "Map Game Object Icons",
+            @"DATA\INTERFACE\NEURONET\NAVMAP\NEWNAVMAP\SPACEOBJECTS",
+            false),
+        new(
+            "Base Map Icons",
+            @"DATA\INTERFACE\NEURONET\NAVMAP\NEWNAVMAP",
+            false),
+    ];
+
+    readonly MainWindow win;
+    readonly GameDataContext context;
+    readonly List<ThreeDbIconCollection> collections = [];
+    readonly List<ThreeDbIconEntry> filtered = [];
+
+    string search = "";
+    int selectedCollection = 0;
+    int page = 0;
+    bool needsFilter = true;
+
+    public ThreeDbIconBrowserTab(MainWindow win, GameDataContext context)
+    {
+        this.win = win;
+        this.context = context;
+        Title = "3DB Icon Browser";
+        BuildCollections();
+    }
+
+    void BuildCollections()
+    {
+        foreach (var definition in CollectionDefinitions)
+        {
+            var files = GetThreeDbFiles(definition.Path, definition.Recursive)
+                .Select(path => new ThreeDbIconEntry(definition.Name, path))
+                .OrderBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            collections.Add(new ThreeDbIconCollection(definition.Name, definition.Path, files));
+        }
+    }
+
+    IEnumerable<string> GetThreeDbFiles(string path, bool recursive)
+    {
+        foreach (var file in context.GameData.VFS.GetFiles(path))
+        {
+            if (file.EndsWith(".3db", StringComparison.OrdinalIgnoreCase))
+                yield return CombineVfs(path, file);
+        }
+
+        if (!recursive)
+            yield break;
+
+        foreach (var dir in context.GameData.VFS.GetDirectories(path))
+        {
+            foreach (var file in GetThreeDbFiles(CombineVfs(path, dir), true))
+                yield return file;
+        }
+    }
+
+    static string CombineVfs(string path, string file) =>
+        path.TrimEnd('\\', '/') + "\\" + file.TrimStart('\\', '/');
+
+    public override void Draw(double elapsed)
+    {
+        DrawToolbar();
+        ImGui.Separator();
+
+        if (needsFilter)
+            ApplyFilter();
+
+        var cellWidth = 170 * ImGuiHelper.Scale;
+        var thumb = 96 * ImGuiHelper.Scale;
+        var columns = GetGridColumns(cellWidth);
+        var pageSize = GetDynamicPageSize(columns, thumb);
+        var totalPages = Math.Max(1, (int)Math.Ceiling(filtered.Count / (double)pageSize));
+        page = Math.Clamp(page, 0, totalPages - 1);
+
+        var start = page * pageSize;
+        var pageItems = filtered.Skip(start).Take(pageSize).ToArray();
+        LoadVisiblePreviews(pageItems);
+        DrawLoadingProgress();
+        DrawPager(totalPages, pageSize);
+        DrawGrid(pageItems, columns, thumb, cellWidth);
+    }
+
+    void DrawToolbar()
+    {
+        ImGui.SetNextItemWidth(260 * ImGuiHelper.Scale);
+        if (ImGui.InputTextWithHint("##search3db", "Search 3DB icons", ref search, 128))
+        {
+            page = 0;
+            needsFilter = true;
+        }
+
+        ImGui.SameLine();
+        var names = new[] { "All Collections" }.Concat(collections.Select(x => x.Name)).ToArray();
+        ImGui.SetNextItemWidth(260 * ImGuiHelper.Scale);
+        if (ImGui.Combo("Collection", ref selectedCollection, names, names.Length))
+        {
+            page = 0;
+            needsFilter = true;
+        }
+
+        ImGui.SameLine();
+        ImGui.TextDisabled($"{filtered.Count} icons");
+    }
+
+    void ApplyFilter()
+    {
+        filtered.Clear();
+        IEnumerable<ThreeDbIconEntry> src = selectedCollection == 0
+            ? collections.SelectMany(x => x.Entries)
+            : collections[selectedCollection - 1].Entries;
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            src = src.Where(x =>
+                x.Name.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                x.Path.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                x.Collection.Contains(search, StringComparison.OrdinalIgnoreCase));
+        }
+
+        filtered.AddRange(src);
+        needsFilter = false;
+    }
+
+    void LoadVisiblePreviews(IReadOnlyList<ThreeDbIconEntry> entries)
+    {
+        var loaded = 0;
+        foreach (var entry in entries)
+        {
+            if (entry.Loaded)
+                continue;
+            LoadPreview(entry);
+            loaded++;
+            if (loaded >= LoadsPerFrame)
+                break;
+        }
+        if (entries.Any(x => !x.Loaded))
+            ImGuiHelper.AnimatingElement();
+    }
+
+    void LoadPreview(ThreeDbIconEntry entry)
+    {
+        entry.Loaded = true;
+        try
+        {
+            context.Resources.LoadResourceFile(entry.Path);
+            var textureName = context.Resources.TexturesInFile(entry.Path).FirstOrDefault();
+            if (textureName == null)
+            {
+                using var stream = context.GameData.VFS.Open(entry.Path);
+                UtfLoader.LoadResourceFile(stream, entry.Path, context.Resources, out var mat, out var txm, out _);
+                textureName = txm?.Textures.Keys.FirstOrDefault();
+                if (textureName == null && mat != null)
+                {
+                    var materialTextureNames = mat.Materials.Values
+                        .SelectMany(GetMaterialTextureNames)
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToArray();
+                    textureName = materialTextureNames.FirstOrDefault(x => context.Resources.FindTexture(x) is Texture2D) ??
+                                  materialTextureNames.FirstOrDefault();
+                }
+            }
+            if (textureName == null)
+            {
+                entry.Error = "No texture library or material texture reference";
+                return;
+            }
+            entry.TextureName = textureName;
+            if (context.Resources.FindTexture(textureName) is Texture2D tex)
+            {
+                entry.Texture = tex;
+                entry.TextureId = ImGuiHelper.RegisterTexture(tex);
+            }
+            else
+            {
+                entry.Error = $"Texture '{textureName}' not loaded";
+            }
+        }
+        catch (Exception ex)
+        {
+            entry.Error = ex.Message;
+        }
+    }
+
+    static IEnumerable<string> GetMaterialTextureNames(LibreLancer.Utf.Mat.Material material)
+    {
+        if (!string.IsNullOrWhiteSpace(material.DtName))
+            yield return material.DtName;
+        if (!string.IsNullOrWhiteSpace(material.EtName))
+            yield return material.EtName;
+        if (!string.IsNullOrWhiteSpace(material.BtName))
+            yield return material.BtName;
+        if (!string.IsNullOrWhiteSpace(material.NtName))
+            yield return material.NtName;
+        if (!string.IsNullOrWhiteSpace(material.DmName))
+            yield return material.DmName;
+        if (!string.IsNullOrWhiteSpace(material.Dm0Name))
+            yield return material.Dm0Name;
+        if (!string.IsNullOrWhiteSpace(material.Dm1Name))
+            yield return material.Dm1Name;
+        if (!string.IsNullOrWhiteSpace(material.MtName))
+            yield return material.MtName;
+        if (!string.IsNullOrWhiteSpace(material.RtName))
+            yield return material.RtName;
+        if (!string.IsNullOrWhiteSpace(material.NmName))
+            yield return material.NmName;
+    }
+
+    void DrawLoadingProgress()
+    {
+        var all = filtered.Count;
+        if (all == 0)
+            return;
+        var loaded = filtered.Count(x => x.Loaded);
+        if (loaded >= all)
+            return;
+
+        ImGui.Spacing();
+        ImGui.Text($"{Icons.SyncAlt} Loading previews {loaded}/{all}");
+        ImGui.ProgressBar(loaded / (float)all, new Vector2(-1, 0));
+        ImGui.Spacing();
+    }
+
+    int GetGridColumns(float cellWidth) =>
+        Math.Max(1, (int)(ImGui.GetContentRegionAvail().X / cellWidth));
+
+    int GetDynamicPageSize(int columns, float thumb)
+    {
+        var cardHeight = thumb + 76 * ImGuiHelper.Scale;
+        var reservedHeight = 42 * ImGuiHelper.Scale;
+        if (filtered.Any(x => !x.Loaded))
+            reservedHeight += 48 * ImGuiHelper.Scale;
+        var availableHeight = Math.Max(cardHeight, ImGui.GetContentRegionAvail().Y - reservedHeight);
+        var rows = Math.Max(1, (int)(availableHeight / cardHeight));
+        return Math.Max(columns, columns * rows);
+    }
+
+    void DrawPager(int totalPages, int pageSize)
+    {
+        if (ImGui.Button(Icons.ArrowLeft.ToString(), new Vector2(34 * ImGuiHelper.Scale, 0)) && page > 0)
+            page--;
+        ImGui.SameLine();
+        ImGui.Text($"Page {page + 1} / {totalPages}   {pageSize} per page");
+        ImGui.SameLine();
+        if (ImGui.Button(Icons.ArrowRight.ToString(), new Vector2(34 * ImGuiHelper.Scale, 0)) && page + 1 < totalPages)
+            page++;
+    }
+
+    void DrawGrid(IReadOnlyList<ThreeDbIconEntry> entries, int columns, float thumb, float cellWidth)
+    {
+        if (!ImGui.BeginTable("##3dbicons", columns, ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.PadOuterX))
+            return;
+
+        foreach (var entry in entries)
+        {
+            ImGui.TableNextColumn();
+            ImGui.PushID(entry.Path);
+            DrawIconCard(entry, thumb, cellWidth);
+            ImGui.PopID();
+        }
+
+        ImGui.EndTable();
+    }
+
+    void DrawIconCard(ThreeDbIconEntry entry, float thumb, float cellWidth)
+    {
+        var imageSize = new Vector2(thumb);
+        if (entry.TextureId.HasValue)
+        {
+            if (ImGui.ImageButton("preview", entry.TextureId.Value, imageSize, new Vector2(0, 1), new Vector2(1, 0)))
+                OpenFull(entry);
+        }
+        else
+        {
+            ImGui.Button(entry.Loaded ? Icons.Warning.ToString() : Icons.SyncAlt.ToString(), imageSize);
+        }
+
+        if (ImGui.IsItemHovered())
+        {
+            ImGui.BeginTooltip();
+            ImGui.Text(entry.Name);
+            ImGui.Text(entry.Path);
+            if (!string.IsNullOrEmpty(entry.TextureName))
+                ImGui.Text("Texture: " + entry.TextureName);
+            if (!string.IsNullOrEmpty(entry.Error))
+                ImGui.TextColored(Theme.ErrorTextColor, entry.Error);
+            ImGui.EndTooltip();
+        }
+
+        var label = entry.Name;
+        if (label.Length > 24)
+            label = label.Substring(0, 21) + "...";
+        ImGui.TextWrapped(label);
+        ImGui.TextDisabled(entry.Collection);
+        if (ImGui.Button("Open Full", new Vector2(cellWidth - 18 * ImGuiHelper.Scale, 0)))
+            OpenFull(entry);
+    }
+
+    void OpenFull(ThreeDbIconEntry entry)
+    {
+        if (entry.Texture != null)
+            win.AddTab(new TextureViewer(entry.Name, entry.Texture, null, false));
+    }
+
+    record ThreeDbIconCollectionDefinition(string Name, string Path, bool Recursive);
+    record ThreeDbIconCollection(string Name, string Path, List<ThreeDbIconEntry> Entries);
+
+    class ThreeDbIconEntry(string collection, string path)
+    {
+        public string Collection = collection;
+        public string Path = path;
+        public string Name = System.IO.Path.GetFileName(path);
+        public bool Loaded;
+        public string TextureName;
+        public Texture2D Texture;
+        public ImTextureRef? TextureId;
+        public string Error;
+    }
+}

--- a/src/Editor/LancerEdit/Utf/UtfTab.cs
+++ b/src/Editor/LancerEdit/Utf/UtfTab.cs
@@ -15,6 +15,7 @@ using LibreLancer;
 using LibreLancer.ContentEdit;
 using LibreLancer.ContentEdit.Model;
 using LibreLancer.Data;
+using LibreLancer.Data.GameData;
 using LibreLancer.Dialogs;
 using LibreLancer.Graphics;
 using LibreLancer.ImageLib;
@@ -37,6 +38,10 @@ namespace LancerEdit
         List<JointMapView> jointViews = new List<JointMapView>();
         private HashSet<uint> materials = new();
         private HashSet<string> textures = new(StringComparer.OrdinalIgnoreCase);
+        private LUtfNode inlineTextureNode;
+        private Texture2D inlineTexturePreview;
+        private TextureCube inlineCubePreview;
+        private ImTextureRef? inlineTextureId;
 
         public GameResourceManager DetachedResources;
         public int DetachedResourceCount;
@@ -139,6 +144,7 @@ namespace LancerEdit
 
         public override void Dispose()
         {
+            ClearInlineTexturePreview();
             DereferenceDetached();
             main.Resources.RemoveResourcesForId(Unique.ToString());
         }
@@ -156,6 +162,86 @@ namespace LancerEdit
             strings.Reverse();
             var path = string.Join("/", strings);
             return path;
+        }
+
+        bool TryGetGameDataDrawable(out IDrawable drawable, out ResourceManager resources)
+        {
+            drawable = null;
+            resources = null;
+
+            if (main.OpenDataContext == null || string.IsNullOrEmpty(FilePath))
+                return false;
+
+            var targetPath = Path.GetFullPath(FilePath);
+            var items = main.OpenDataContext.GameData.Items;
+            IDrawable foundDrawable = null;
+            ResourceManager foundResources = null;
+
+            bool Matches(ResolvedModel mdl)
+            {
+                if (mdl?.ModelFile == null)
+                    return false;
+                var modelPath = mdl.ModelFile;
+                if (!Path.IsPathRooted(modelPath))
+                    modelPath = Path.Combine(main.OpenDataContext.Folder, modelPath);
+                return string.Equals(Path.GetFullPath(modelPath), targetPath, StringComparison.OrdinalIgnoreCase);
+            }
+
+            bool TryLoad(ResolvedModel mdl)
+            {
+                if (!Matches(mdl))
+                    return false;
+
+                var loaded = mdl.LoadFile(main.OpenDataContext.Resources);
+                foundDrawable = loaded?.Drawable;
+                foundResources = main.OpenDataContext.Resources;
+                return foundDrawable != null;
+            }
+
+            foreach (var arch in items.Archetypes)
+                if (TryLoad(arch.ModelFile))
+                {
+                    drawable = foundDrawable;
+                    resources = foundResources;
+                    return true;
+                }
+            foreach (var ship in items.Ships)
+                if (TryLoad(ship.ModelFile))
+                {
+                    drawable = foundDrawable;
+                    resources = foundResources;
+                    return true;
+                }
+            foreach (var asteroid in items.Asteroids)
+                if (TryLoad(asteroid.ModelFile))
+                {
+                    drawable = foundDrawable;
+                    resources = foundResources;
+                    return true;
+                }
+            foreach (var asteroid in items.DynamicAsteroids)
+                if (TryLoad(asteroid.ModelFile))
+                {
+                    drawable = foundDrawable;
+                    resources = foundResources;
+                    return true;
+                }
+            foreach (var simple in items.SimpleObjects)
+                if (TryLoad(simple.Model))
+                {
+                    drawable = foundDrawable;
+                    resources = foundResources;
+                    return true;
+                }
+            foreach (var equipment in items.Equipment)
+                if (TryLoad(equipment.ModelFile))
+                {
+                    drawable = foundDrawable;
+                    resources = foundResources;
+                    return true;
+                }
+
+            return false;
         }
 
         public void GenerateTangents()
@@ -270,11 +356,16 @@ namespace LancerEdit
                 if (tb.ButtonItem("View Model"))
                 {
                     IDrawable drawable = null;
+                    ResourceManager modelResources = null;
                     ModelNodes hpn = new ModelNodes();
                     hpn.RootNode = Utf.Root;
                     try
                     {
-                        drawable = LibreLancer.Utf.UtfLoader.GetDrawable(Utf.Export(), main.Resources);
+                        if (!TryGetGameDataDrawable(out drawable, out modelResources))
+                        {
+                            drawable = LibreLancer.Utf.UtfLoader.GetDrawable(Utf.Export(), main.Resources);
+                            modelResources = main.Resources;
+                        }
                         if (Utf.Root.Children.Any((x) => x.Name.Equals("cmpnd", StringComparison.OrdinalIgnoreCase)))
                         {
                             foreach (var child in Utf.Root.Children.Where((x) => x.Name.EndsWith(".3db", StringComparison.OrdinalIgnoreCase)))
@@ -301,7 +392,7 @@ namespace LancerEdit
                     if (drawable != null)
                     {
                         ReferenceDetached();
-                        main.AddTab(new ModelViewer(DocumentName, drawable, main, this, hpn));
+                        main.AddTab(new ModelViewer(DocumentName, drawable, main, this, hpn, modelResources));
                     }
                 }
 
@@ -498,6 +589,7 @@ namespace LancerEdit
                             ImGui.Text(((int*)ptr)[i].ToString());
                         }
                     }
+                    DrawInlineTexturePreview(selectedNode);
                 }
                 else
                 {
@@ -545,13 +637,7 @@ namespace LancerEdit
                     try
                     {
 #endif
-                    using (var stream = new MemoryStream(selectedNode.Data))
-                    {
-                        if (DDS.StreamIsDDS(stream))
-                            tex = DDS.FromStream(main.RenderContext, stream);
-                        else
-                            tex = TGA.TextureFromStream(main.RenderContext, stream);
-                    }
+                    tex = LoadTextureFromNode(selectedNode);
                     var title = string.Format("{0} ({1})", selectedNode.Name, Title);
                     if (tex is Texture2D tex2d)
                     {
@@ -709,6 +795,69 @@ namespace LancerEdit
             }
             foreach (var jmv in removeJmv) jointViews.Remove(jmv);
             ImGui.EndChild();
+        }
+
+        Texture LoadTextureFromNode(LUtfNode node)
+        {
+            if (node?.Data == null || node.Data.Length == 0)
+                return null;
+            using var stream = new MemoryStream(node.Data);
+            if (DDS.StreamIsDDS(stream))
+                return DDS.FromStream(main.RenderContext, stream);
+            return TGA.TextureFromStream(main.RenderContext, stream);
+        }
+
+        void ClearInlineTexturePreview()
+        {
+            if (inlineTexturePreview != null)
+            {
+                ImGuiHelper.DeregisterTexture(inlineTexturePreview);
+                inlineTexturePreview.Dispose();
+            }
+            inlineCubePreview?.Dispose();
+            inlineTexturePreview = null;
+            inlineCubePreview = null;
+            inlineTextureId = null;
+            inlineTextureNode = null;
+        }
+
+        void DrawInlineTexturePreview(LUtfNode node)
+        {
+            if (inlineTextureNode != node)
+            {
+                ClearInlineTexturePreview();
+                inlineTextureNode = node;
+                try
+                {
+                    var tex = LoadTextureFromNode(node);
+                    switch (tex)
+                    {
+                        case Texture2D tex2d:
+                            inlineTexturePreview = tex2d;
+                            inlineTextureId = ImGuiHelper.RegisterTexture(tex2d);
+                            break;
+                        case TextureCube cube:
+                            inlineCubePreview = cube;
+                            break;
+                    }
+                }
+                catch
+                {
+                    inlineTextureNode = node;
+                }
+            }
+
+            if (inlineTexturePreview == null || inlineTextureId == null)
+                return;
+
+            ImGui.Spacing();
+            ImGui.Text("Texture Preview:");
+            var maxSize = Math.Min(256 * ImGuiHelper.Scale, ImGui.GetContentRegionAvail().X);
+            var scale = Math.Min(maxSize / inlineTexturePreview.Width, maxSize / inlineTexturePreview.Height);
+            scale = Math.Clamp(scale, 0.05f, 1f);
+            var size = new Vector2(inlineTexturePreview.Width, inlineTexturePreview.Height) * scale;
+            ImGui.Image(inlineTextureId.Value, size, new Vector2(0, 1), new Vector2(1, 0));
+            ImGui.TextDisabled($"{inlineTexturePreview.Width} x {inlineTexturePreview.Height} {inlineTexturePreview.Format}");
         }
 
         void ImportTexture()

--- a/src/Editor/LibreLancer.ContentEdit/RandomMissions/VignetteParamsCompiler.cs
+++ b/src/Editor/LibreLancer.ContentEdit/RandomMissions/VignetteParamsCompiler.cs
@@ -40,7 +40,7 @@ public class VignetteParamsCompiler
                 return new VIfElse(lexer);
             if(lexer.IsIdentifier("call"))
                 return new VCall(lexer);
-            if (lexer.IsIdentifier("err_unimplemented"))
+            if (lexer.IsIdentifier("err_unimplemented") || lexer.IsIdentifier("noop"))
                 return new VUnimplemented(lexer);
             if (lexer.IsIdentifier("doc"))
                 return new VDoc(lexer);
@@ -347,7 +347,7 @@ public class VignetteParamsCompiler
         public VUnimplemented(Lexer lexer):
             base(lexer.Source, lexer.Current)
         {
-            if (!lexer.IsIdentifier("err_unimplemented"))
+            if (!lexer.IsIdentifier("err_unimplemented") && !lexer.IsIdentifier("noop"))
                 throw new InvalidOperationException();
             Def = lexer.Current;
             lexer.Next();

--- a/src/Editor/LibreLancer.ContentEdit/RandomMissions/VignetteParamsDecompiler.cs
+++ b/src/Editor/LibreLancer.ContentEdit/RandomMissions/VignetteParamsDecompiler.cs
@@ -8,6 +8,8 @@ namespace LibreLancer.ContentEdit.RandomMissions;
 
 public static class VignetteParamsDecompiler
 {
+    const string Noop = "noop; # no branch in original INI";
+
     static bool IsEmptyError(VignetteAst ast)
     {
         if (ast is not AstData dat)
@@ -29,7 +31,7 @@ public static class VignetteParamsDecompiler
     {
         if (IsEmptyError(node))
         {
-            writer.AppendLine("err_unimplemented;");
+            writer.AppendLine(Noop);
             return;
         }
         if (!implement && references[node.Id] > 1)
@@ -55,21 +57,47 @@ public static class VignetteParamsDecompiler
                 WriteNode(ifElse.Children[^1], writer, false, references, groups, false);
                 writer.UnIndent();
             }
+            else if (ifElse.Conditions.Count == 1)
+            {
+                writer.AppendLine("else");
+                writer.Indent();
+                writer.AppendLine(Noop);
+                writer.UnIndent();
+            }
             writer.AppendLine("end");
         }
         else if (node is AstDecision dec)
         {
             var condA = dec.GroupA != null ? $"group ({groups[FormatGroup(dec.GroupA)]})" : dec.Decision.Nickname;
-            var b = dec.GroupB != null ? $"elif group({groups[FormatGroup(dec.GroupB)]})" : "else";
+            if (dec.Children.Count == 0)
+            {
+                writer.AppendLine($"if {condA}");
+                writer.Indent();
+                writer.AppendLine(Noop);
+                writer.UnIndent();
+                writer.AppendLine("end");
+                return;
+            }
 
             writer.AppendLine($"if {condA}");
             writer.Indent();
             WriteNode(dec.Children[0], writer, dec.GroupA != null, references, groups, false);
             writer.UnIndent();
-            writer.AppendLine(b);
-            writer.Indent();
-            WriteNode(dec.Children[^1], writer, dec.GroupB != null, references, groups, false);
-            writer.UnIndent();
+            if (dec.Children.Count > 1)
+            {
+                var b = dec.GroupB != null ? $"elif group({groups[FormatGroup(dec.GroupB)]})" : "else";
+                writer.AppendLine(b);
+                writer.Indent();
+                WriteNode(dec.Children[^1], writer, dec.GroupB != null, references, groups, false);
+                writer.UnIndent();
+            }
+            else
+            {
+                writer.AppendLine("else");
+                writer.Indent();
+                writer.AppendLine(Noop);
+                writer.UnIndent();
+            }
             writer.AppendLine("end");
         }
         else if (node is AstDoc doc)
@@ -83,7 +111,7 @@ public static class VignetteParamsDecompiler
         else if (node is AstData data)
         {
             if (!data.Data.Implemented)
-                writer.AppendLine("err_unimplemented;");
+                writer.AppendLine(Noop);
             if (!branchParent && data.Data.OfferGroup?.Length > 0)
                 writer.AppendLine($"offer_group {groups[FormatGroup(data.Data.OfferGroup)]};");
             if(data.Data.HostileGroup?.Length > 0)
@@ -189,13 +217,15 @@ public static class VignetteParamsDecompiler
             if (kv.Value is AstDecision dec &&
                 dec.Decision.Nickname.Equals("branch", StringComparison.OrdinalIgnoreCase))
             {
-                if (dec.Children[0] is not AstData d1 ||
+                if (dec.Children.Count == 0 ||
+                    dec.Children[0] is not AstData d1 ||
                     d1.Data.OfferGroup?.Length <= 0)
                 {
-                    throw new Exception("Invalid branch node");
+                    continue;
                 }
                 dec.GroupA = d1.Data.OfferGroup;
-                if (dec.Children[1] is AstData d2 &&
+                if (dec.Children.Count > 1 &&
+                    dec.Children[1] is AstData d2 &&
                     d2.Data.OfferGroup?.Length > 0)
                 {
                     dec.GroupB = d2.Data.OfferGroup;
@@ -211,7 +241,8 @@ public static class VignetteParamsDecompiler
                 continue;
             if (n is AstDecision dec)
             {
-                if (dec.Children[1] is AstDecision dec2)
+                if (dec.Children.Count > 1 &&
+                    dec.Children[1] is AstDecision { Children.Count: > 1 } dec2)
                 {
                     // Set up if/else node with multiple conditions
                     var ifElse = new AstIfElse(newId++);
@@ -228,7 +259,8 @@ public static class VignetteParamsDecompiler
             }
             else if (n is AstIfElse ie)
             {
-                if (ie.Children[^1] is AstDecision dec2)
+                if (ie.Children.Count > 0 &&
+                    ie.Children[^1] is AstDecision { Children.Count: > 1 } dec2)
                 {
                     // Add another condition node
                     ie.Children.RemoveAt(ie.Children.Count - 1);

--- a/src/Editor/LibreLancer.ImUI/ColorTextEdit.cs
+++ b/src/Editor/LibreLancer.ImUI/ColorTextEdit.cs
@@ -31,6 +31,15 @@ public class ColorTextEdit : IDisposable
     static extern void igExtTextEditorGetCoordinates(IntPtr textedit, out int x, out int y);
 
     [DllImport("cimgui")]
+    static extern void igExtTextEditorSetCursor(IntPtr textedit, int line, int column);
+
+    [DllImport("cimgui")]
+    static extern void igExtTextEditorSelectLine(IntPtr textedit, int line);
+
+    [DllImport("cimgui")]
+    static extern void igExtTextEditorScrollToLine(IntPtr textedit, int line);
+
+    [DllImport("cimgui")]
     static extern void igExtTextEditorFree(IntPtr textedit);
 
     [DllImport("cimgui")]
@@ -48,6 +57,7 @@ public class ColorTextEdit : IDisposable
     private IntPtr textedit;
     private bool textChanged = false;
     private int lastUndoIndex = 0;
+    private bool lineNavigationUnavailable;
 
     public ColorTextEdit()
     {
@@ -92,6 +102,26 @@ public class ColorTextEdit : IDisposable
     {
         igExtTextEditorGetCoordinates(textedit, out int x, out int y);
         return new Point(x,y);
+    }
+
+    public bool GoToLine(int line)
+    {
+        if (lineNavigationUnavailable)
+            return false;
+
+        var zeroBased = Math.Max(0, line - 1);
+        try
+        {
+            igExtTextEditorSetCursor(textedit, zeroBased, 0);
+            igExtTextEditorSelectLine(textedit, zeroBased);
+            igExtTextEditorScrollToLine(textedit, zeroBased);
+            return true;
+        }
+        catch (EntryPointNotFoundException)
+        {
+            lineNavigationUnavailable = true;
+            return false;
+        }
     }
 
     public bool TextChanged()

--- a/src/LibreLancer.Data/GameData/Items/MissileEquip.cs
+++ b/src/LibreLancer.Data/GameData/Items/MissileEquip.cs
@@ -4,6 +4,6 @@ public class MissileEquip : Equipment
 {
     public required Data.Schema.Equipment.Munition Def;
     public required Data.Schema.Equipment.Motor? Motor;
-    public required Data.Schema.Equipment.Explosion Explosion;
+    public Data.Schema.Equipment.Explosion? Explosion;
     public ResolvedFx? ExplodeFx;
 }

--- a/src/LibreLancer.Data/GameItemDb.cs
+++ b/src/LibreLancer.Data/GameItemDb.cs
@@ -1005,6 +1005,16 @@ public class GameItemDb
             equip.Volume = val.Volume;
         }
 
+        void AddEquipment(Equipment equip)
+        {
+            if (Equipment.Contains(equip.Nickname))
+            {
+                FLLog.Warning("Equipment", $"Duplicate equipment nickname '{equip.Nickname}', replacing previous entry");
+            }
+
+            Equipment.Add(equip);
+        }
+
         //Process munitions first
         foreach (var mn in flData.Equipment.Munitions)
         {
@@ -1012,17 +1022,43 @@ public class GameItemDb
 
             if (!string.IsNullOrEmpty(mn.Motor))
             {
+                var motor = flData.Equipment.Motors.FirstOrDefault(x =>
+                    x.Nickname.Equals(mn.Motor, StringComparison.OrdinalIgnoreCase));
+                if (motor == null)
+                {
+                    FLLog.Warning(
+                        "Equipment",
+                        $"Munition '{mn.Nickname}' references missing motor '{mn.Motor}'");
+                }
+
+                Data.Schema.Equipment.Explosion? explosion = null;
+                if (!string.IsNullOrEmpty(mn.ExplosionArch))
+                {
+                    explosion = flData.Equipment.Explosions.FirstOrDefault(x =>
+                        x.Nickname.Equals(mn.ExplosionArch, StringComparison.OrdinalIgnoreCase));
+                    if (explosion == null)
+                    {
+                        FLLog.Warning(
+                            "Equipment",
+                            $"Munition '{mn.Nickname}' references missing explosion_arch '{mn.ExplosionArch}'");
+                    }
+                }
+                else
+                {
+                    FLLog.Warning(
+                        "Equipment",
+                        $"Munition '{mn.Nickname}' has motor '{mn.Motor}' but no explosion_arch");
+                }
+
                 var mequip = new MissileEquip()
                 {
                     Def = mn,
                     ModelFile = ResolveDrawable(mn.MaterialLibrary, mn.DaArchetype),
-                    Motor = flData.Equipment.Motors.First(x =>
-                        x.Nickname.Equals(mn.Motor, StringComparison.OrdinalIgnoreCase)),
-                    Explosion = flData.Equipment.Explosions.First(x =>
-                        x.Nickname.Equals(mn.ExplosionArch, StringComparison.OrdinalIgnoreCase))
+                    Motor = motor,
+                    Explosion = explosion
                 };
 
-                if (!string.IsNullOrEmpty(mequip.Explosion.Effect))
+                if (!string.IsNullOrEmpty(mequip.Explosion?.Effect))
                 {
                     mequip.ExplodeFx = Effects.Get(mequip.Explosion.Effect);
                 }
@@ -1042,7 +1078,7 @@ public class GameItemDb
             }
 
             SetCommonFields(equip, mn);
-            Equipment.Add(equip);
+            AddEquipment(equip);
         }
 
         // Then all equipment
@@ -1052,7 +1088,12 @@ public class GameItemDb
 
             if (val is Light l)
             {
-                lights.Add(val.Nickname, new LightInheritHelper(l));
+                if (lights.ContainsKey(val.Nickname))
+                {
+                    FLLog.Warning("Light", $"Duplicate light nickname '{val.Nickname}', replacing previous entry");
+                }
+
+                lights[val.Nickname] = new LightInheritHelper(l);
             }
             else if (val is InternalFx)
             {
@@ -1264,7 +1305,7 @@ public class GameItemDb
             }
 
             SetCommonFields(equip, val);
-            Equipment.Add(equip);
+            AddEquipment(equip);
         }
 
         //Resolve light inheritance
@@ -1284,7 +1325,7 @@ public class GameItemDb
             var eq = GetLight(lt);
             eq.Nickname = lt.Nickname;
             eq.CRC = FLHash.CreateID(eq.Nickname);
-            Equipment.Add(eq);
+            AddEquipment(eq);
         }
 
         // LootCrateEquipment references

--- a/src/LibreLancer.Tests/VignetteGraphAnalyzerTests.cs
+++ b/src/LibreLancer.Tests/VignetteGraphAnalyzerTests.cs
@@ -1,0 +1,186 @@
+using System.Linq;
+using LancerEdit.GameContent.VignetteNodes;
+using LibreLancer.Data.Ini;
+using LibreLancer.ContentEdit.RandomMissions;
+using LibreLancer.Data.Schema.RandomMissions;
+using Xunit;
+
+namespace LibreLancer.Tests;
+
+public class VignetteGraphAnalyzerTests
+{
+    [Fact]
+    public void ValidGraphFindsRootAndTerminal()
+    {
+        var graph = Analyze(
+            Node(1, 2),
+            Node(2, 3),
+            Node(3));
+
+        Assert.Equal(3, graph.Nodes.Count);
+        Assert.Equal(2, graph.Edges.Count);
+        Assert.True(graph.NodeById(1)!.IsRoot);
+        Assert.True(graph.NodeById(3)!.IsTerminal);
+        Assert.DoesNotContain(graph.Diagnostics, x => x.Severity == VignetteDiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void BrokenReferenceIsDiagnosed()
+    {
+        var graph = Analyze(Node(1, 99));
+
+        Assert.Contains(graph.Edges, x => x.TargetNodeId == 99 && x.Broken);
+        Assert.Contains(graph.Diagnostics, x => x.Message.Contains("Broken reference"));
+    }
+
+    [Fact]
+    public void CycleIsDiagnosed()
+    {
+        var graph = Analyze(
+            Node(1, 2),
+            Node(2, 3),
+            Node(3, 1));
+
+        Assert.All(graph.Nodes, x => Assert.True(x.IsInCycle));
+        Assert.Contains(graph.Diagnostics, x => x.Message.Contains("Cycle"));
+    }
+
+    [Fact]
+    public void UnreachableNodeIsDiagnosed()
+    {
+        var graph = Analyze(
+            Node(1, 2),
+            Node(2),
+            Node(9));
+
+        Assert.True(graph.NodeById(9)!.IsUnreachable);
+        Assert.Contains(graph.Diagnostics, x => x.NodeId == 9 && x.Message.Contains("Unreachable"));
+    }
+
+    [Fact]
+    public void UnknownAndRepeatedPropertiesArePreserved()
+    {
+        var section = Node(1);
+        section.Add(Entry(section, "custom_field", "a"));
+        section.Add(Entry(section, "custom_field", "b"));
+
+        var graph = Analyze(section);
+        var node = graph.NodeById(1)!;
+
+        Assert.Equal(2, node.Properties.Count(x => x.Name == "custom_field"));
+        Assert.Contains("custom_field = a", node.RawIni);
+        Assert.Contains("custom_field = b", node.RawIni);
+        Assert.Contains(graph.Diagnostics, x => x.Message.Contains("Unknown property"));
+    }
+
+    [Fact]
+    public void DataNodeOfferTextIsDescribedSemantically()
+    {
+        var section = Node(461, 6);
+        section.Add(Entry(section, "offer_text", "replace", 327682, "MISSION_DIFFICULTY", "REWARD_MONEY"));
+
+        var graph = Analyze(section, Node(6));
+        var node = graph.NodeById(461)!;
+        var semantic = node.SemanticLines();
+
+        Assert.Contains("offer replace 327682", node.Summary);
+        Assert.Contains(semantic, x => x.Contains("offer_text: replace") &&
+                                       x.Contains("IDS_NAME 327682") &&
+                                       x.Contains("MISSION_DIFFICULTY") &&
+                                       x.Contains("REWARD_MONEY"));
+    }
+
+    [Fact]
+    public void EdgeRelationsDescribeNodeKind()
+    {
+        var data = Node(1, 2);
+        var decision = new Section("DecisionNode");
+        decision.Add(Entry(decision, "node_id", 2));
+        decision.Add(Entry(decision, "nickname", "branch"));
+        decision.Add(Entry(decision, "child_node", 3));
+        decision.Add(Entry(decision, "child_node", 4));
+        var documentation = new Section("DocumentationNode");
+        documentation.Add(Entry(documentation, "node_id", 3));
+        documentation.Add(Entry(documentation, "documentation", "Main_battle"));
+        documentation.Add(Entry(documentation, "child_node", 4));
+
+        var graph = Analyze(data, decision, documentation, Node(4));
+
+        Assert.Contains(graph.Edges, x => x.SourceNodeId == 1 && x.Relation == "next after data");
+        Assert.Contains(graph.Edges, x => x.SourceNodeId == 2 && x.TargetNodeId == 3 && x.Relation == "true/left");
+        Assert.Contains(graph.Edges, x => x.SourceNodeId == 2 && x.TargetNodeId == 4 && x.Relation == "false/right");
+        Assert.Contains(graph.Edges, x => x.SourceNodeId == 3 && x.Relation == "next after documentation");
+    }
+
+    [Fact]
+    public void SingleChildDecisionIsABranchMatchNotTrueFalse()
+    {
+        var decision = new Section("DecisionNode");
+        decision.Add(Entry(decision, "node_id", 5));
+        decision.Add(Entry(decision, "nickname", "Assassinate_mission"));
+        decision.Add(Entry(decision, "child_node", 173));
+
+        var graph = Analyze(decision, Node(173));
+
+        Assert.Contains(graph.Edges, x => x.SourceNodeId == 5 && x.TargetNodeId == 173 && x.Relation == "branch match");
+        Assert.Contains(graph.NodeById(5)!.SemanticLines(), x => x == "branch match -> 173");
+    }
+
+    [Fact]
+    public void SingleChildDecisionDecompilesToCompilableDsl()
+    {
+        var vparams = new VignetteParamsIni();
+        vparams.Nodes.Add(new DecisionNode
+        {
+            NodeId = 5,
+            Nickname = "Assassinate_mission",
+            ChildId = { 173 }
+        });
+        vparams.Nodes.Add(new DataNode
+        {
+            NodeId = 173,
+            Implemented = false
+        });
+
+        var script = VignetteParamsDecompiler.Decompile(vparams);
+        var sections = VignetteParamsCompiler.Compile(script, "single-child-decision");
+
+        Assert.Contains("noop;", script);
+        Assert.DoesNotContain("err_unimplemented", script);
+        Assert.NotEmpty(sections);
+    }
+
+    [Fact]
+    public void NoopAliasCompilesAsEmptyBranchPlaceholder()
+    {
+        var sections = VignetteParamsCompiler.Compile("""
+            if Some_condition
+                noop;
+            else
+                noop;
+            end
+            """, "noop-test");
+
+        Assert.NotEmpty(sections);
+    }
+
+    private static VignetteGraph Analyze(params Section[] sections) =>
+        VignetteGraphAnalyzer.FromSections(sections, "vignetteparams.ini", null);
+
+    private static Section Node(int id, params int[] children)
+    {
+        var section = new Section("DataNode");
+        section.Add(Entry(section, "node_id", id));
+        foreach (var child in children)
+            section.Add(Entry(section, "child_node", child));
+        return section;
+    }
+
+    private static Entry Entry(Section section, string name, params ValueBase[] values)
+    {
+        var entry = new Entry(section, name);
+        foreach (var value in values)
+            entry.Add(value);
+        return entry;
+    }
+}

--- a/src/LibreLancer/Render/SunRenderer.cs
+++ b/src/LibreLancer/Render/SunRenderer.cs
@@ -5,11 +5,13 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using LibreLancer.Data;
 using LibreLancer.Data.GameData.Archetypes;
 using LibreLancer.Graphics;
 using LibreLancer.Graphics.Vertices;
 using LibreLancer.Render.Cameras;
 using LibreLancer.Render.Materials;
+using LibreLancer.Resources;
 
 namespace LibreLancer.Render
 {
@@ -34,27 +36,30 @@ namespace LibreLancer.Render
             pos = Vector3.Zero;
         }
 
-        private static void AddQuad(VertexBillboardColor2[] vx, ref int i, Vector3 pos, Vector2 size, float angle, Color4 c1, Color4 c2)
+        private static void AddQuad(VertexBillboardColor2[] vx, ref int i, Vector3 pos, Vector2 size, float angle, Color4 c1, Color4 c2) =>
+            AddQuad(vx, ref i, pos, size, angle, c1, c2, new RectangleF(0, 0, 1, 1));
+
+        private static void AddQuad(VertexBillboardColor2[] vx, ref int i, Vector3 pos, Vector2 size, float angle, Color4 c1, Color4 c2, RectangleF texCoords)
         {
             vx[i++] = new VertexBillboardColor2(
                 pos, -0.5f * size.X, -0.5f * size.Y, angle,
                 c1,c2,
-                new Vector2(0, 0)
+                new Vector2(texCoords.X, texCoords.Y)
             );
             vx[i++] = new VertexBillboardColor2(
                 pos, 0.5f * size.X, -0.5f * size.Y, angle,
                 c1,c2,
-                new Vector2(1, 0)
+                new Vector2(texCoords.X + texCoords.Width, texCoords.Y)
             );
             vx[i++] = new VertexBillboardColor2(
                 pos, -0.5f * size.X, 0.5f * size.Y, angle,
                 c1,c2,
-                new Vector2(0, 1)
+                new Vector2(texCoords.X, texCoords.Y + texCoords.Height)
             );
             vx[i++] = new VertexBillboardColor2(
                 pos, 0.5f * size.X, 0.5f * size.Y, angle,
                 c1,c2,
-                new Vector2(1, 1)
+                new Vector2(texCoords.X + texCoords.Width, texCoords.Y + texCoords.Height)
             );
         }
 
@@ -73,18 +78,27 @@ namespace LibreLancer.Render
             return count;
         }
 
-        public static void CreateVertices(VertexBillboardColor2[] vx, Vector3 pos, Sun sun)
+        public static void CreateVertices(VertexBillboardColor2[] vx, Vector3 pos, Sun sun) =>
+            CreateVertices(vx, pos, sun, 0);
+
+        public static void CreateVertices(VertexBillboardColor2[] vx, Vector3 pos, Sun sun, float angleOffset)
+            => CreateVertices(vx, pos, sun, angleOffset, null, null, null);
+
+        public static void CreateVertices(VertexBillboardColor2[] vx, Vector3 pos, Sun sun, float angleOffset,
+            RectangleF? centerCoords, RectangleF? glowCoords, RectangleF? spinesCoords)
         {
             var idx = 0;
             // center
             if (sun.CenterSprite != null)
                 AddQuad(vx, ref idx, pos, new Vector2(sun.Radius * sun.CenterScale), 0,
                     new Color4(sun.CenterColorInner, 1),
-                    new Color4(sun.CenterColorOuter, 1));
+                    new Color4(sun.CenterColorOuter, 1),
+                    centerCoords ?? new RectangleF(0, 0, 1, 1));
             // glow
             AddQuad(vx, ref idx, pos, new Vector2(sun.Radius * sun.GlowScale), 0,
                 new Color4(sun.GlowColorInner, 1),
-                new Color4(sun.GlowColorOuter, 1));
+                new Color4(sun.GlowColorOuter, 1),
+                glowCoords ?? new RectangleF(0, 0, 1, 1));
 
             // spines
             if (sun.SpinesSprite != null)
@@ -99,29 +113,44 @@ namespace LibreLancer.Render
                         ref idx,
                         pos,
                         new Vector2(sun.Radius) * sun.SpinesScale * new Vector2(s.WidthScale / s.LengthScale, s.LengthScale),
-                        (float)current_angle,
+                        (float)current_angle + angleOffset,
                         new Color4(s.InnerColor, s.Alpha),
-                        new Color4(s.OuterColor, s.Alpha)
+                        new Color4(s.OuterColor, s.Alpha),
+                        spinesCoords ?? new RectangleF(0, 0, 1, 1)
                     );
                 }
             }
         }
 
+        private static TextureShape? ResolveShape(ResourceManager resources, string? name)
+        {
+            if (!string.IsNullOrEmpty(name) &&
+                resources.TryGetShape(name, out var shape) &&
+                shape.HasValue)
+            {
+                return shape.Value;
+            }
+            return null;
+        }
+
         public override bool PrepareRender(ICamera camera, NebulaRenderer nr, SystemRenderer sys, bool forceCull)
         {
+            var centerShape = ResolveShape(sys.ResourceManager, Sun.CenterSprite);
+            var glowShape = ResolveShape(sys.ResourceManager, Sun.GlowSprite);
+            var spinesShape = ResolveShape(sys.ResourceManager, Sun.SpinesSprite);
             if (sysr == null)
             {
-                spineMaterial = new SunSpineMaterial(sys.ResourceManager, Sun.SpinesSprite!, Vector2.One);
+                spineMaterial = new SunSpineMaterial(sys.ResourceManager, spinesShape?.Texture ?? Sun.SpinesSprite!, Vector2.One);
 
                 centerMaterial = new SunRadialMaterial(sys.ResourceManager)
                 {
-                    Texture = Sun.CenterSprite!,
+                    Texture = centerShape?.Texture ?? Sun.CenterSprite!,
                     Additive = true
                 };
 
                 glowMaterial = new SunRadialMaterial(sys.ResourceManager)
                 {
-                    Texture = Sun.GlowSprite!
+                    Texture = glowShape?.Texture ?? Sun.GlowSprite!
                 };
             }
 
@@ -130,7 +159,10 @@ namespace LibreLancer.Render
             if (vertices == null || pos != genPos)
             {
                  vertices = new VertexBillboardColor2[GetVertexCount(Sun)];
-                 CreateVertices(vertices, pos, Sun);
+                 CreateVertices(vertices, pos, Sun, 0,
+                     centerShape?.Dimensions,
+                     glowShape?.Dimensions,
+                     spinesShape?.Dimensions);
                  genPos = pos;
             }
 

--- a/src/cimgui_ext/ImGuiColorTextEdit/cimgui_colortextedit.cpp
+++ b/src/cimgui_ext/ImGuiColorTextEdit/cimgui_colortextedit.cpp
@@ -68,6 +68,24 @@ CIMGUI_API void igExtTextEditorGetCoordinates(texteditor_t textedit, int32_t *x,
 	*y = cursor.line;
 }
 
+CIMGUI_API void igExtTextEditorSetCursor(texteditor_t textedit, int32_t line, int32_t column)
+{
+	TextEditor *editor = (TextEditor*)textedit;
+	editor->SetCursor(line, column);
+}
+
+CIMGUI_API void igExtTextEditorSelectLine(texteditor_t textedit, int32_t line)
+{
+	TextEditor *editor = (TextEditor*)textedit;
+	editor->SelectLine(line);
+}
+
+CIMGUI_API void igExtTextEditorScrollToLine(texteditor_t textedit, int32_t line)
+{
+	TextEditor *editor = (TextEditor*)textedit;
+	editor->ScrollToLine(line, TextEditor::Scroll::alignMiddle);
+}
+
 CIMGUI_API void igExtTextEditorRender(texteditor_t textedit, const char *id)
 {
 	TextEditor *editor = (TextEditor*)textedit;

--- a/src/cimgui_ext/include/cimgui_ext.h
+++ b/src/cimgui_ext/include/cimgui_ext.h
@@ -76,6 +76,9 @@ CIMGUI_API void igExtFree(void *mem);
 CIMGUI_API void igExtTextEditorSetText(texteditor_t textedit, const char *text);
 CIMGUI_API int igExtTextEditorGetUndoIndex(texteditor_t textedit);
 CIMGUI_API void igExtTextEditorGetCoordinates(texteditor_t textedit, int32_t *x, int32_t *y);
+CIMGUI_API void igExtTextEditorSetCursor(texteditor_t textedit, int32_t line, int32_t column);
+CIMGUI_API void igExtTextEditorSelectLine(texteditor_t textedit, int32_t line);
+CIMGUI_API void igExtTextEditorScrollToLine(texteditor_t textedit, int32_t line);
 CIMGUI_API void igExtTextEditorRender(texteditor_t textedit, const char *id);
 CIMGUI_API void igExtTextEditorFree(texteditor_t textedit);
 //guizmo


### PR DESCRIPTION
# Changes Since the Previous Version

This update expands LancerEdit with three new game-data tools focused on understanding, checking, and previewing Freelancer content directly inside the editor.

<img width="342" height="511" alt="image" src="https://github.com/user-attachments/assets/0b1c3dcc-c06c-443d-86e5-c98542b3fdee" />

## Voice Browser

Added a new voice inspection tool available from the `Data` menu after game data is loaded.

<img width="1853" height="660" alt="image" src="https://github.com/user-attachments/assets/d5439204-6324-4d2a-985f-0ccd505b48a9" />
<img width="306" height="313" alt="image" src="https://github.com/user-attachments/assets/c8317e40-3d8c-407d-86f6-0bcfa48e495d" />
<img width="1585" height="549" alt="image" src="https://github.com/user-attachments/assets/f7a663aa-5898-46a0-83cc-13fe109e9feb" />

The browser collects voice definitions from the loaded game data and cross-checks them against the referenced UTF voice files. It helps answer practical modding questions such as:

- which voice lines are defined in INI but missing in UTF;
- which UTF entries exist but are not linked back to INI messages;
- which voice entries come from base, space, mission, recognizable, mixed, or other voice sources;
- what CRC/hash is used for a specific voice message.

The tool includes search, status filters, source filters, diagnostics, and playback controls so voice packs can be audited without manually jumping between voice INI files and UTF trees.

## Stars Browser

Added a visual browser for star/sun definitions.

<img width="1853" height="989" alt="image" src="https://github.com/user-attachments/assets/667fe0e6-bcbe-460e-ad81-3e195d30184a" />
<img width="1850" height="966" alt="image" src="https://github.com/user-attachments/assets/2ede1e7b-69e4-4e30-bf6c-f79be90e40b7" />

The new browser renders thumbnails from `stararch.ini` data and makes stars easier to compare visually instead of only reading nicknames and numeric fields. It includes:

- searchable star grid;
- used/unused filtering;
- "used first" sorting;
- live preview panel;
- larger preview window;
- usage lookup showing where a star is referenced by systems or objects.

This makes it much easier to choose, verify, and debug star assets while editing systems.

## Vignette Nodes Browser

Added a dedicated browser for `randommissions/vignetteparams.ini`.

<img width="1844" height="1018" alt="image" src="https://github.com/user-attachments/assets/44d55b05-8ab0-4688-bd90-9f600bee33af" />
<img width="1837" height="836" alt="image" src="https://github.com/user-attachments/assets/33d0a6f1-4369-4663-8425-978cb71f8393" />
<img width="2695" height="1142" alt="image" src="https://github.com/user-attachments/assets/bf018066-c37d-4a80-b81b-85b0566d3953" />
<img width="1739" height="509" alt="image" src="https://github.com/user-attachments/assets/fdb76059-230d-4c47-9739-affc15a8d629" />

This is the largest feature in the batch. It turns the raw random mission vignette node file into a navigable inspection tool with:

- node list with filtering and diagnostics;
- semantic view for selected nodes;
- raw INI view;
- connection view;
- full graph view;
- structural tree / DSL view;
- IDS_NAME text resolution;
- human-readable faction names;
- search with jump-to-line support;
- compile preview from the readable DSL back into INI sections.

The graph view now tries to show what the random mission flow is doing rather than only displaying numeric `child_node` links. Decision branches, data chains, documentation nodes, terminal nodes, incoming callers, and outgoing relations are exposed in the UI.

The Tree tab adds a readable DSL representation of `vignetteparams.ini`. It supports `#` comments, human hints for factions and IDS_NAME strings, basic DSL help, and an IntelliSense-style suggestion panel for syntax, conditions, groups, factions, IDS_NAME values, and nodes.

Decompiler/compiler handling was also hardened for edge cases such as single-child decisions and empty branches. Empty missing branches are now represented as:

```text
noop; # no branch in original INI
```

The old `err_unimplemented;` marker remains supported for compatibility.

## Supporting Improvements

The text editor bridge used by LancerEdit now exposes cursor, line selection, and scroll-to-line helpers through `cimgui`. This is used by the Vignette Tree search to jump to the selected match while keeping the normal code-editor behavior.

Star preview rendering was extended so browser thumbnails and detailed previews can share the same rendering path and display stars more reliably in small UI cells and large preview panes.

## Validation

Added focused tests for the vignette graph analyzer and DSL/decompiler behavior, including broken links, terminal nodes, branch relations, search-relevant metadata, and `noop` compilation.
