### PR TITLE
Add ambient light color picker to Model Viewer

### DIFF
--- a/src/Editor/LancerEdit/Model/ModelViewer.cs
+++ b/src/Editor/LancerEdit/Model/ModelViewer.cs
@@ -72,6 +72,8 @@ namespace LancerEdit
         const int M_NORMALS = 3;
         const int M_NONE = 4;
 
+        Vector3 ambientColor = new(0.0f, 0.0f, 0.0f);
+
         static readonly Color4[] initialCmpColors = new Color4[] {
             Color4.White,
             Color4.Red,
@@ -244,6 +246,11 @@ namespace LancerEdit
                 ImGui.SameLine();
             }
             ImGuiExt.DropdownButton("View Mode", ref viewMode, ViewModes);
+            ImGui.SameLine();
+            if (viewMode == M_LIT && ImGui.ColorEdit3("Ambient Light", ref ambientColor, ImGuiColorEditFlags.NoInputs))
+            {
+                lighting.Ambient = new Color3f(ambientColor.X, ambientColor.Y, ambientColor.Z);
+            }
             ImGui.SameLine();
             using (var ct = Toolbar.Begin("#controls", true)) {
                 ct.CheckItem("Background", ref doBackground);

--- a/src/Editor/LibreLancer.ContentEdit/ModelImageRenderer.cs
+++ b/src/Editor/LibreLancer.ContentEdit/ModelImageRenderer.cs
@@ -10,7 +10,7 @@ namespace LibreLancer.ContentEdit;
 
 public class ModelImageRenderer
 {
-    static Lighting lighting;
+    public static Lighting lighting;
     static ModelImageRenderer()
     {
         lighting = Lighting.Create();


### PR DESCRIPTION
Adds a color picker for ambient lighting to the model viewer. Pitch black doesn't look very good ;)
Also makes the lighting field in ModelImageRenderer public so that scripts can manipulate it.