### PR TITLE
Fix hash for items

### DIFF
--- a/src/LibreLancer/Server/GameServer.cs
+++ b/src/LibreLancer/Server/GameServer.cs
@@ -194,7 +194,7 @@ namespace LibreLancer.Server
             {
                 bp.Add(new BaselinePrice()
                 {
-                    GoodCRC = CrcTool.FLModelCrc(good.Ini.Nickname),
+                    GoodCRC = FLHash.CreateID(good.Ini.Nickname),
                     Price = (ulong) good.Ini.Price
                 });
             }

--- a/src/LibreLancer/Server/Player.cs
+++ b/src/LibreLancer/Server/Player.cs
@@ -509,7 +509,7 @@ namespace LibreLancer.Server
                 rpcClient.BaseEnter(Base!, Objective, thns.Pack(), news.ToArray(), Baseside.BaseData.SoldGoods
                     .Select(x => new SoldGood()
                     {
-                        GoodCRC = CrcTool.FLModelCrc(x.Good.Ini.Nickname),
+                        GoodCRC = FLHash.CreateID(x.Good.Ini.Nickname),
                         Price = x.Price,
                         Rank = x.Rank,
                         Rep = x.Rep,


### PR DESCRIPTION
On commit "Implement collision + net spawning for dynamic asteroids with kinematic proxies", GameItemDb.cs was changed to use FLHash instead of CrcTool, GameServer.cs and Player.cs still used the old one, making the vendors don't show items, I've changed it to the newer so they show valid 